### PR TITLE
[Buttons] Remove all example references to MDCFloatingActionButtonThemer.

### DIFF
--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -84,6 +84,7 @@ mdc_examples_swift_library(
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
         "//components/schemes/Color",
+        "//components/schemes/Container",
         "//components/schemes/Typography",
     ],
 )

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -82,7 +82,7 @@ mdc_examples_swift_library(
         ":ColorThemer",
         "//components/AppBar",
         "//components/Buttons",
-        "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -18,6 +18,7 @@ import UIKit
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
+import MaterialComponents.MaterialBottomAppBar_Theming
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -19,6 +19,7 @@ import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTypographyScheme

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -18,7 +18,6 @@ import UIKit
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
-import MaterialComponents.MaterialBottomAppBar_Theming
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -23,7 +23,6 @@ import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTypographyScheme
-import MaterialComponents.MaterialButtons_ButtonThemer
 
 class BottomAppBarTypicalUseSwiftExample: UIViewController {
 

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -20,6 +20,7 @@ import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialBottomAppBar_ColorThemer
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTypographyScheme
 import MaterialComponents.MaterialButtons_ButtonThemer
 
@@ -27,8 +28,7 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
 
   let appBarViewController = MDCAppBarViewController()
   let bottomBarView = MDCBottomAppBarView()
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  @objc var containerScheme = MDCContainerScheme()
 
   init() {
     super.init(nibName: nil, bundle: nil)
@@ -75,12 +75,10 @@ class BottomAppBarTypicalUseSwiftExample: UIViewController {
     bottomBarView.floatingButtonPosition = .center
 
     // Theme the floating button.
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
-    MDCFloatingActionButtonThemer.applyScheme(buttonScheme, to: bottomBarView.floatingButton)
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomBarView)
+    bottomBarView.floatingButton.applySecondaryTheme(withScheme: containerScheme)
+    MDCBottomAppBarColorThemer
+      .applySurfaceVariant(withSemanticColorScheme: containerScheme.colorScheme,
+                           to: bottomBarView)
 
     // Configure the navigation buttons to be shown on the bottom app bar.
     let barButtonLeadingItem = UIBarButtonItem()

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -72,7 +72,7 @@ swift_library(
     deps = [
         ":MaskedTransition",
         "//components/Buttons",
-        "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/schemes/Container",
     ],
 )

--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -73,6 +73,7 @@ swift_library(
         ":MaskedTransition",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -15,6 +15,7 @@
 import Foundation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialMaskedTransition
 

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -15,6 +15,7 @@
 import Foundation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialMaskedTransition
 
 open class MaskedTransitionTypicalUseSwiftExample: UIViewController {

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -27,8 +27,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     let useSafeAreaInsets: Bool
   }
   var targets: [TargetInfo] = []
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  @objc var containerScheme = MDCContainerScheme()
   let rightFAB = MDCFloatingButton()
   let leftFAB = MDCFloatingButton()
 
@@ -43,16 +42,13 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     view.addSubview(tableView)
 
     let addImage = UIImage(named: "Add")
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
     rightFAB.setImage(addImage, for: .normal)
-    MDCFloatingActionButtonThemer.applyScheme(buttonScheme, to: rightFAB)
+    rightFAB.applySecondaryTheme(withScheme: containerScheme)
     rightFAB.addTarget(self, action: #selector(didTapFab), for: .touchUpInside)
     view.addSubview(rightFAB)
 
     leftFAB.setImage(addImage, for: .normal)
-    MDCFloatingActionButtonThemer.applyScheme(buttonScheme, to: leftFAB)
+    leftFAB.applySecondaryTheme(withScheme: containerScheme)
     leftFAB.addTarget(self, action: #selector(didTapFab), for: .touchUpInside)
     view.addSubview(leftFAB)
 

--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -14,7 +14,6 @@
 
 import Foundation
 import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
 import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialMaskedTransition


### PR DESCRIPTION
This is pre-work for being able to annotate MDCFloatingActionButtonThemer as deprecated.

Part of https://github.com/material-components/material-components-ios/issues/5702