### PR TITLE
[Buttons] Revert updating fonts after adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable has been updated

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -973,13 +973,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self sizeToFit];
 }
 
-- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
-    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
-      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-  [self updateTitleFont];
-}
-
 - (BOOL)mdc_legacyFontScaling {
   return self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 }

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1118,26 +1118,6 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
 /**
  Test legacy dynamic type has no impact on a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO that the font stays
- the same.
- */
-- (void)testLegacyDynamicTypeDisabled {
-  // Given
-  UIFont *fakeFont = [UIFont systemFontOfSize:55];
-  [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
-  UIFont *originalFont = self.button.titleLabel.font;
-  self.button.mdc_adjustsFontForContentSizeCategory = YES;
-
-  // When
-  self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-
-  // Then
-  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:originalFont],
-                @"%@ is not equal to %@", self.button.titleLabel.font, originalFont);
-}
-
-/**
- Test legacy dynamic type has no impact on a @c MDCButton when @c
  adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
  mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
  */


### PR DESCRIPTION
This change reverts the changes in #7466 

This change deviates from the rest of our components therefore we are reverting it to bring buttons into alignment with our other components.