### PR TITLE
[Dialogs] Add test for legacy dynamic type

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -98,7 +98,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 @property(nonatomic, strong, readonly, nonnull) MDCStatefulRippleView *rippleView;
 @property(nonatomic, strong) MDCInkView *inkView;
 @property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
-- (void)updateTitleFont;
 @end
 
 @implementation MDCButton

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -968,6 +968,11 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self updateTitleFont];
 }
 
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+  [self updateTitleFont];
+}
+
 - (void)contentSizeCategoryDidChange:(__unused NSNotification *)notification {
   [self updateTitleFont];
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -967,8 +967,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self updateTitleFont];
 }
 
-- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
+    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   [self updateTitleFont];
 }
 

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -82,10 +82,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
   return [string copy];
 }
 
-@interface MDCButton (Testing)
-- (void)updateTitleFont;
-@end
-
 @interface FakeShadowLayer : MDCShapedShadowLayer
 @property(nonatomic, assign) NSInteger elevationAssignmentCount;
 @end
@@ -1134,7 +1130,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
   // When
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-  [self.button updateTitleFont];
 
   // Then
   XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:originalFont],
@@ -1154,7 +1149,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
   // When
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-  [self.button updateTitleFont];
 
   // Then
   XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:originalFont], @"%@ is equal to %@",

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -77,7 +77,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
-- (void)setupAlertView;
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;
 
@@ -369,9 +368,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)setupAlertView {
   // Explicitly overwrite the view default if true
-  if (_mdc_adjustsFontForContentSizeCategory) {
-    self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
-  }
   self.alertView.titleLabel.text = self.title;
   self.alertView.messageLabel.text = self.message;
   self.alertView.titleFont = self.titleFont;
@@ -380,6 +376,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.messageColor = self.messageColor;
   self.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
       self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+  if (_mdc_adjustsFontForContentSizeCategory) {
+    self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
+  }
   if (self.backgroundColor) {
     // Avoid reset background color to transparent when self.backgroundColor is nil.
     self.alertView.backgroundColor = self.backgroundColor;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -77,7 +77,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
-
+- (void)setupAlertView;
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -77,6 +77,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
+
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -375,6 +375,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.messageFont = self.messageFont;
   self.alertView.titleColor = self.titleColor;
   self.alertView.messageColor = self.messageColor;
+  self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
   self.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
       self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   if (_mdc_adjustsFontForContentSizeCategory) {
@@ -388,7 +389,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     // Avoid reset title color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonColor = self.buttonTitleColor;  // b/117717380: Will be deprecated
   }
-  self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
+  //self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
   if (self.buttonInkColor) {
     // Avoid reset ink color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonInkColor = self.buttonInkColor;  // b/117717380: Will be deprecated
@@ -401,6 +402,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   // Create buttons for the actions (if not already created) and apply default styling
   for (MDCAlertAction *action in self.actions) {
     [self addButtonToAlertViewForAction:action];
+  }
+  for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
+    [button setTitleFont:self.buttonFont forState:UIControlStateNormal];
   }
 }
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -389,7 +389,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     // Avoid reset title color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonColor = self.buttonTitleColor;  // b/117717380: Will be deprecated
   }
-  //self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
+  // self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
   if (self.buttonInkColor) {
     // Avoid reset ink color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonInkColor = self.buttonInkColor;  // b/117717380: Will be deprecated

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -627,8 +627,10 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateFonts];
 }
 
-- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
+    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   [self updateFonts];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -282,6 +282,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateButtonFont {
   UIFont *buttonFont = [self buttonFontForDynamicType];
   for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
+    button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     [button setTitleFont:buttonFont forState:UIControlStateNormal];
   }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -130,6 +130,7 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
       // reset the title to the default
       [button setTitleColor:_buttonColor forState:UIControlStateNormal];
     }
+    [button setTitleFont:[self buttonFontForDynamicType] forState:UIControlStateNormal];
     [button setTitleFont:_buttonFont forState:UIControlStateNormal];
     button.inkColor = self.buttonInkColor;
     // TODO(#1726): Determine default text color values for Normal and Disabled
@@ -265,17 +266,23 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateButtonFont];
 }
 
