### PR TITLE
[Dialogs] Add dynamic type support for fonts with scaling curves

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -160,14 +160,18 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateTitleFont {
   UIFont *titleFont = self.titleFont ?: [[self class] titleFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.titleLabel.font =
-          [titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                                  scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (titleFont.mdc_scalingCurve) {
+      titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        titleFont = [titleFont
+            mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
-  } else {
-    _titleLabel.font = titleFont;
   }
+
+  self.titleLabel.font = titleFont;
   [self setNeedsLayout];
 }
 
@@ -236,14 +240,17 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateMessageFont {
   UIFont *messageFont = _messageFont ?: [[self class] messageFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.messageLabel.font = [messageFont
-          mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
-                       scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (messageFont.mdc_scalingCurve) {
+      messageFont = [messageFont mdc_scaledFontForTraitEnvironment:self];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        messageFont = [messageFont
+            mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
-  } else {
-    _messageLabel.font = messageFont;
   }
+  self.messageLabel.font = messageFont;
   [self setNeedsLayout];
 }
 
@@ -269,10 +276,14 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 - (void)updateButtonFont {
   UIFont *finalButtonFont = self.buttonFont ?: [[self class] buttonFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      finalButtonFont = [finalButtonFont
-          mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
-                       scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+    if (finalButtonFont.mdc_scalingCurve) {
+      finalButtonFont = [finalButtonFont mdc_scaledFontForTraitEnvironment:self];
+    } else {
+      if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
+        finalButtonFont = [finalButtonFont
+            mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
+                         scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
+      }
     }
   }
   for (MDCButton *button in self.actionManager.buttonsInActionOrder) {


### PR DESCRIPTION
This updates the behavior within Dialogs when dynamic type is enabled and the fonts provided for `titleFont`, `messageFont`, or `buttonFont` have _scaling curves_ attached. If any of the fonts do not have _scaling curves_ attached then the fonts will fall back to the legacy behavior.

Tests added in #7447 