### PR TITLE
[Tabs] Provide a way for subclasses of MDCTabBar to override the trait collection.

### DIFF
--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -445,6 +445,12 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(
 
 #pragma mark - Private
 
+// This method may be overriden by subclasses that wish to return a different size
+// class to be used by MDCItemBar.
++ (UIUserInterfaceSizeClass)horizontalSizeClassForObject:(id<UITraitEnvironment>)object {
+  return object.traitCollection.horizontalSizeClass;
+}
+
 + (MDCItemBarStyle *)defaultStyleForPosition:(UIBarPosition)position
                               itemAppearance:(MDCTabBarItemAppearance)appearance {
   MDCItemBarStyle *style = [[MDCItemBarStyle alloc] init];

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -18,6 +18,7 @@
 
 #import "MDCItemBarCell.h"
 #import "MDCItemBarStyle.h"
+#import "MDCTabBar.h"
 #import "MDCTabBarIndicatorAttributes.h"
 #import "MDCTabBarIndicatorTemplate.h"
 #import "MDCTabBarIndicatorView.h"
@@ -56,6 +57,14 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 @end
 
 #pragma mark -
+
+// This class extension simply exposes a private method of MDCTabBar that is needed by
+// MDCItemBar. The method should be checked with `respondsToSelector:` before calling it
+// to ensure safety, and in the case that `respondsToSelector:` returns NO, a fallback
+// value must be used instead.
+@interface MDCTabBar ()
++ (UIUserInterfaceSizeClass)horizontalSizeClassForObject:(id<UITraitEnvironment>)object;
+@end
 
 @interface MDCItemBar () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout>
 @end
@@ -489,6 +498,12 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (UIUserInterfaceSizeClass)horizontalSizeClass {
+  // Return the size class from the MDCTabBar method, since it may be overriden by
+  // custom subclasses to return a custom size classes.
+  Class superviewClass = [self.superview class];
+  if ([superviewClass respondsToSelector:@selector(horizontalSizeClassForObject:)]) {
+    return [superviewClass horizontalSizeClassForObject:self];
+  }
   return self.traitCollection.horizontalSizeClass;
 }
 


### PR DESCRIPTION
This causes an awkward dependency between MDCItemBar -> MDCTabBar, but
it's my understanding that the long-term goal is to redesign MDCTabBar
to not use this subclass.

Basically this CL adds a helper class method in MDCTabBar (which may be overriden by
its subclasses) to return the size class for a given object (the
MDCItemBar instance). By default, this just returns the item bar's
sizeClass (as before). However subclasses may override this to return
custom sizeClass values as a way to circumvent the hardcoded dependency
on UITraitCollection's horizontalSizeClass.

I wrote this code in a way that none of the interfaces were changed,
such that this code can be dropped as the code of MDCTabBar/MDCItemBar
is refactored, while still allowing clients of this code to have an
avenue to avoid bugs caused in projects that do not yet adopt
UITraitCollection.
