### PR TITLE
[Buttons] Refactor dynamic type support to use mdc_scaledFontForTraitEnvironment.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -387,7 +387,6 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/Shapes"
     component.dependency "MaterialComponents/Typography"
-    component.dependency "MaterialComponents/private/Application"
     component.dependency "MaterialComponents/private/Math"
 
     component.test_spec 'UnitTests' do |unit_tests|

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -44,7 +44,6 @@ mdc_public_objc_library(
         "//components/ShapeLibrary",
         "//components/Shapes",
         "//components/Typography",
-        "//components/private/Application",
         "//components/private/Math",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -15,7 +15,6 @@
 #import "MDCButton.h"
 
 #import <MDFTextAccessibility/MDFTextAccessibility.h>
-#import "MaterialApplication.h"
 #import "MaterialInk.h"
 #import "MaterialMath.h"
 #import "MaterialRipple.h"
@@ -892,13 +891,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if (_mdc_adjustsFontForContentSizeCategory) {
     // Dynamic type is enabled so apply scaling
     if (font.mdc_scalingCurve) {
-      UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
-      if (@available(iOS 10.0, *)) {
-        sizeCategory = self.traitCollection.preferredContentSizeCategory;
-      } else if ([UIApplication mdc_safeSharedApplication]) {
-        sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-      }
-      font = [font mdc_scaledFontForSizeCategory:sizeCategory];
+      font = [font mdc_scaledFontForTraitEnvironment:self];
     } else {
       if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
         font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleButton


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/7470

The existing behavior is being replaced with the identical behavior implemented by UIFont's `-mdc_scaledFontForTraitEnvironment:`, shown below:

https://github.com/material-components/material-components-ios/blob/8a139a87327eb9f8561944f59b0ee25f0b8d11c7/components/Typography/src/UIFont%2BMaterialScalable.m#L56-L64