### PR TITLE
[Dialogs] Add test for legacy dynamic type behavior around `buttonFont`

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -368,14 +368,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 - (void)setupAlertView {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
->>>>>>> Fix broken test
-=======
-
->>>>>>> Fix issue and improve test
   self.alertView.titleLabel.text = self.title;
   self.alertView.messageLabel.text = self.message;
   self.alertView.titleFont = self.titleFont;
@@ -407,17 +399,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     [self addButtonToAlertViewForAction:action];
   }
   // Explicitly overwrite the view default if true
-<<<<<<< HEAD
-<<<<<<< HEAD
   // We set this last to make sure all other properties are set first and no overriden by setting
   // this.
   if (self.mdc_adjustsFontForContentSizeCategory) {
-=======
-  if (_mdc_adjustsFontForContentSizeCategory) {
->>>>>>> Fix broken test
-=======
-  if (_mdc_adjustsFontForContentSizeCategory) {
->>>>>>> Fix issue and improve test
     self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
   }
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -369,9 +369,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (void)setupAlertView {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
 >>>>>>> Fix broken test
+=======
+
+>>>>>>> Fix issue and improve test
   self.alertView.titleLabel.text = self.title;
   self.alertView.messageLabel.text = self.message;
   self.alertView.titleFont = self.titleFont;
@@ -404,12 +408,16 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
   // Explicitly overwrite the view default if true
 <<<<<<< HEAD
+<<<<<<< HEAD
   // We set this last to make sure all other properties are set first and no overriden by setting
   // this.
   if (self.mdc_adjustsFontForContentSizeCategory) {
 =======
   if (_mdc_adjustsFontForContentSizeCategory) {
 >>>>>>> Fix broken test
+=======
+  if (_mdc_adjustsFontForContentSizeCategory) {
+>>>>>>> Fix issue and improve test
     self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
   }
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -368,6 +368,10 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 - (void)setupAlertView {
+<<<<<<< HEAD
+=======
+
+>>>>>>> Fix broken test
   self.alertView.titleLabel.text = self.title;
   self.alertView.messageLabel.text = self.message;
   self.alertView.titleFont = self.titleFont;
@@ -399,9 +403,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     [self addButtonToAlertViewForAction:action];
   }
   // Explicitly overwrite the view default if true
+<<<<<<< HEAD
   // We set this last to make sure all other properties are set first and no overriden by setting
   // this.
   if (self.mdc_adjustsFontForContentSizeCategory) {
+=======
+  if (_mdc_adjustsFontForContentSizeCategory) {
+>>>>>>> Fix broken test
     self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
   }
 }

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -234,16 +234,15 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 }
 
 - (void)updateMessageFont {
-  UIFont *messageFont = _messageFont ?: [[self class] messageFontDefault];
+  UIFont *messageFont = self.messageFont ?: [[self class] messageFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      self.messageLabel.font = [messageFont
+      messageFont = [messageFont
           mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
                        scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
-  } else {
-    _messageLabel.font = messageFont;
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 
@@ -253,6 +252,10 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   self.messageLabel.font = messageFont;
 =======
 >>>>>>> Revert last commit
+=======
+  
+  self.messageLabel.font = messageFont;
+>>>>>>> Imp
   [self setNeedsLayout];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -628,8 +628,10 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateFonts];
 }
 
-- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
+    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   [self updateFonts];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -234,20 +234,25 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 }
 
 - (void)updateMessageFont {
-  UIFont *messageFont = self.messageFont ?: [[self class] messageFontDefault];
+  UIFont *messageFont = _messageFont ?: [[self class] messageFontDefault];
   if (self.mdc_adjustsFontForContentSizeCategory) {
     if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
-      messageFont = [messageFont
+      self.messageLabel.font = [messageFont
           mdc_fontSizedForMaterialTextStyle:kMessageTextStyle
                        scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
+  } else {
+    _messageLabel.font = messageFont;
   }
+<<<<<<< HEAD
 <<<<<<< HEAD
 
 =======
   
 >>>>>>> Implementation
   self.messageLabel.font = messageFont;
+=======
+>>>>>>> Revert last commit
   [self setNeedsLayout];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -628,13 +628,6 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateFonts];
 }
 
-- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
-    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
-      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-  [self updateFonts];
-}
-
 // Update the fonts used based on whether Dynamic Type is enabled
 - (void)updateFonts {
   [self updateTitleFont];

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -242,7 +242,11 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
                        scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
   }
+<<<<<<< HEAD
 
+=======
+  
+>>>>>>> Implementation
   self.messageLabel.font = messageFont;
   [self setNeedsLayout];
 }

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -628,6 +628,11 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
   [self updateFonts];
 }
 
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:(BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+  [self updateFonts];
+}
+
 // Update the fonts used based on whether Dynamic Type is enabled
 - (void)updateFonts {
   [self updateTitleFont];

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -123,7 +123,6 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
 
 - (void)addActionButton:(nonnull MDCButton *)button {
   if (button.superview == nil) {
-    button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
     [self.actionsScrollView addSubview:button];
     if (_buttonColor) {
       // We only set if _buttonColor since settingTitleColor to nil doesn't
@@ -132,6 +131,9 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
     }
     [button setTitleFont:_buttonFont forState:UIControlStateNormal];
     button.inkColor = self.buttonInkColor;
+    button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+        self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+    button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;
     // TODO(#1726): Determine default text color values for Normal and Disabled
     CGRect buttonRect = button.bounds;
     buttonRect.size.height = MAX(buttonRect.size.height, MDCDialogActionButtonMinimumHeight);
@@ -242,20 +244,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
                        scaledForDynamicType:self.mdc_adjustsFontForContentSizeCategory];
     }
   }
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
-  
->>>>>>> Implementation
   self.messageLabel.font = messageFont;
-=======
->>>>>>> Revert last commit
-=======
-  
-  self.messageLabel.font = messageFont;
->>>>>>> Imp
   [self setNeedsLayout];
 }
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -131,6 +131,8 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
     }
     [button setTitleFont:_buttonFont forState:UIControlStateNormal];
     button.inkColor = self.buttonInkColor;
+    // These two lines must be after @c setTitleFont:forState: in order to @c MDCButton to handle
+    // dynamic type correctly.
     button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
         self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
     button.mdc_adjustsFontForContentSizeCategory = self.mdc_adjustsFontForContentSizeCategory;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -20,6 +20,7 @@
 
 #import "../../src/private/MDCDialogShadowedView.h"
 #import "MDCAlertControllerView+Private.h"
+#import "MDCAlertController+ButtonForAction.h"
 
 #pragma mark - Subclasses for testing
 
@@ -332,85 +333,29 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
-<<<<<<< HEAD
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-<<<<<<< HEAD
-
-  // When
-  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-  // Then
-=======
->>>>>>> Add tests
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-=======
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-
-  // Then
->>>>>>> Test title font
-=======
-
-  // Then
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
->>>>>>> clang
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
-                view.titleLabel.font, fakeTitleFont);
-}
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Revert setter for adjust...whenUnavailable
-- (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
-=======
-/**
- Test legacy dynamic type has no impact on a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
- mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
- */
-- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
->>>>>>> Test title font
-=======
-=======
->>>>>>> Revert setter for adjust...whenUnavailable
-- (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
->>>>>>> Update test names and delete comments
-  // Given
-  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
-  self.alert.titleFont = fakeTitleFont;
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-<<<<<<< HEAD
->>>>>>> Test title font
-=======
->>>>>>> Test title font
-=======
-  //MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
->>>>>>> Fix broken test
-=======
->>>>>>> Fix issue and improve test
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> clang'
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
   XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
                 @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
+  MDCButton *button = [self.alert buttonForAction:fakeAction];
+  XCTAssertTrue([[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
+                @"%@ is not equal to %@", [button titleFontForState:UIControlStateNormal],
+                fakeButtonFont);
 }
 
 - (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
@@ -419,102 +364,28 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-<<<<<<< HEAD
-=======
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
-=======
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
->>>>>>> Add tests
-=======
-=======
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
->>>>>>> Fix issue and improve test
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
->>>>>>> clean up test
-=======
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
->>>>>>> clean up test
-                view.titleLabel.font, fakeTitleFont);
-  XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
-}
-
-- (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
-  // Given
-  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
-  self.alert.titleFont = fakeTitleFont;
-<<<<<<< HEAD
-  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
-  self.alert.messageFont = fakeMessageFont;
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-<<<<<<< HEAD
->>>>>>> Test title font
-=======
->>>>>>> Fix issue and improve test
-  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-=======
->>>>>>> Add tests
-=======
-  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
-                view.titleLabel.font, fakeTitleFont);
-}
-
-- (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
-  // Given
-  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
-  self.alert.titleFont = fakeTitleFont;
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
-  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
->>>>>>> Test title font
-=======
->>>>>>> Fix broken test
-
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
+                                                       handler:^(MDCAlertAction *action){
+                                                       }];
+  [self.alert addAction:fakeAction];
+  UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
+  self.alert.buttonFont = fakeButtonFont;
+  
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
-
+  
   // Then
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Fix broken test
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
   XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@",
                  view.messageLabel.font, fakeMessageFont);
