### PR TITLE
[Buttons] Fix issue with legacy dynamic type

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -974,6 +974,13 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self sizeToFit];
 }
 
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
+    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+  [self updateTitleFont];
+}
+
 - (BOOL)mdc_legacyFontScaling {
   return self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -98,7 +98,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 @property(nonatomic, strong, readonly, nonnull) MDCStatefulRippleView *rippleView;
 @property(nonatomic, strong) MDCInkView *inkView;
 @property(nonatomic, readonly, strong) MDCShapedShadowLayer *layer;
-- (void)updateTitleFont;
 @end
 
 @implementation MDCButton

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1137,6 +1137,26 @@ static NSString *controlStateDescription(UIControlState controlState) {
 }
 
 /**
+ Test legacy dynamic type has no impact on a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
+ mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
+ */
+- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
+  // Given
+  UIFont *fakeFont = [UIFont systemFontOfSize:55];
+  [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
+  UIFont *originalFont = self.button.titleLabel.font;
+  self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
+
+  // When
+  self.button.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // Then
+  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:originalFont],
+                @"%@ is not equal to %@", self.button.titleLabel.font, originalFont);
+}
+
+/**
  Test legacy dynamic type impacts a @c MDCButton when @c
  adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
  */

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1134,7 +1134,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
   // When
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-  [self.button updateTitleFont];
 
   // Then
   XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:originalFont],
@@ -1154,7 +1153,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
   // When
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-  [self.button updateTitleFont];
 
   // Then
   XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:originalFont], @"%@ is equal to %@",

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -82,10 +82,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
   return [string copy];
 }
 
-@interface MDCButton (Testing)
-- (void)updateTitleFont;
-@end
-
 @interface FakeShadowLayer : MDCShapedShadowLayer
 @property(nonatomic, assign) NSInteger elevationAssignmentCount;
 @end


### PR DESCRIPTION
## Motivation
The possible code paths for the legacy dynamic type when there are no scaling curves associated with a font are as follows

#### Case 1
```swift
button.mdc_adjustsFontForContentSizeCategory = true
button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = true
// This should update the font use the legacy *magic* font
```
#### Case 2
```swift
button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = true
button.mdc_adjustsFontForContentSizeCategory = true
// This should update the font use the legacy *magic* font
```
#### Case 3
```swift
button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = false
button.mdc_adjustsFontForContentSizeCategory = true
// This should *not* update the font use the legacy *magic* font
```
#### Case 4
```swift
button.mdc_adjustsFontForContentSizeCategory = true
button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = false
// This should *not* update the font use the legacy *magic* font
```

Currently we only cover cases 1-3, but it's reasonable for a client to get into _Case 4_, this requires a setter for `adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable` to _undo_ **magic** behavior if the **magic** behavior has been applied.

## Detailed changes
This change adds a setter to `adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable` to update the fonts accordingly and _undo_ any changes done to the component.

Related to #7464 