### PR TITLE
[schemes/Typography] Add useCurrentContentSizeCategoryWhenApplied.

### DIFF
--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -159,10 +159,11 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 @property(nonatomic, nonnull, readwrite, copy) UIFont *overline;
 
 /**
- Whether the application of this scheme to components should apply fonts in respect to the current
- Dynamic Type setting.
+ A hint for how fonts in this scheme should be applied to components in relation to Dynamic Type.
 
- This flag only has an effect if the fonts stored on this scheme are scalable.
+ @note Enabling this flag only has an effect if the fonts stored on this scheme are scalable. See
+ MDCTypographySchemeDefaults for default versions that are scalable. Alternatively, you can specify
+ custom scalable fonts using the MDCFontScaler API.
 
  When fonts are applied to components:
 

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -106,9 +106,9 @@
  the component.
 
  @note This flag will become required in the future as a replacement for
- mdc_adjustsFontForContentSizeCategory.
+ @c mdc_adjustsFontForContentSizeCategory.
  */
-@property(nonatomic, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
+@property(nonatomic, assign, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 
 @end
 
@@ -170,7 +170,7 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  - If this flag is disabled, make no changes to the font.
  - If this flag is enabled, adjust the font with respect to the current content size category.
  */
-@property(nonatomic, readwrite) BOOL useCurrentContentSizeCategoryWhenApplied;
+@property(nonatomic, assign, readwrite) BOOL useCurrentContentSizeCategoryWhenApplied;
 
 /**
  Initializes the typography scheme with the latest material defaults.
@@ -188,6 +188,6 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  @warning Will eventually be deprecated and removed. Please use
  useCurrentContentSizeCategoryWhenApplied instead.
  */
-@property(nonatomic, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
+@property(nonatomic, assign, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
 
 @end

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -90,8 +90,26 @@
 
  This can be used by client to communicate whether they support dynamic type to both our theming
  functionality and embedded frameworks that also render UI.
+
+ @warning This API will eventually be deprecated. Please use
+ @c useCurrentContentSizeCategoryWhenApplied instead.
 */
 @property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory;
+
+@optional
+
+/**
+ Whether applications of this scheme to components should apply fonts in respect to the current
+ Dynamic Type setting.
+
+ If this flag is enabled and the typography scheme's font is scalable with Dynamic Type, then fonts
+ should be adjusted for the current Dynamic Type content size category prior to being assigned to
+ the component.
+
+ This flag will become required in the future as a replacement for
+ mdc_adjustsFontForContentSizeCategory.
+ */
+@property(nonatomic, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 
 @end
 
@@ -101,6 +119,8 @@
 typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
   /**
    The Material defaults, circa April 2018.
+
+   useCurrentContentSizeCategoryWhenApplied will be NO by default.
    */
   MDCTypographySchemeDefaultsMaterial201804,
 
@@ -110,6 +130,8 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
    This scheme implements fonts with the similar metrics as
    MDCTypographySchemeDefaultsMaterial201804 with the addition that vended fonts will have
    appropriate scalingCurves attached.
+
+   useCurrentContentSizeCategoryWhenApplied will be YES by default.
    */
   MDCTypographySchemeDefaultsMaterial201902,
 };
@@ -134,7 +156,19 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 @property(nonatomic, nonnull, readwrite, copy) UIFont *caption;
 @property(nonatomic, nonnull, readwrite, copy) UIFont *button;
 @property(nonatomic, nonnull, readwrite, copy) UIFont *overline;
-@property(nonatomic, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
+
+/**
+ Whether the application of this scheme to components should apply fonts in respect to the current
+ Dynamic Type setting.
+
+ This flag only has an effect if the fonts stored on this scheme are scalable.
+
+ When fonts are applied to components:
+
+ - If this flag is disabled, make no changes to the font.
+ - If this flag is enabled, adjust the font with respect to the current content size category.
+ */
+@property(nonatomic, readwrite) BOOL useCurrentContentSizeCategoryWhenApplied;
 
 /**
  Initializes the typography scheme with the latest material defaults.
@@ -145,5 +179,13 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  Initializes the typography scheme with the values associated with the given defaults.
  */
 - (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults;
+
+#pragma mark - To be deprecated
+
+/**
+ @warning Will eventually be deprecated and removed. Please use
+ useCurrentContentSizeCategoryWhenApplied instead.
+ */
+@property(nonatomic, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
 
 @end

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -99,8 +99,7 @@
 @optional
 
 /**
- Whether applications of this scheme to components should apply fonts in respect to the current
- Dynamic Type setting.
+ A hint for how fonts in this scheme should be applied to components in relation to Dynamic Type.
 
  If this flag is enabled and the typography scheme's font is scalable with Dynamic Type, then fonts
  should be adjusted for the current Dynamic Type content size category prior to being assigned to

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -105,7 +105,7 @@
  should be adjusted for the current Dynamic Type content size category prior to being assigned to
  the component.
 
- This flag will become required in the future as a replacement for
+ @note This flag will become required in the future as a replacement for
  mdc_adjustsFontForContentSizeCategory.
  */
 @property(nonatomic, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
@@ -119,7 +119,8 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
   /**
    The Material defaults, circa April 2018.
 
-   useCurrentContentSizeCategoryWhenApplied will be NO by default.
+   MDCTypographyScheming's useCurrentContentSizeCategoryWhenApplied is assigned to NO by default
+   with this version.
    */
   MDCTypographySchemeDefaultsMaterial201804,
 
@@ -130,7 +131,8 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
    MDCTypographySchemeDefaultsMaterial201804 with the addition that vended fonts will have
    appropriate scalingCurves attached.
 
-   useCurrentContentSizeCategoryWhenApplied will be YES by default.
+   MDCTypographyScheming's useCurrentContentSizeCategoryWhenApplied is assigned to YES by default
+   with this version.
    */
   MDCTypographySchemeDefaultsMaterial201902,
 };

--- a/components/schemes/Typography/src/MDCTypographyScheme.m
+++ b/components/schemes/Typography/src/MDCTypographyScheme.m
@@ -62,7 +62,7 @@
         _button = [UIFont systemFontOfSize:14.0];
         _overline = [UIFont systemFontOfSize:12.0];
 #endif
-        _mdc_adjustsFontForContentSizeCategory = NO;
+        _useCurrentContentSizeCategoryWhenApplied = NO;
         break;
       case MDCTypographySchemeDefaultsMaterial201902:
 #if defined(__IPHONE_8_2)
@@ -100,7 +100,7 @@
         _overline = [UIFont systemFontOfSize:12.0];
 #endif
 
-        _mdc_adjustsFontForContentSizeCategory = YES;
+        _useCurrentContentSizeCategoryWhenApplied = YES;
 
         // Attach a sizing curve to all fonts
         MDCFontScaler *fontScaler =
@@ -182,6 +182,14 @@
   copy.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
 
   return copy;
+}
+
+- (BOOL)mdc_adjustsFontForContentSizeCategory {
+  return self.useCurrentContentSizeCategoryWhenApplied;
+}
+
+- (void)setMdc_adjustsFontForContentSizeCategory:(BOOL)mdc_adjustsFontForContentSizeCategory {
+  self.useCurrentContentSizeCategoryWhenApplied = mdc_adjustsFontForContentSizeCategory;
 }
 
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -167,4 +167,28 @@
   XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
+- (void)testMdc_adjustsFontForContentSizeCategoryIsMappedToUseCurrentContentSizeCategoryWhenApplied {
+  // Given
+  MDCTypographyScheme *scheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
+  // When
+  scheme.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // Then
+  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
+
+  // When
+  scheme.mdc_adjustsFontForContentSizeCategory = NO;
+
+  // Then
+  XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
+
+  // When (just in case the initial "truth" equality was a coincidence)
+  scheme.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // Then
+  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
+}
+
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -149,4 +149,22 @@
       mdc_isSimplyEqual:[scheme201902.overline mdc_scaledFontAtDefaultSize]]);
 }
 
+- (void)testTypographyScheme201804DisableUseCurrentContentSizeCategoryWhenAppliedByDefault {
+  // Given
+  MDCTypographyScheme *scheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
+  // Then
+  XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
+}
+
+- (void)testTypographyScheme201902EnablesUseCurrentContentSizeCategoryWhenAppliedByDefault {
+  // Given
+  MDCTypographyScheme *scheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
+
+  // Then
+  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
+}
+
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -167,7 +167,8 @@
   XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
-- (void)testMdc_adjustsFontForContentSizeCategoryIsMappedToUseCurrentContentSizeCategoryWhenApplied {
+- (void)
+    testMdc_adjustsFontForContentSizeCategoryIsMappedToUseCurrentContentSizeCategoryWhenApplied {
   // Given
   MDCTypographyScheme *scheme =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];


### PR DESCRIPTION
This new property is a replacement for `mdc_adjustsFontForContentSizeCategory`, with the name more clearly demonstrating its intended use case.

Expected client usage:

```objc
typographyScheme = [[MDCTypographyScheme alloc] initWithDefaults:
                        MDCTypographySchemeDefaultsMaterial201902];
typographyScheme.useCurrentContentSizeCategoryWhenApplied = YES;
containerScheme.typographyScheme = typographyScheme;
button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
[button applyThemeWithScheme:containerScheme];
```

Expected theming extension implementation usage (pseudo-code):

```objc
- applyThemeWithScheme:(id<MDCContainerScheming>)scheme {
 if ([scheme.typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]
         && scheme.typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
    UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
    if (@available(iOS 10.0, *)) {
      sizeCategory = self.traitCollection.preferredContentSizeCategory;
    } else if ([UIApplication mdc_safeSharedApplication]) {
      sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
    }
    [self setTitleFont:[scheme.typographyScheme.button mdc_scaledFontForSizeCategory:sizeCategory]
              forState:UIControlStateNormal];
  } else {
    [self setTitleFont:scheme.typographyScheme.button forState:UIControlStateNormal];
  }
}
```

Issue is being mirrored. Will update this description once it is available.