### PR TITLE
[Typography] Copy-edit of UIFont+MaterialScalable.h

### DIFF
--- a/components/Typography/src/UIFont+MaterialScalable.h
+++ b/components/Typography/src/UIFont+MaterialScalable.h
@@ -16,43 +16,38 @@
 
 #import "MDCFontTextStyle.h"
 
+/**
+ A representation of a mapping of UIContentSizeCategory keys to font size values.
+
+ The values of this dictionary are CGFloat values represented as an NSNumber. Each value defines the
+ font size to be used for a given content size category.
+ */
+typedef NSDictionary<UIContentSizeCategory, NSNumber *> * MDCScalingCurve;
+
 @interface UIFont (MaterialScalable)
 
 /**
- An associated scaling curve that can be used to create resized versions of the font based on a
- UIContentSizeCategory.
+ A custom scaling curve to be used when scaling this font for Dynamic Type.
 
- An associated scaling curve that is a dictionary that maps UISizeCategory to fontsize.
- The dictionary keys MUST include a complete set of size categories, from
+ The keys of a scaling curve MUST include the complete set of UIContentSizeCategory values, from
  UIContentSizeCategoryExtraSmall to UIContentSizeCategoryExtraExtraExtraLarge AND all
- UIContentSizeCategoryAccessibility categories.
-
- The dictionary values are the desired pointSize stored as a CGFloat wrapped in an NSNumber.
-
- Generally, clients will use MDCFontScaler to attach particular scaling curves to a font.
+ UIContentSizeCategoryAccessibility categories. If any of these keys are missing then any scaling
+ behavior that reads from this property is undefined.
  */
-@property(nonatomic, copy, nullable, setter=mdc_setScalingCurve:)
-    NSDictionary<UIContentSizeCategory, NSNumber *> *mdc_scalingCurve;
+@property(nonatomic, copy, nullable, setter=mdc_setScalingCurve:) MDCScalingCurve mdc_scalingCurve;
 
 /**
- Return a font with the same family, weight and traits, with a size based on the given size
- category and an associated scaling curve.
+ Returns a font with the same family, weight and traits, but whose point size is based on the given
+ size category and the font's @c mdc_scalingCurve.
 
- @param sizeCategory used to query the associated scaling curve for font size
- @return Font sized for the current size category OR self if there is no associated curve
+ @param sizeCategory The size category for which the font should be scaled.
+ @return A font whose point size matches the @c mdc_scalingCurve's current size category value, or
+ self if @c mdc_scalingCurve is nil.
  */
 - (nonnull UIFont *)mdc_scaledFontForSizeCategory:(nonnull UIContentSizeCategory)sizeCategory;
 
 /**
- Return a font with the same family, weight and traits, with a size based on the device's
- text size setting and an associated scaling curve.
-
- @return Font sized for the current size category OR self if there is no associated curve
- */
-- (nonnull UIFont *)mdc_scaledFontForCurrentSizeCategory;
-
-/**
- Return a font with the same family, weight and traits, with a font size based on the default
+ Returns a font with the same family, weight and traits, with a font size based on the default
  size category of UIContentSizeCategoryLarge.
 
  This can be used to return a font for a text element that should *not* be scaled with Dynamic
@@ -61,5 +56,16 @@
  @return Font sized for UIContentSizeCategoryLarge OR self if there is no associated curve
  */
 - (nonnull UIFont *)mdc_scaledFontAtDefaultSize;
+
+/**
+ Returns a font with the same family, weight and traits, but whose point size is the device's
+ text size setting and the font's @c mdc_scalingCurve.
+
+ @note Prefer @c -mdc_scaledFontForSizeCategory: because it encourages use of trait collections
+ instead.
+
+ @return Font sized for the current size category OR self if there is no associated curve
+ */
+- (nonnull UIFont *)mdc_scaledFontForCurrentSizeCategory;
 
 @end

--- a/components/Typography/src/UIFont+MaterialScalable.h
+++ b/components/Typography/src/UIFont+MaterialScalable.h
@@ -41,8 +41,8 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
  size category and the font's @c mdc_scalingCurve.
 
  @param sizeCategory The size category for which the font should be scaled.
