### PR TITLE
[Typography] Align useCurrentContentSizeCategoryWhenApplied with internal behavior.

### DIFF
--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -118,9 +118,6 @@
 typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
   /**
    The Material defaults, circa April 2018.
-
-   MDCTypographyScheming's useCurrentContentSizeCategoryWhenApplied is assigned to NO by default
-   with this version.
    */
   MDCTypographySchemeDefaultsMaterial201804,
 
@@ -130,9 +127,6 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
    This scheme implements fonts with the similar metrics as
    MDCTypographySchemeDefaultsMaterial201804 with the addition that vended fonts will have
    appropriate scalingCurves attached.
-
-   MDCTypographyScheming's useCurrentContentSizeCategoryWhenApplied is assigned to YES by default
-   with this version.
    */
   MDCTypographySchemeDefaultsMaterial201902,
 };
@@ -169,6 +163,8 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 
  - If this flag is disabled, make no changes to the font.
  - If this flag is enabled, adjust the font with respect to the current content size category.
+
+ Default value is NO.
  */
 @property(nonatomic, assign, readwrite) BOOL useCurrentContentSizeCategoryWhenApplied;
 
@@ -187,6 +183,8 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 /**
  @warning Will eventually be deprecated and removed. Please use
  useCurrentContentSizeCategoryWhenApplied instead.
+
+ Modifying this property will also modify useCurrentContentSizeCategoryWhenApplied, and vice-versa.
  */
 @property(nonatomic, assign, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
 

--- a/components/schemes/Typography/src/MDCTypographyScheme.m
+++ b/components/schemes/Typography/src/MDCTypographyScheme.m
@@ -26,6 +26,8 @@
 - (instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults {
   self = [super init];
   if (self) {
+    _useCurrentContentSizeCategoryWhenApplied = NO;
+
     switch (defaults) {
       case MDCTypographySchemeDefaultsMaterial201804:
 #if defined(__IPHONE_8_2)
@@ -62,7 +64,6 @@
         _button = [UIFont systemFontOfSize:14.0];
         _overline = [UIFont systemFontOfSize:12.0];
 #endif
-        _useCurrentContentSizeCategoryWhenApplied = NO;
         break;
       case MDCTypographySchemeDefaultsMaterial201902:
 #if defined(__IPHONE_8_2)
@@ -99,8 +100,6 @@
         _button = [UIFont systemFontOfSize:14.0];
         _overline = [UIFont systemFontOfSize:12.0];
 #endif
-
-        _useCurrentContentSizeCategoryWhenApplied = YES;
 
         // Attach a sizing curve to all fonts
         MDCFontScaler *fontScaler =

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -149,7 +149,7 @@
       mdc_isSimplyEqual:[scheme201902.overline mdc_scaledFontAtDefaultSize]]);
 }
 
-- (void)testTypographyScheme201804DisableUseCurrentContentSizeCategoryWhenAppliedByDefault {
+- (void)testTypographyScheme201804UseCurrentContentSizeCategoryWhenAppliedIsDisabledByDefault {
   // Given
   MDCTypographyScheme *scheme =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
@@ -158,13 +158,13 @@
   XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
-- (void)testTypographyScheme201902EnablesUseCurrentContentSizeCategoryWhenAppliedByDefault {
+- (void)testTypographyScheme201902UseCurrentContentSizeCategoryWhenAppliedIsDisabledByDefault {
   // Given
   MDCTypographyScheme *scheme =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
 
   // Then
-  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
+  XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
 - (void)


### PR DESCRIPTION
- useCurrentContentSizeCategoryWhenApplied should always be NO by default.
- Docs have been updated for clarity.

Follow up to https://github.com/material-components/material-components-ios/issues/7467