### PR TITLE
[List] add Dynamic Type support on List Typography Themer.

### DIFF
--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -47,6 +47,7 @@ mdc_extension_objc_library(
     name = "TypographyThemer",
     deps = [
         ":List",
+        "//components/Typography",
         "//components/schemes/Typography",
     ],
 )
@@ -94,6 +95,7 @@ mdc_objc_library(
         ":List",
         ":ListThemer",
         ":TypographyThemer",
+        "//components/Typography",
         "//components/schemes/Typography",
     ],
 )

--- a/components/List/src/TypographyThemer/MDCListTypographyThemer.m
+++ b/components/List/src/TypographyThemer/MDCListTypographyThemer.m
@@ -13,13 +13,31 @@
 // limitations under the License.
 
 #import "MDCListTypographyThemer.h"
+#import "MaterialTypography.h"
 
 @implementation MDCListTypographyThemer
 
 + (void)applyTypographyScheme:(id<MDCTypographyScheming>)typographyScheme
        toSelfSizingStereoCell:(MDCSelfSizingStereoCell *)cell {
-  cell.titleLabel.font = typographyScheme.subtitle1;
-  cell.detailLabel.font = typographyScheme.body2;
+  UIFont *titleFont = typographyScheme.subtitle1;
+  UIFont *detailFont = typographyScheme.body2;
+
+  BOOL useCurrentContentSizeCategoryWhenApplied = NO;
+  if ([typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]) {
+    useCurrentContentSizeCategoryWhenApplied =
+    typographyScheme.useCurrentContentSizeCategoryWhenApplied;
+  } else {
+    useCurrentContentSizeCategoryWhenApplied =
+    typographyScheme.mdc_adjustsFontForContentSizeCategory;
+  }
+
+  if (useCurrentContentSizeCategoryWhenApplied) {
+    titleFont = [titleFont mdc_scaledFontForTraitEnvironment:cell];
+    detailFont = [detailFont mdc_scaledFontForTraitEnvironment:cell];
+  }
+
+  cell.titleLabel.font = titleFont;
+  cell.detailLabel.font = detailFont;
 }
 
 @end

--- a/components/List/src/TypographyThemer/MDCListTypographyThemer.m
+++ b/components/List/src/TypographyThemer/MDCListTypographyThemer.m
@@ -25,10 +25,10 @@
   BOOL useCurrentContentSizeCategoryWhenApplied = NO;
   if ([typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]) {
     useCurrentContentSizeCategoryWhenApplied =
-    typographyScheme.useCurrentContentSizeCategoryWhenApplied;
+        typographyScheme.useCurrentContentSizeCategoryWhenApplied;
   } else {
     useCurrentContentSizeCategoryWhenApplied =
-    typographyScheme.mdc_adjustsFontForContentSizeCategory;
+        typographyScheme.mdc_adjustsFontForContentSizeCategory;
   }
 
   if (useCurrentContentSizeCategoryWhenApplied) {

--- a/components/List/tests/unit/MDCListTypographyThemerTests.m
+++ b/components/List/tests/unit/MDCListTypographyThemerTests.m
@@ -36,7 +36,7 @@
 }
 
 - (instancetype)initWithContentSizeCategoryOverride:
