### PR TITLE
[Typography] Implement copy semantics on UIFont's mdc_scalingCurve.

### DIFF
--- a/components/Typography/src/UIFont+MaterialScalable.m
+++ b/components/Typography/src/UIFont+MaterialScalable.m
@@ -68,7 +68,7 @@ static char MDCFontScaleObjectKey;
 
 - (void)mdc_setScalingCurve:(NSDictionary<UIContentSizeCategory, NSNumber *> *)scalingCurve {
   objc_setAssociatedObject(self, &MDCFontScaleObjectKey, scalingCurve,
-                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                           OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 @end

--- a/components/Typography/tests/unit/MaterialScalableFontTests.m
+++ b/components/Typography/tests/unit/MaterialScalableFontTests.m
@@ -35,6 +35,22 @@
   XCTAssert([font mdc_isSimplyEqual:nonScaledFont1]);
 }
 
+- (void)testScalingCurveIsCopied {
+  // Given
+  UIFont *font = [UIFont systemFontOfSize:18.0];
+  NSMutableDictionary<UIContentSizeCategory, NSNumber *> *scalingCurve = [@{
+    UIContentSizeCategoryExtraSmall : @0,
+  } mutableCopy];
+  font.mdc_scalingCurve = scalingCurve;
+
+  // When
+  scalingCurve[UIContentSizeCategoryExtraSmall] = @100;
+
+  // Then
+  XCTAssertNotEqual(font.mdc_scalingCurve[UIContentSizeCategoryExtraSmall],
+                    scalingCurve[UIContentSizeCategoryExtraSmall]);
+}
+
 - (void)testNegativeAndZeroScalingCurve {
   // Given
   UIFont *font = [UIFont systemFontOfSize:18.0];


### PR DESCRIPTION
Prior to this change, mdc_scalingCurve was implemented using retain semantics insteaad of copy semantics. This potentially enabled a class of surprising bugs if mutable dictionaries were being assigned and then modified after the fact.

After this change, mdc_scalingCurve implements copy semantics as its public API defines.

The added test was verified to fail prior to this PR's change, and passes with the PR's change.

Closes https://github.com/material-components/material-components-ios/issues/7472