-=======
-  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
-<<<<<<< HEAD
-                view.titleLabel.font, fakeTitleFont);
->>>>>>> Test title font
-=======
-                 view.titleLabel.font, fakeTitleFont);
->>>>>>> clang
-=======
-=======
->>>>>>> clean up test
-  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
-                 view.titleLabel.font, fakeTitleFont);
-    XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@", view.messageLabel.font, fakeMessageFont);
->>>>>>> Add tests
-=======
-  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
-<<<<<<< HEAD
-                view.titleLabel.font, fakeTitleFont);
->>>>>>> Test title font
-=======
-=======
-=======
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
->>>>>>> Fix issue and improve test
-  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
->>>>>>> clean up test
-                 view.titleLabel.font, fakeTitleFont);
->>>>>>> clang
+  MDCButton *button = [self.alert buttonForAction:fakeAction];
+  XCTAssertFalse([[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
+                 @"%@ is equal to %@", [button titleFontForState:UIControlStateNormal],
+                 fakeButtonFont);
 }
+
+
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -328,41 +328,12 @@
   XCTAssertFalse(self.alert.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-<<<<<<< HEAD
-=======
-=======
->>>>>>> Test title font
-/**
- Test legacy dynamic type has no impact on a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO that the font stays
- the same.
- */
-- (void)testLegacyDynamicTypeDisabled {
-<<<<<<< HEAD
-=======
-- (void)testDynamicTypeEnabledThenLegacyDynamicTypeDisabledDoesNotUpdateFonts {
->>>>>>> Update test names and delete comments
-=======
->>>>>>> Test title font
-=======
-- (void)testDynamicTypeEnabledThenLegacyDynamicTypeDisabledDoesNotUpdateFonts {
->>>>>>> Update test names and delete comments
-  // Given
-  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
-  self.alert.titleFont = fakeTitleFont;
-  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -331,6 +331,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -339,15 +340,20 @@
   self.alert.messageFont = fakeMessageFont;
 <<<<<<< HEAD
 =======
+=======
+>>>>>>> Test title font
 /**
  Test legacy dynamic type has no impact on a @c MDCButton when @c
  adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO that the font stays
  the same.
  */
 - (void)testLegacyDynamicTypeDisabled {
+<<<<<<< HEAD
 =======
 - (void)testDynamicTypeEnabledThenLegacyDynamicTypeDisabledDoesNotUpdateFonts {
 >>>>>>> Update test names and delete comments
+=======
+>>>>>>> Test title font
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -355,22 +361,40 @@
 
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
+<<<<<<< HEAD
 
   // Then
 =======
 >>>>>>> Add tests
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+=======
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+
+  // Then
+>>>>>>> Test title font
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
 }
 
+<<<<<<< HEAD
 =======
 >>>>>>> Revert setter for adjust...whenUnavailable
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
+=======
+/**
+ Test legacy dynamic type has no impact on a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
+ mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
+ */
+- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
+>>>>>>> Test title font
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+<<<<<<< HEAD
+>>>>>>> Test title font
+=======
 >>>>>>> Test title font
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
@@ -378,6 +402,7 @@
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -421,11 +446,28 @@
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 =======
 >>>>>>> Add tests
+=======
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+                view.titleLabel.font, fakeTitleFont);
+}
+
+/**
+ Test legacy dynamic type impacts a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
+ */
+- (void)testLegacyDynamicTypeEnabled {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+>>>>>>> Test title font
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -449,6 +491,10 @@
                  view.titleLabel.font, fakeTitleFont);
     XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@", view.messageLabel.font, fakeMessageFont);
 >>>>>>> Add tests
+=======
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
+                view.titleLabel.font, fakeTitleFont);
+>>>>>>> Test title font
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -21,7 +21,6 @@
 #import "../../src/private/MDCDialogShadowedView.h"
 #import "MDCAlertController+ButtonForAction.h"
 #import "MDCAlertControllerView+Private.h"
-#import "MDCAlertController+ButtonForAction.h"
 
 #pragma mark - Subclasses for testing
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -334,6 +334,7 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
+<<<<<<< HEAD
 
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
@@ -384,6 +385,9 @@
 >>>>>>> Test title font
 =======
 >>>>>>> Test title font
+=======
+  //MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> Fix broken test
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
@@ -411,6 +415,7 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
+<<<<<<< HEAD
 =======
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
 =======
@@ -450,6 +455,8 @@
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 >>>>>>> Test title font
+=======
+>>>>>>> Fix broken test
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
@@ -460,6 +467,9 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Fix broken test
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -337,6 +337,7 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
+<<<<<<< HEAD
 =======
 /**
  Test legacy dynamic type has no impact on a @c MDCButton when @c
@@ -356,6 +357,8 @@
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // Then
+=======
+>>>>>>> Add tests
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
@@ -376,6 +379,7 @@
 
   // Then
 <<<<<<< HEAD
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
@@ -391,21 +395,31 @@
   self.alert.messageFont = fakeMessageFont;
 =======
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+=======
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
+>>>>>>> Add tests
                 view.titleLabel.font, fakeTitleFont);
+  XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
 }
 
 - (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+  UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
+  self.alert.messageFont = fakeMessageFont;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+<<<<<<< HEAD
 >>>>>>> Test title font
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+=======
+>>>>>>> Add tests
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
 <<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
@@ -420,6 +434,11 @@
 =======
                  view.titleLabel.font, fakeTitleFont);
 >>>>>>> clang
+=======
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
+                 view.titleLabel.font, fakeTitleFont);
+    XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@", view.messageLabel.font, fakeMessageFont);
+>>>>>>> Add tests
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -349,9 +349,9 @@
 
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
-  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
 
   // Then
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
 }
@@ -416,8 +416,12 @@
                  view.messageLabel.font, fakeMessageFont);
 =======
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
+<<<<<<< HEAD
                 view.titleLabel.font, fakeTitleFont);
 >>>>>>> Test title font
+=======
+                 view.titleLabel.font, fakeTitleFont);
+>>>>>>> clang
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -381,6 +381,9 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> clang'
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -380,6 +380,7 @@
   // Then
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
@@ -398,6 +399,9 @@
 =======
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
 >>>>>>> Add tests
+=======
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
+>>>>>>> clean up test
                 view.titleLabel.font, fakeTitleFont);
   XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
 }
@@ -421,6 +425,7 @@
   // Then
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
@@ -435,6 +440,8 @@
                  view.titleLabel.font, fakeTitleFont);
 >>>>>>> clang
 =======
+=======
+>>>>>>> clean up test
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
     XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@", view.messageLabel.font, fakeMessageFont);

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -424,6 +424,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> clang'
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
@@ -444,6 +445,9 @@
 =======
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
 >>>>>>> Add tests
+=======
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
+>>>>>>> clean up test
 =======
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
 >>>>>>> clean up test
@@ -484,6 +488,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
@@ -510,6 +515,9 @@
                 view.titleLabel.font, fakeTitleFont);
 >>>>>>> Test title font
 =======
+=======
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
+>>>>>>> clean up test
                  view.titleLabel.font, fakeTitleFont);
 >>>>>>> clang
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -362,6 +362,7 @@
   // When
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 <<<<<<< HEAD
+<<<<<<< HEAD
 
   // Then
 =======
@@ -372,6 +373,11 @@
 
   // Then
 >>>>>>> Test title font
+=======
+
+  // Then
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> clang
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
 }
@@ -493,8 +499,12 @@
 >>>>>>> Add tests
 =======
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
+<<<<<<< HEAD
                 view.titleLabel.font, fakeTitleFont);
 >>>>>>> Test title font
+=======
+                 view.titleLabel.font, fakeTitleFont);
+>>>>>>> clang
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -328,18 +328,52 @@
   XCTAssertFalse(self.alert.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
 
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
+=======
+/**
+ Test legacy dynamic type has no impact on a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO that the font stays
+ the same.
+ */
+- (void)testLegacyDynamicTypeDisabled {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  self.alert.mdc_adjustsFontForContentSizeCategory = YES;
+
+  // When
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+
+  // Then
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+                view.titleLabel.font, fakeTitleFont);
+}
+
+/**
+ Test legacy dynamic type has no impact on a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
+ mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
+ */
+- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> Test title font
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
                 view.titleLabel.font, fakeTitleFont);
@@ -353,17 +387,37 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
+=======
+  XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is not equal to %@",
+                view.titleLabel.font, fakeTitleFont);
+}
+
+/**
+ Test legacy dynamic type impacts a @c MDCButton when @c
+ adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
+ */
+- (void)testLegacyDynamicTypeEnabled {
+  // Given
+  UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
+  self.alert.titleFont = fakeTitleFont;
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> Test title font
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
                  view.titleLabel.font, fakeTitleFont);
   XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@",
                  view.messageLabel.font, fakeMessageFont);
