### PR TITLE
[Catalog] Add accessibilityHint to Catalog tiles

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -40,7 +40,8 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
     self.isAccessibilityElement = true
     let rawAccessibilityTraits =
       accessibilityTraits.rawValue | UIAccessibilityTraits.button.rawValue
-    self.accessibilityTraits = UIAccessibilityTraits(rawValue: rawAccessibilityTraits)
+    accessibilityTraits = UIAccessibilityTraits(rawValue: rawAccessibilityTraits)
+    accessibilityHint = "Opens the example"
 
     updateTheme()
 


### PR DESCRIPTION
Add `accessibilityHint` to `MDCCatalogCollectionViewCell`

Testing:
1) Enable VoiceOver and ensure that Speak Hints is enabled.
2) Open the MDCCatalog app
3) Move focus to one of the component 
4) Confirm that VoiceOver reads the component name, "button", and "Opens the example"

Closes #3162 
