### PR TITLE
[Buttons] Update fonts dictionary when dynamic type is enabled

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -890,6 +890,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
 
   if (_mdc_adjustsFontForContentSizeCategory) {
+    // Dynamic type is enabled so apply scaling
     [self updateFontForDynamicTypeWithFont:font];
   }
 
@@ -899,28 +900,20 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (void)updateFontForDynamicTypeWithFont:(UIFont *)font {
-  // Dynamic type is enabled so apply scaling
   if (font.mdc_scalingCurve) {
-    UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
-    if (@available(iOS 10.0, *)) {
-      sizeCategory = self.traitCollection.preferredContentSizeCategory;
-    } else if ([UIApplication mdc_safeSharedApplication]) {
-      sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-    }
-    font = [font mdc_scaledFontForSizeCategory:sizeCategory];
+    font = [font mdc_scaledFontForTraitEnvironment:self];
   } else {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleButton
                                 scaledForDynamicType:YES];
     }
   }
-}
-
-if (_fonts[@(self.state)] != nil) {
-  _fonts[@(self.state)] = font;
-} else {
-  _fonts[@(UIControlStateNormal)] = font;
-}
+  // Update the _font dictionary so that it returns the correct font.
+  if (_fonts[@(self.state)] != nil) {
+    _fonts[@(self.state)] = font;
+  } else {
+    _fonts[@(UIControlStateNormal)] = font;
+  }
 }
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -891,7 +891,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   if (_mdc_adjustsFontForContentSizeCategory) {
     // Dynamic type is enabled so apply scaling
-    [self updateFontForDynamicTypeWithFont:font];
+    font = [self updateFontForDynamicTypeWithFont:font];
   }
 
   self.titleLabel.font = font;
@@ -899,7 +899,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self setNeedsLayout];
 }
 
-- (void)updateFontForDynamicTypeWithFont:(UIFont *)font {
+- (UIFont *)updateFontForDynamicTypeWithFont:(UIFont *)font {
   if (font.mdc_scalingCurve) {
     font = [font mdc_scaledFontForTraitEnvironment:self];
   } else {
@@ -914,6 +914,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   } else {
     _fonts[@(UIControlStateNormal)] = font;
   }
+  return font;
 }
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -893,12 +893,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     [self updateFontForDynamicTypeWithFont:font];
   }
 
-  /*if (_fonts[@(self.state)] != nil) {
-    _fonts[@(self.state)] = font;
-  } else {
-    _fonts[@(UIControlStateNormal)] = font;
-  }*/
-
   self.titleLabel.font = font;
 
   [self setNeedsLayout];

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -890,32 +890,43 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   }
 
   if (_mdc_adjustsFontForContentSizeCategory) {
-    // Dynamic type is enabled so apply scaling
-    if (font.mdc_scalingCurve) {
-      UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
-      if (@available(iOS 10.0, *)) {
-        sizeCategory = self.traitCollection.preferredContentSizeCategory;
-      } else if ([UIApplication mdc_safeSharedApplication]) {
-        sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-      }
-      font = [font mdc_scaledFontForSizeCategory:sizeCategory];
-    } else {
-      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-        font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleButton
-                                  scaledForDynamicType:YES];
-      }
-    }
+    [self updateFontForDynamicTypeWithFont:font];
   }
 
-  if (_fonts[@(self.state)] != nil) {
+  /*if (_fonts[@(self.state)] != nil) {
     _fonts[@(self.state)] = font;
   } else {
     _fonts[@(UIControlStateNormal)] = font;
-  }
+  }*/
 
   self.titleLabel.font = font;
 
   [self setNeedsLayout];
+}
+
+- (void)updateFontForDynamicTypeWithFont:(UIFont *)font {
+  // Dynamic type is enabled so apply scaling
+  if (font.mdc_scalingCurve) {
+    UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
+    if (@available(iOS 10.0, *)) {
+      sizeCategory = self.traitCollection.preferredContentSizeCategory;
+    } else if ([UIApplication mdc_safeSharedApplication]) {
+      sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
+    }
+    font = [font mdc_scaledFontForSizeCategory:sizeCategory];
+  } else {
+    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+      font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleButton
+                                scaledForDynamicType:YES];
+    }
+  }
+}
+
+if (_fonts[@(self.state)] != nil) {
+  _fonts[@(self.state)] = font;
+} else {
+  _fonts[@(UIControlStateNormal)] = font;
+}
 }
 
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -907,6 +907,12 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
     }
   }
 