+=======
+  XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@, is equal to %@",
+                view.titleLabel.font, fakeTitleFont);
+>>>>>>> Test title font
 }
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -329,6 +329,7 @@
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -342,6 +343,9 @@
  the same.
  */
 - (void)testLegacyDynamicTypeDisabled {
+=======
+- (void)testDynamicTypeEnabledThenLegacyDynamicTypeDisabledDoesNotUpdateFonts {
+>>>>>>> Update test names and delete comments
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -356,12 +360,7 @@
                 view.titleLabel.font, fakeTitleFont);
 }
 
-/**
- Test legacy dynamic type has no impact on a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c NO before setting @c
- mdc_adjustsFontForContentSizeCategory to @c YES that the font stays the same.
- */
-- (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
+- (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -392,11 +391,7 @@
                 view.titleLabel.font, fakeTitleFont);
 }
 
-/**
- Test legacy dynamic type impacts a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
- */
-- (void)testLegacyDynamicTypeEnabled {
+- (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -333,6 +333,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -400,6 +401,8 @@
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
 >>>>>>> Test title font
 =======
+=======
+>>>>>>> Revert setter for adjust...whenUnavailable
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
 >>>>>>> Update test names and delete comments
   // Given

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -330,6 +330,7 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -360,6 +361,8 @@
                 view.titleLabel.font, fakeTitleFont);
 }
 
