### PR TITLE
[ButtonBar] Fix a typo in the docs for rectForItem:inCoordinateSpace:.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.h
+++ b/components/ButtonBar/src/MDCButtonBar.h
@@ -99,7 +99,7 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable) NSArray<UIBarButtonItem *> *items;
 
 /**
- Returns the rect of the item's view within the coordinate space of @c view.
+ Returns the rect of the item's view within the given @c coordinateSpace.
 
  If the provided item is not contained in @c items, then the behavior is undefined.
 


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/7248