### PR TITLE
[MaskedTransition] Fix infinite loops in masked transition example

### DIFF
--- a/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
+++ b/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift
@@ -57,7 +57,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     view.addSubview(leftFAB)
 
     targets.append(.init(name: "Bottom sheet", viewControllerType: ModalViewController.self, calculateFrame: { info in
-      let containerBounds = info.frameOfPresentedViewInContainerView
+      guard let containerBounds = info.containerView?.bounds else { return .zero }
       let size = CGSize(width: containerBounds.width, height: 300)
       return CGRect(x: containerBounds.minX,
                     y: containerBounds.height - size.height,
@@ -66,7 +66,7 @@ open class MaskedTransitionTypicalUseSwiftExample: UIViewController {
     }, autoresizingMask: [.flexibleWidth, .flexibleTopMargin], useSafeAreaInsets: true))
 
     targets.append(.init(name: "Centered card", viewControllerType: ModalViewController.self, calculateFrame: { info in
-      let containerBounds = info.frameOfPresentedViewInContainerView
+      guard let containerBounds = info.containerView?.bounds else { return .zero }
       let size = CGSize(width: 200, height: 200)
       return CGRect(x: (containerBounds.width - size.width) / 2,
                     y: (containerBounds.height - size.height) / 2,

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -63,7 +63,8 @@
  `UIModalPresentationCustom` in order to use this property.
 
  Avoid calling -frameOfPresentedViewInContainerView on the UIPresentationController parameter of
- this block, because this block is called from an overriden implementation of that method that passes self in as a parameter, and doing this can result in an infinite loop.
+ this block, because this block is called from an overriden implementation of that method that
+ passes self in as a parameter, and doing this can result in an infinite loop.
  */
 @property(nonatomic, copy, nullable) CGRect (^calculateFrameOfPresentedView)
     (UIPresentationController *_Nonnull);

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -61,8 +61,10 @@
 
  You must set the view controller-to-be-presented's modalPresentationStyle property to
  `UIModalPresentationCustom` in order to use this property.
+
+ Avoid calling -frameOfPresentedViewInContainerView on the UIPresentationController parameter of
+ this block, because this block is called from an overriden implementation of that method that passes self in as a parameter, and doing this can result in an infinite loop.
  */
 @property(nonatomic, copy, nullable) CGRect (^calculateFrameOfPresentedView)
     (UIPresentationController *_Nonnull);
-
 @end


### PR DESCRIPTION
I noticed some crashes in the masked transition example while conducting a FAB accessibility audit. 

@romoore was able to reproduce the crash using iPhone 7/iOS 11.2:

1. Open "Masked Transition (Swift)"
2. Select "Centered Card"
3. Activate (tap) the left Floating Action Button.

```
Thread 1 Queue : com.apple.main-thread (serial)
#0	0x000000010a0db3ff in objc::DenseMapBase<objc::DenseMap<DisguisedPtr<objc_object>, unsigned long, true, objc::DenseMapInfo<DisguisedPtr<objc_object> > >, DisguisedPtr<objc_object>, unsigned long, objc::DenseMapInfo<DisguisedPtr<objc_object> >, true>::FindAndConstruct(DisguisedPtr<objc_object> const&) ()
#1	0x000000010a0d977a in objc_object::sidetable_retain() ()
#2	0x0000000109375a7e in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#3	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#4	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#5	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#6	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#7	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#8	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#9	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#10	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#11	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#12	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#13	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#14	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#15	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#16	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#17	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#18	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#19	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#20	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#21	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
#22	0x00000001093734e8 in closure #2 in MaskedTransitionTypicalUseSwiftExample.viewDidLoad() at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/examples/MaskedTransitionTypicalUse.swift:69
#23	0x0000000109375a90 in thunk for @escaping @callee_guaranteed (@guaranteed UIPresentationController) -> (@unowned CGRect) ()
#24	0x0000000108ebec01 in -[MDCMaskedPresentationController frameOfPresentedViewInContainerView] at /Users/rsmoore/git/material-components-ios/components/MaskedTransition/src/private/MDCMaskedPresentationController.m:51
```

This small PR fixes the crash.

Closes #7520