### PR TITLE
{Blocked}[Dialogs] Add dynamic type scaling curves

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -854,6 +854,7 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/ShadowElevations"
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/Typography"
+    component.dependency "MaterialComponents/private/Application"
     component.dependency "MaterialComponents/private/KeyboardWatcher"
     component.dependency "MDFInternationalization"
 

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -42,6 +42,7 @@ mdc_public_objc_library(
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",
+        "//components/private/Application",
         "//components/private/KeyboardWatcher",
         "@material_internationalization_ios//:MDFInternationalization",
         "@motion_animator_objc//:MotionAnimator",

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -17,6 +17,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialApplication.h"
 #import "MaterialButtons.h"
 #import "MaterialMath.h"
 #import "MaterialTypography.h"
@@ -160,13 +161,17 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateTitleFont {
   UIFont *titleFont = self.titleFont ?: [[self class] titleFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.titleLabel.font =
-          [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                                  scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (titleFont.mdc_scalingCurve) {
+      titleFont = [titleFont mdc_scaledFontForSizeCategory:[self sizeCategory]];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        self.titleLabel.font =
+        [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                                scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
   } else {
-    _titleLabel.font = titleFont;
+    self.titleLabel.font = titleFont;
   }
   [self setNeedsLayout];
 }
@@ -234,15 +239,19 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 }
 
 - (void)updateMessageFont {
-  UIFont *messageFont = _messageFont ?: [[self class] messageFontDefault];
+  UIFont *messageFont = self.messageFont ?: [[self class] messageFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.messageLabel.font = [messageFont
-          mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
-                       scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (messageFont.mdc_scalingCurve) {
+      messageFont = [messageFont mdc_scaledFontForSizeCategory:[self sizeCategory]];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        self.messageLabel.font = [messageFont
+                                  mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
+                                  scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
   } else {
-    _messageLabel.font = messageFont;
+    self.messageLabel.font = messageFont;
   }
   [self setNeedsLayout];
 }
@@ -269,10 +278,14 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateButtonFont {
   UIFont *finalButtonFont = self.buttonFont ?: [[self class] buttonFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      finalButtonFont = [finalButtonFont
-          mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                       scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (finalButtonFont.mdc_scalingCurve) {
+      finalButtonFont = [finalButtonFont mdc_scaledFontForSizeCategory:[self sizeCategory]];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        finalButtonFont = [finalButtonFont
+                           mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                           scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
   }
   for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
@@ -635,6 +648,16 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateButtonFont];
 
   [self setNeedsLayout];
+}
+
+- (UIContentSizeCategory)sizeCategory {
+  UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
+  if (@available(iOS 10.0, *)) {
+    sizeCategory = self.traitCollection.preferredContentSizeCategory;
+  } else if ([UIApplication mdc_safeSharedApplication]) {
+    sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
+  }
+  return sizeCategory;
 }
 
 @end

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -167,9 +167,9 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
       titleFont = [titleFont mdc_scaledFontForSizeCategory:[self sizeCategory]];
     } else {
       if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-        self.titleLabel.font =
-        [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                                scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+        self.titleLabel.font = [titleFont
+            mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
       }
     }
   } else {
@@ -248,8 +248,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
     } else {
       if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
         self.messageLabel.font = [messageFont
-                                  mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
-                                  scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+            mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
       }
     }
   } else {
@@ -285,8 +285,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
     } else {
       if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
         finalButtonFont = [finalButtonFont
-                           mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                           scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+            mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
       }
     }
   }

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -125,13 +125,15 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)addActionButton:(nonnull MDCButton *)button {
   if (button.superview == nil) {
     button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+        self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     [self.actionsScrollView addSubview:button];
     if (_buttonColor) {
       // We only set if _buttonColor since settingTitleColor to nil doesn't
       // reset the title to the default
       [button setTitleColor:_buttonColor forState:UIControlStateNormal];
     }
-    [button setTitleFont:_buttonFont forState:UIControlStateNormal];
+    [button setTitleFont:self.buttonFont forState:UIControlStateNormal];
     button.inkColor = self.buttonInkColor;
     // TODO(#1726): Determine default text color values for Normal and Disabled
     CGRect buttonRect = button.bounds;


### PR DESCRIPTION
## Why blocked
This is waiting on #7447 to land

## Motivation
Dynamic type within material components should act the same as dynamic type in UIKit, in that it attaches scaling curves for fonts that should use dynamic type.

## Detailed changes
Add scaling curves for `titleFont`, `messageFont` and `buttonFont`. Also, add the necessary dependancies on the necessary build environments. 

One tricky thing is _Dialogs_ have a _sub-component MDCButton_ which makes dynamic type a little trickier. For that instance, we set the respective properties on the _MDCButton_ and the font when necessary. We do *not* add a curve for the button if `mdc_adjustsFontForContentSizeCategory` is true because that would mean that we always scale. If a client wants the font to scale with the new curve they would need to attach a font to the `buttonFont` property.