### PR TITLE
[BottomNavigation] Add a titles-only example.

### DIFF
--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -168,6 +168,7 @@ swift_library(
         ":TypographyThemer",
         "//components/AppBar",
         "//components/Buttons",
+        "//components/schemes/Container",
         "//components/Palettes",
     ],
 )

--- a/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
@@ -1,4 +1,4 @@
-// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
@@ -14,11 +14,11 @@
 
 import Foundation
 import MaterialComponents.MaterialBottomNavigation_ColorThemer
-import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialContainerScheme
 
 class BottomNavigationTitlesOnlySwiftExample: UIViewController {
 
-  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var containerScheme = MDCContainerScheme()
 
   // Create a bottom navigation bar to add to a view.
   let bottomNavBar = MDCBottomNavigationBar()
@@ -27,7 +27,7 @@ class BottomNavigationTitlesOnlySwiftExample: UIViewController {
     super.viewDidLoad()
 
     bottomNavBar.sizeThatFitsIncludesSafeArea = false
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
     // Always show bottom navigation bar item titles.

--- a/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitlesOnlyExample.swift
@@ -1,0 +1,80 @@
+// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MaterialComponents.MaterialBottomNavigation_ColorThemer
+import MaterialComponents.MaterialColorScheme
+
+class BottomNavigationTitlesOnlySwiftExample: UIViewController {
+
+  @objc var colorScheme = MDCSemanticColorScheme()
+
+  // Create a bottom navigation bar to add to a view.
+  let bottomNavBar = MDCBottomNavigationBar()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    bottomNavBar.sizeThatFitsIncludesSafeArea = false
+    view.backgroundColor = colorScheme.backgroundColor
+    view.addSubview(bottomNavBar)
+
+    // Always show bottom navigation bar item titles.
+    bottomNavBar.titleVisibility = .always
+
+    // Cluster and center the bottom navigation bar items.
+    bottomNavBar.alignment = .centered
+
+    // Add items to the bottom navigation bar.
+    let tabBarItem1 = UITabBarItem(title: "Home", image: nil, tag: 0)
+    let tabBarItem2 =
+      UITabBarItem(title: "Messages", image: nil, tag: 1)
+    let tabBarItem3 =
+      UITabBarItem(title: "Favorites", image: nil, tag: 2)
+    bottomNavBar.items = [ tabBarItem1, tabBarItem2, tabBarItem3 ]
+
+    // Select a bottom navigation bar item.
+    bottomNavBar.selectedItem = tabBarItem2;
+  }
+  
+  func layoutBottomNavBar() {
+    let size = bottomNavBar.sizeThatFits(view.bounds.size)
+    var bottomNavBarFrame = CGRect(x: 0,
+                                   y: view.bounds.height - size.height,
+                                   width: size.width,
+                                   height: size.height)
+    if #available(iOS 11.0, *) {
+      bottomNavBarFrame.size.height += view.safeAreaInsets.bottom
+      bottomNavBarFrame.origin.y -= view.safeAreaInsets.bottom
+    }
+    bottomNavBar.frame = bottomNavBarFrame
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    layoutBottomNavBar()
+  }
+}
+
+// MARK: Catalog by convention
+extension BottomNavigationTitlesOnlySwiftExample {
+
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Navigation", "Titles only"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}


### PR DESCRIPTION
This example is a Dragon. This example is in service to testing accessibility of this component.

<img width="658" alt="Screen Shot 2019-06-03 at 9 02 54 AM" src="https://user-images.githubusercontent.com/45670/58804272-77770200-85df-11e9-9d63-7f0ebdc432d9.png">