- @return A font whose point size matches the @c mdc_scalingCurve's current size category value, or
- self if @c mdc_scalingCurve is nil.
+ @return A font whose point size is extracted from @c mdc_scalingCurve for the given size category,
+ or self if @c mdc_scalingCurve is nil.
  */
 - (nonnull UIFont *)mdc_scaledFontForSizeCategory:(nonnull UIContentSizeCategory)sizeCategory;
 
@@ -53,7 +53,8 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
  This can be used to return a font for a text element that should *not* be scaled with Dynamic
  Type.
 
- @return Font sized for UIContentSizeCategoryLarge OR self if there is no associated curve
+ @return A font whose point size is extracted from @c mdc_scalingCurve for
+ UIContentSizeCategoryLarge, or self if @c mdc_scalingCurve is nil.
  */
 - (nonnull UIFont *)mdc_scaledFontAtDefaultSize;
 
@@ -64,7 +65,11 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
  @note Prefer @c -mdc_scaledFontForSizeCategory: because it encourages use of trait collections
  instead.
 
- @return Font sized for the current size category OR self if there is no associated curve
+ @return If @c mdc_scalingCurve is nil, returns self. On iOS 10 and above, returns a font whose
+ point size is extracted from @c mdc_scalingCurve for UIScreen.mainScreen's
+ preferredContentSizeCategory. On iOS 9, returns a font whose point size is extracted from
+ @c mdc_scalingCurve for UIApplication.sharedApplication's preferredContentSizeCategory, if a shared
+ application is available, otherwise uses UIContentSizeCategoryLarge instead.
  */
 - (nonnull UIFont *)mdc_scaledFontForCurrentSizeCategory;
 

--- a/components/Typography/src/UIFont+MaterialScalable.h
+++ b/components/Typography/src/UIFont+MaterialScalable.h
@@ -22,7 +22,7 @@
  The values of this dictionary are CGFloat values represented as an NSNumber. Each value defines the
  font size to be used for a given content size category.
  */
-typedef NSDictionary<UIContentSizeCategory, NSNumber *> * MDCScalingCurve;
+typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
 
 @interface UIFont (MaterialScalable)
 

--- a/components/Typography/src/UIFont+MaterialScalable.h
+++ b/components/Typography/src/UIFont+MaterialScalable.h
@@ -38,7 +38,7 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
 
 /**
  Returns a font with the same family, weight and traits, but whose point size is based on the given
- size category and the font's @c mdc_scalingCurve.
+ size category and the corresponding value from @c mdc_scalingCurve.
 
  @param sizeCategory The size category for which the font should be scaled.
  @return A font whose point size is extracted from @c mdc_scalingCurve for the given size category,
@@ -47,8 +47,9 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
 - (nonnull UIFont *)mdc_scaledFontForSizeCategory:(nonnull UIContentSizeCategory)sizeCategory;
 
 /**
- Returns a font with the same family, weight and traits, with a font size based on the default
- size category of UIContentSizeCategoryLarge.
+ Returns a font with the same family, weight and traits, but whose point size is based on the
+ default size category of UIContentSizeCategoryLarge and the corresponding value from
+ @c mdc_scalingCurve.
 
  This can be used to return a font for a text element that should *not* be scaled with Dynamic
  Type.
@@ -59,8 +60,8 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
 - (nonnull UIFont *)mdc_scaledFontAtDefaultSize;
 
 /**
- Returns a font with the same family, weight and traits, but whose point size is the device's
- text size setting and the font's @c mdc_scalingCurve.
+ Returns a font with the same family, weight and traits, but whose point size is based on the
+ device's current content size category and the corresponding value from @c mdc_scalingCurve.
 
  @note Prefer @c -mdc_scaledFontForSizeCategory: because it encourages use of trait collections
  instead.


### PR DESCRIPTION
- `-mdc_scaledFontForSizeCategory:` has been documented as preferred over `-mdc_scaledFontForCurrentSizeCategory` because it encourages use of trait collections and is more testable as a result.
- The method summaries follow the verb form guidance at https://developers.google.com/style/reference-verbs (i.e. "Returns" instead of "Return").
- `mdc_scalingCurve's` property type is now typedef'd so that it can be consistently used throughout the Typography target.
- All of the public API have been copy-edited for clarity and conciseness.

Closes https://github.com/material-components/material-components-ios/issues/7474