+=======
+>>>>>>> Revert setter for adjust...whenUnavailable
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -371,10 +371,11 @@
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;
+  self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
-  
+
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
@@ -386,7 +387,5 @@
                  @"%@ is equal to %@", [button titleFontForState:UIControlStateNormal],
                  fakeButtonFont);
 }
-
-
 
 @end

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -332,6 +332,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
@@ -354,6 +355,9 @@
 >>>>>>> Update test names and delete comments
 =======
 >>>>>>> Test title font
+=======
+- (void)testDynamicTypeEnabledThenLegacyDynamicTypeDisabledDoesNotUpdateFonts {
+>>>>>>> Update test names and delete comments
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -383,6 +387,7 @@
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> Revert setter for adjust...whenUnavailable
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
@@ -394,6 +399,9 @@
  */
 - (void)testLegacyDynamicTypeDisabledThenDynamicTypeTurnedOn {
 >>>>>>> Test title font
+=======
+- (void)testLegacyDynamicTypeDisabledThenDynamicTypeEnabledDoesNotUpdateFonts {
+>>>>>>> Update test names and delete comments
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
@@ -457,11 +465,7 @@
                 view.titleLabel.font, fakeTitleFont);
 }
 
-/**
- Test legacy dynamic type impacts a @c MDCButton when @c
- adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable is set to @c YES that the font changes.
- */
-- (void)testLegacyDynamicTypeEnabled {
+- (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -19,6 +19,7 @@
 #import "MaterialTypography.h"
 
 #import "../../src/private/MDCDialogShadowedView.h"
+#import "MDCAlertController+ButtonForAction.h"
 #import "MDCAlertControllerView+Private.h"
 #import "MDCAlertController+ButtonForAction.h"
 
@@ -370,7 +371,7 @@
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
   self.alert.buttonFont = fakeButtonFont;
-  
+
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
   

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -332,6 +332,7 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+<<<<<<< HEAD
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
 <<<<<<< HEAD
@@ -388,12 +389,15 @@
 =======
   //MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
 >>>>>>> Fix broken test
+=======
+>>>>>>> Fix issue and improve test
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -422,6 +426,9 @@
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
 >>>>>>> Add tests
 =======
+=======
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> Fix issue and improve test
   XCTAssertTrue([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is not equal to %@",
 >>>>>>> clean up test
 =======
@@ -435,11 +442,14 @@
   // Given
   UIFont *fakeTitleFont = [UIFont systemFontOfSize:55];
   self.alert.titleFont = fakeTitleFont;
+<<<<<<< HEAD
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
 <<<<<<< HEAD
 >>>>>>> Test title font
+=======
+>>>>>>> Fix issue and improve test
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 =======
 >>>>>>> Add tests
@@ -462,6 +472,7 @@
   self.alert.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Then
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -497,6 +508,9 @@
 >>>>>>> Test title font
 =======
 =======
+=======
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+>>>>>>> Fix issue and improve test
   XCTAssertFalse([view.titleLabel.font mdc_isSimplyEqual:fakeTitleFont], @"%@ is equal to %@",
 >>>>>>> clean up test
                  view.titleLabel.font, fakeTitleFont);


### PR DESCRIPTION
This changes adds test for legacy dynamic type, mainly focused on the behavior around `adjustFontForContentSizeCategoryWhenScaledFontIsUnavailable` and `mdc_adjustFontForContentSizeCategory` with respect to the `buttonFont` property. 

Related to #7464