### PR TITLE
[releasing] Add requirements to post status updates about the release

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -30,14 +30,15 @@ typical weekly release.
 If you are not able to cut a release Wednesday morning, cut it Tuesday evening before you leave the
 office.
 
-Please post regular updates about the status of the release to the team's chat room. At minimum, the following
-inflection points should be noted:
+Please post regular updates about the status of the release to the team's chat room. This helps inform the
+team of the status of the release, and also encourages team problem solving in the event that something is
+stuck. At minimum, the following inflection points should be noted:
 
 - The release is being initiated.
-- Testing the release has begun.
-- Testing the release has ended.
-- The release is being submitted.
-- The release has landed.
+- Internal testing of the release has begun.
+- Internal testing of the release has ended.
+- The release has been submitted internally.
+- The release has been published to CocoaPods.
 
 For Googlers, also read [go/mdc-release-engineering](http://go/mdc-release-engineering) for additional details.
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -30,6 +30,15 @@ typical weekly release.
 If you are not able to cut a release Wednesday morning, cut it Tuesday evening before you leave the
 office.
 
+Please post regular updates about the status of the release to the team's chat room. At minimum, the following
+inflection points should be noted:
+
+- The release is being initiated.
+- Testing the release has begun.
+- Testing the release has ended.
+- The release is being submitted.
+- The release has landed.
+
 For Googlers, also read [go/mdc-release-engineering](http://go/mdc-release-engineering) for additional details.
 
 ## Before you start


### PR DESCRIPTION
Cutting a release can take time and can sometimes be challenging, so sharing status updates with the team as the release progresses ensures that the team is informed of the status of the release. This PR adds a note about communicating the status of the release to the team's internal chat room.