### PR TITLE
[List] Refactor dynamic type support to use mdc_scaledFontForTraitEnvironment.

### DIFF
--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -38,7 +38,6 @@ mdc_public_objc_library(
         "//components/ShadowElevations",
         "//components/ShadowLayer",
         "//components/Typography",
-        "//components/private/Application",
         "@material_internationalization_ios//:MDFInternationalization",
     ],
 )

--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -18,7 +18,6 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
-#import "MaterialApplication.h"
 #import "MaterialInk.h"
 #import "MaterialMath.h"
 #import "MaterialTypography.h"
@@ -228,15 +227,8 @@ static const CGFloat kDetailColorOpacity = (CGFloat)0.6;
   UIFont *titleFont = self.titleLabel.font ?: self.defaultTitleLabelFont;
   UIFont *detailFont = self.detailLabel.font ?: self.defaultDetailLabelFont;
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
-    if (@available(iOS 10.0, *)) {
-      sizeCategory = self.traitCollection.preferredContentSizeCategory;
-    } else if ([UIApplication mdc_safeSharedApplication]) {
-      sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
-    }
-
     if (titleFont.mdc_scalingCurve) {
-      titleFont = [titleFont mdc_scaledFontForSizeCategory:sizeCategory];
+      titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
     } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       titleFont =
           [titleFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleTitle
@@ -244,7 +236,7 @@ static const CGFloat kDetailColorOpacity = (CGFloat)0.6;
     }
 
     if (detailFont.mdc_scalingCurve) {
-      detailFont = [detailFont mdc_scaledFontForSizeCategory:sizeCategory];
+      detailFont = [detailFont mdc_scaledFontForTraitEnvironment:self];
     } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       detailFont =
           [detailFont mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleCaption


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/7470

The existing behavior is being replaced with the identical behavior implemented by UIFont's `-mdc_scaledFontForTraitEnvironment:`, shown below:

https://github.com/material-components/material-components-ios/blob/8a139a87327eb9f8561944f59b0ee25f0b8d11c7/components/Typography/src/UIFont%2BMaterialScalable.m#L56-L64