-- (void)updateButtonFont {
-  UIFont *finalButtonFont = self.buttonFont ?: [[self class] buttonFontDefault];
+- (UIFont *)buttonFontForDynamicType {
+  UIFont *buttonFont = self.buttonFont ?: [[self class] buttonFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      finalButtonFont = [finalButtonFont
-          mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                       scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      buttonFont = [buttonFont
+                         mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
   }
+
+  return buttonFont;
+}
+
+- (void)updateButtonFont {
+  UIFont *buttonFont = [self buttonFontForDynamicType];
   for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
-    [button setTitleFont:finalButtonFont forState:UIControlStateNormal];
+    [button setTitleFont:buttonFont forState:UIControlStateNormal];
   }
 
   [self setNeedsLayout];

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -124,6 +124,7 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)addActionButton:(nonnull MDCButton *)button {
   if (button.superview == nil) {
     button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     [self.actionsScrollView addSubview:button];
     if (_buttonColor) {
       // We only set if _buttonColor since settingTitleColor to nil doesn't
@@ -131,7 +132,6 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
       [button setTitleColor:_buttonColor forState:UIControlStateNormal];
     }
     [button setTitleFont:[self buttonFontForDynamicType] forState:UIControlStateNormal];
-    [button setTitleFont:_buttonFont forState:UIControlStateNormal];
     button.inkColor = self.buttonInkColor;
     // TODO(#1726): Determine default text color values for Normal and Disabled
     CGRect buttonRect = button.bounds;

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -161,13 +161,13 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   UIFont *titleFont = self.titleFont ?: [[self class] titleFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.titleLabel.font =
+      titleFont =
           [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
                                   scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
-  } else {
-    _titleLabel.font = titleFont;
   }
+
+  self.titleLabel.font = titleFont;
   [self setNeedsLayout];
 }
 
@@ -237,13 +237,12 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   UIFont *messageFont = _messageFont ?: [[self class] messageFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.messageLabel.font = [messageFont
+      messageFont = [messageFont
           mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
                        scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
-  } else {
-    _messageLabel.font = messageFont;
   }
+  self.messageLabel.font = messageFont;
   [self setNeedsLayout];
 }
 
@@ -625,6 +624,11 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
     button.mdc_adjustsFontForContentSizeCategory = adjusts;
   }
 
+  [self updateFonts];
+}
+
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   [self updateFonts];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -124,7 +124,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)addActionButton:(nonnull MDCButton *)button {
   if (button.superview == nil) {
     button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
-    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+        self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     [self.actionsScrollView addSubview:button];
     if (_buttonColor) {
       // We only set if _buttonColor since settingTitleColor to nil doesn't
@@ -270,9 +271,9 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   UIFont *buttonFont = self.buttonFont ?: [[self class] buttonFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      buttonFont = [buttonFont
-                         mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      buttonFont =
+          [buttonFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                                   scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
   }
 
@@ -283,7 +284,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   UIFont *buttonFont = [self buttonFontForDynamicType];
   for (MDCButton *button in self.actionManager.buttonsInActionOrder) {
     button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
-    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+        self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     [button setTitleFont:buttonFont forState:UIControlStateNormal];
   }
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -336,6 +336,12 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
+  self.alert.messageFont = fakeMessageFont;
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // When
@@ -345,6 +351,11 @@
   // Then
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
+  XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
+                @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
+  UIButton *button = [view.actionManager buttonForAction:fakeAction];
+  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
+                @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
 }
 
 /**
@@ -356,6 +367,12 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
+  self.alert.messageFont = fakeMessageFont;
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
@@ -365,6 +382,11 @@
   // Then
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
+  XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
+                 @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
+  UIButton *button = [view.actionManager buttonForAction:fakeAction];
+  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
+                @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
 }
 
 /**
@@ -375,6 +397,12 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
+  self.alert.messageFont = fakeMessageFont;
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // When
@@ -384,6 +412,11 @@
   // Then
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
+  XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@",
+                 view.messageLabel.font, fakeMessageFont);
+  UIButton *button = [view.actionManager buttonForAction:fakeAction];
+  XCTAssertFalse([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont], @"%@ is equal to %@",
+                 button.titleLabel.font, fakeMessageFont);
 }
 
 /**
@@ -395,6 +428,12 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
+  self.alert.messageFont = fakeMessageFont;
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
@@ -404,6 +443,11 @@
   // Then
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
+  XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@",
+                 view.messageLabel.font, fakeMessageFont);
+  UIButton *button = [view.actionManager buttonForAction:fakeAction];
+  XCTAssertFalse([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont], @"%@ is equal to %@",
+                 button.titleLabel.font, fakeButtonFont);
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -338,7 +338,9 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;
@@ -354,8 +356,8 @@
   XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
                 @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
   UIButton *button = [view.actionManager buttonForAction:fakeAction];
-  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
-                @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
+  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont], @"%@ is not equal to %@",
+                button.titleLabel.font, fakeButtonFont);
 }
 
 /**
@@ -369,7 +371,9 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;
@@ -383,10 +387,10 @@
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
   XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
-                 @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
+                @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
   UIButton *button = [view.actionManager buttonForAction:fakeAction];
-  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
-                @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
+  XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont], @"%@ is not equal to %@",
+                button.titleLabel.font, fakeButtonFont);
 }
 
 /**
@@ -399,7 +403,9 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;
@@ -430,7 +436,9 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:^(MDCAlertAction *action) {}];
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -342,6 +342,21 @@
                 @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
 }
 
+- (void)testLegacyDynamicTypeDisabledFoo {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // When
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
+
+  // Then
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont],
+                @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
+}
+
 - (void)testLegacyDynamicTypeEnabled {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -24,7 +24,6 @@
 
 @interface MDCAlertController (Testing)
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
-- (void)setupAlertView;
 @end
 
 @interface MDCDialogPresentationController (Testing)
@@ -332,32 +331,30 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-  [self.alert setupAlertView];
-  UIFont *originalTitleFont = view.titleLabel.font;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
-  
+
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-  [self.alert.alertView updateFonts];
-  
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+
   // Then
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:originalTitleFont], @"%@, is not equal to %@", view.titleLabel.font, originalTitleFont);
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont],
+                @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
 }
 
 - (void)testLegacyDynamicTypeEnabled {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
-  UIFont *originalFont = self.alert.alertView.titleLabel.font;
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
-  
+
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-  [self.alert.alertView updateFonts];
-  
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+
   // Then
-  XCTAssertFalse([self.alert.alertView.titleLabel.font mdc_isSimplyEqual:originalFont]);
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
+                 view.titleLabel.font, fakeTitleFont);
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -15,6 +15,7 @@
 #import <XCTest/XCTest.h>
 #import "MaterialButtons.h"
 #import "MaterialDialogs.h"
+#import "MaterialTypography.h"
 
 #import "../../src/private/MDCDialogShadowedView.h"
 #import "MDCAlertControllerView+Private.h"
@@ -23,6 +24,7 @@
 
 @interface MDCAlertController (Testing)
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
+- (void)setupAlertView;
 @end
 
 @interface MDCDialogPresentationController (Testing)
@@ -324,6 +326,38 @@
 
   // Then
   XCTAssertFalse(self.alert.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
+}
+
+- (void)testLegacyDynamicTypeDisabled {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+  [self.alert setupAlertView];
+  UIFont *originalTitleFont = view.titleLabel.font;
+  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
+  
+  // When
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
+  [self.alert.alertView updateFonts];
+  
+  // Then
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:originalTitleFont], @"%@, is not equal to %@", view.titleLabel.font, originalTitleFont);
+}
+
+- (void)testLegacyDynamicTypeEnabled {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  UIFont *originalFont = self.alert.alertView.titleLabel.font;
+  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
+  
+  // When
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+  [self.alert.alertView updateFonts];
+  
+  // Then
+  XCTAssertFalse([self.alert.alertView.titleLabel.font mdc_isSimplyEqual:originalFont]);
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -327,6 +327,11 @@
   XCTAssertFalse(self.alert.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
 
+/**
+ Test legacy dynamic type has no impact on a @c MDCAlertController when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font stays
+ the same.
+ */
 - (void)testLegacyDynamicTypeDisabled {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -342,7 +347,12 @@
                 @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
 }
 
-- (void)testLegacyDynamicTypeDisabledFoo {
+/**
+ Test legacy dynamic type has no impact on a @c MDCAlertController when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES after the @c view has
+ been created that the font stays the same.
+ */
+- (void)testLegacyDynamicTypeDisabledAfterViewHasBeenCreated {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -357,6 +367,10 @@
                 @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
 }
 
+/**
+ Test legacy dynamic type impacts a @c MDCAlertController when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
+ */
 - (void)testLegacyDynamicTypeEnabled {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -366,6 +380,26 @@
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+
+  // Then
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
+                 view.titleLabel.font, fakeTitleFont);
+}
+
+/**
+ Test legacy dynamic type impacts a @c MDCAlertController when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES after the @c view has
+ been created that the font changes.
+ */
+- (void)testLegacyDynamicTypeEnabledAfterViewHasBeenCreated {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // When
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
   // Then
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -343,8 +343,8 @@
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
 
   // Then
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont],
-                @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+                view.titleLabel.font, fakeTitleFont);
 }
 
 /**
@@ -363,8 +363,8 @@
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // Then
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont],
-                @"%@, is not equal to %@", view.titleLabel.font, fakeTitleFont);
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+                view.titleLabel.font, fakeTitleFont);
 }
 
 /**


### PR DESCRIPTION
## Motivation
In #7446 we added a flag for bypassing the legacy dynamic type system. Test were added for the setter  but not for the side effects of this property. We should test the setting this property has the correct behavior.

## Detailed changes
In adding these test I found a couple issues within Dialogs.
1. When setting `mdc_adjustsFontForContentSizeCategory` it updates the labels but the fonts may be `nil` because they haven't been set. In order to fix this we move setting `mdc_adjustsFontForContentSizeCategory` lower in the `setupAlertView` method to after all of the fonts have been set and after `adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable` has been set.
2. When setting `adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable` that should make it so that the fonts don't scale if `mdc_adjustFontForContentSizeCategory` is on, but we may have already scaled the fonts. In that instance we need to recall `updateFonts` to set them back to the correct `ivar` values.

*Note* This is stacked on #7466 