+  if (_fonts[@(self.state)] != nil) {
+    _fonts[@(self.state)] = font;
+  } else {
+    _fonts[@(UIControlStateNormal)] = font;
+  }
+
   self.titleLabel.font = font;
 
   [self setNeedsLayout];

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1137,10 +1137,9 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // Given
   UIFont *fakeFont = [UIFont systemFontOfSize:55];
   [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
-  self.button.mdc_adjustsFontForContentSizeCategory = YES;
 
   // When
-  self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+  self.button.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
   XCTAssertFalse([[self.button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeFont],

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1129,7 +1129,8 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertTrue([[self.button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeFont],
                 @"%@ is not equal to %@", [self.button titleFontForState:UIControlStateNormal],
                 fakeFont);
-  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is not equal to %@", self.button.titleLabel.font, fakeFont);
+  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is not equal to %@",
+                self.button.titleLabel.font, fakeFont);
 }
 
 - (void)testLegacyDynamicTypeEnabledDoesChangeTheFont {
@@ -1145,7 +1146,8 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertFalse([[self.button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeFont],
                  @"%@ is equal to %@", [self.button titleFontForState:UIControlStateNormal],
                  fakeFont);
-    XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is equal to %@", self.button.titleLabel.font, fakeFont);
+  XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is equal to %@",
+                 self.button.titleLabel.font, fakeFont);
 }
 
 #pragma mark - Size-related tests

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1116,43 +1116,36 @@ static NSString *controlStateDescription(UIControlState controlState) {
                              @"Font size should be equal to MDCFontTextStyleButton's.");
 }
 
-/**
- Test legacy dynamic type has no impact on a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
- mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
- */
-- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
+- (void)testLegacyDynamicTypeDisabledDoesNotChangeTheFont {
   // Given
   UIFont *fakeFont = [UIFont systemFontOfSize:55];
   [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
-  UIFont *originalFont = self.button.titleLabel.font;
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
   self.button.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
-  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:originalFont],
-                @"%@ is not equal to %@", self.button.titleLabel.font, originalFont);
+  XCTAssertTrue([[self.button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeFont],
+                @"%@ is not equal to %@", [self.button titleFontForState:UIControlStateNormal],
+                fakeFont);
+  XCTAssertTrue([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is not equal to %@", self.button.titleLabel.font, fakeFont);
 }
 
-/**
- Test legacy dynamic type impacts a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
- */
-- (void)testLegacyDynamicTypeEnabled {
+- (void)testLegacyDynamicTypeEnabledDoesChangeTheFont {
   // Given
   UIFont *fakeFont = [UIFont systemFontOfSize:55];
   [self.button setTitleFont:fakeFont forState:UIControlStateNormal];
-  UIFont *originalFont = self.button.titleLabel.font;
   self.button.mdc_adjustsFontForContentSizeCategory = YES;
 
   // When
   self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
   // Then
-  XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:originalFont], @"%@ is equal to %@",
-                 self.button.titleLabel.font, originalFont);
+  XCTAssertFalse([[self.button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeFont],
+                 @"%@ is equal to %@", [self.button titleFontForState:UIControlStateNormal],
+                 fakeFont);
+    XCTAssertFalse([self.button.titleLabel.font mdc_isSimplyEqual:fakeFont], @"%@ is equal to %@", self.button.titleLabel.font, fakeFont);
 }
 
 #pragma mark - Size-related tests


### PR DESCRIPTION
When a client enables dynamic type on an `MDCButton` we update the titleLabel.font based off the internal _fonts_ dictionary. The getter for the _fonts_ dictionary `titleFont:forState:` never gets updated. This changes updates the dictionary to get the right value based of the newly calculated font.

Closes #7492