-(UIContentSizeCategory)contentSizeCategoryOverride {
+    (UIContentSizeCategory)contentSizeCategoryOverride {
   self = [super init];
   if (self) {
     self.contentSizeCategoryOverride = contentSizeCategoryOverride;
@@ -47,7 +47,7 @@
 - (UITraitCollection *)traitCollection {
   if (@available(iOS 10.0, *)) {
     UITraitCollection *traitCollection = [UITraitCollection
-                                          traitCollectionWithPreferredContentSizeCategory:self.contentSizeCategoryOverride];
+        traitCollectionWithPreferredContentSizeCategory:self.contentSizeCategoryOverride];
     return traitCollection;
   }
   return [super traitCollection];
@@ -77,10 +77,9 @@
     typographyScheme.useCurrentContentSizeCategoryWhenApplied = YES;
 
     // When
-    MDCListTypographyThemerContentSizeCategoryOverrideWindow
-    *extraLargeContainer =
-    [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
-     initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
+    MDCListTypographyThemerContentSizeCategoryOverrideWindow *extraLargeContainer =
+        [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
+            initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
     [extraLargeContainer addSubview:cell];
     [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:cell];
 
@@ -99,10 +98,9 @@
     typographyScheme.useCurrentContentSizeCategoryWhenApplied = NO;
 
     // When
-    MDCListTypographyThemerContentSizeCategoryOverrideWindow
-    *extraLargeContainer =
-    [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
-     initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
+    MDCListTypographyThemerContentSizeCategoryOverrideWindow *extraLargeContainer =
+        [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
+            initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
     [extraLargeContainer addSubview:cell];
     [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:cell];
 

--- a/components/List/tests/unit/MDCListTypographyThemerTests.m
+++ b/components/List/tests/unit/MDCListTypographyThemerTests.m
@@ -14,8 +14,46 @@
 
 #import "MaterialList+TypographyThemer.h"
 #import "MaterialList.h"
+#import "MaterialTypography.h"
 
 #import <XCTest/XCTest.h>
+
+@interface MDCListTypographyThemerContentSizeCategoryOverrideWindow : UIWindow
+
+/** Used to override the value of @c preferredContentSizeCategory. */
+@property(nonatomic, copy) UIContentSizeCategory contentSizeCategoryOverride;
+
+@end
+
+@implementation MDCListTypographyThemerContentSizeCategoryOverrideWindow
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.contentSizeCategoryOverride = UIContentSizeCategoryLarge;
+  }
+  return self;
+}
+
+- (instancetype)initWithContentSizeCategoryOverride:
+(UIContentSizeCategory)contentSizeCategoryOverride {
+  self = [super init];
+  if (self) {
+    self.contentSizeCategoryOverride = contentSizeCategoryOverride;
+  }
+  return self;
+}
+
+- (UITraitCollection *)traitCollection {
+  if (@available(iOS 10.0, *)) {
+    UITraitCollection *traitCollection = [UITraitCollection
+                                          traitCollectionWithPreferredContentSizeCategory:self.contentSizeCategoryOverride];
+    return traitCollection;
+  }
+  return [super traitCollection];
+}
+
+@end
 
 @interface MDCListTypographyThemerTests : XCTestCase
 
@@ -29,6 +67,50 @@
   [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:cell];
   XCTAssertEqualObjects(cell.titleLabel.font, typographyScheme.subtitle1);
   XCTAssertEqualObjects(cell.detailLabel.font, typographyScheme.body2);
+}
+
+- (void)testFontThemerWhenCurrentContentSizeCategoryIsUsed {
+  if (@available(iOS 10.0, *)) {
+    // Given
+    MDCSelfSizingStereoCell *cell = [[MDCSelfSizingStereoCell alloc] initWithFrame:CGRectZero];
+    MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+    typographyScheme.useCurrentContentSizeCategoryWhenApplied = YES;
+
+    // When
+    MDCListTypographyThemerContentSizeCategoryOverrideWindow
+    *extraLargeContainer =
+    [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
+     initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
+    [extraLargeContainer addSubview:cell];
+    [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:cell];
+
+    // Then
+    XCTAssertNotNil(cell.titleLabel.font.mdc_scalingCurve);
+    XCTAssertFalse([cell.titleLabel.font mdc_isSimplyEqual:typographyScheme.subtitle1]);
+    XCTAssertFalse([cell.detailLabel.font mdc_isSimplyEqual:typographyScheme.body2]);
+  }
+}
+
+- (void)testFontThemerWhenCurrentContentSizeCategoryIsNotUsed {
+  if (@available(iOS 10.0, *)) {
+    // Given
+    MDCSelfSizingStereoCell *cell = [[MDCSelfSizingStereoCell alloc] initWithFrame:CGRectZero];
+    MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+    typographyScheme.useCurrentContentSizeCategoryWhenApplied = NO;
+
+    // When
+    MDCListTypographyThemerContentSizeCategoryOverrideWindow
+    *extraLargeContainer =
+    [[MDCListTypographyThemerContentSizeCategoryOverrideWindow alloc]
+     initWithContentSizeCategoryOverride:UIContentSizeCategoryExtraLarge];
+    [extraLargeContainer addSubview:cell];
+    [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:cell];
+
+    // Then
+    XCTAssertNotNil(cell.titleLabel.font.mdc_scalingCurve);
+    XCTAssertTrue([cell.titleLabel.font mdc_isSimplyEqual:typographyScheme.subtitle1]);
+    XCTAssertTrue([cell.detailLabel.font mdc_isSimplyEqual:typographyScheme.body2]);
+  }
 }
 
 @end

--- a/components/List/tests/unit/MDCListTypographyThemerTests.m
+++ b/components/List/tests/unit/MDCListTypographyThemerTests.m
@@ -85,8 +85,8 @@
 
     // Then
     XCTAssertNotNil(cell.titleLabel.font.mdc_scalingCurve);
-    XCTAssertFalse([cell.titleLabel.font mdc_isSimplyEqual:typographyScheme.subtitle1]);
-    XCTAssertFalse([cell.detailLabel.font mdc_isSimplyEqual:typographyScheme.body2]);
+    XCTAssertGreaterThan(cell.titleLabel.font.pointSize, typographyScheme.subtitle1.pointSize);
+    XCTAssertGreaterThan(cell.detailLabel.font.pointSize, typographyScheme.body2.pointSize);
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/7385.

This PR adds support for List Typography Themer to scale fonts on titleLabel and detailLabel if `useCurrentContentSizeCategoryWhenApplied` or `mdc_adjustsFontForContentSizeCategory` (legacy flag) is turned on.