### PR TITLE
[List] Fix self sizing layout in iOS 13

### DIFF
--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -142,6 +142,12 @@ static const CGFloat kDetailColorOpacity = (CGFloat)0.6;
   [super setNeedsLayout];
 }
 
+-(UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes {
+  UICollectionViewLayoutAttributes *attributes = [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
+  attributes.size = [self systemLayoutSizeFittingSize:layoutAttributes.size];
+  return attributes;
+}
+
 - (CGSize)systemLayoutSizeFittingSize:(CGSize)targetSize {
   MDCSelfSizingStereoCellLayout *layout = [self layoutForCellWidth:targetSize.width];
   return CGSizeMake(targetSize.width, layout.calculatedHeight);

--- a/components/List/src/MDCSelfSizingStereoCell.m
+++ b/components/List/src/MDCSelfSizingStereoCell.m
@@ -142,8 +142,10 @@ static const CGFloat kDetailColorOpacity = (CGFloat)0.6;
   [super setNeedsLayout];
 }
 
--(UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:(UICollectionViewLayoutAttributes *)layoutAttributes {
-  UICollectionViewLayoutAttributes *attributes = [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
+- (UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:
+    (UICollectionViewLayoutAttributes *)layoutAttributes {
+  UICollectionViewLayoutAttributes *attributes =
+      [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
   attributes.size = [self systemLayoutSizeFittingSize:layoutAttributes.size];
   return attributes;
 }

--- a/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
+++ b/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
@@ -164,16 +164,14 @@
   cell.detailLabel.text = oneLineString;
   UICollectionViewLayoutAttributes *attributes = [[UICollectionViewLayoutAttributes alloc] init];
   attributes.size = estimatedCellSize;
-  attributes =
-      [cell preferredLayoutAttributesFittingAttributes:attributes];
+  attributes = [cell preferredLayoutAttributesFittingAttributes:attributes];
   CGSize initialAttributeSize = attributes.size;
 
   // When
   cell.titleLabel.text = twoLineString;
   cell.detailLabel.text = twoLineString;
   [cell setNeedsLayout];
-  attributes =
-      [cell preferredLayoutAttributesFittingAttributes:attributes];
+  attributes = [cell preferredLayoutAttributesFittingAttributes:attributes];
 
   // Then
   XCTAssert(attributes.size.height > initialAttributeSize.height);

--- a/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
+++ b/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
@@ -153,4 +153,30 @@
   XCTAssertTrue([cell.detailLabel.font mdc_isSimplyEqual:originalDetailFont]);
 }
 
+- (void)testSizingWithPreferredLayoutAttributesFittingAttributes {
+  // Given
+  NSString *oneLineString = @"Text spanning one line";
+  NSString *twoLineString = @"Text spanning\ntwo lines";
+  CGSize estimatedCellSize = CGSizeMake(100, 40);
+  CGRect initialCellFrame = CGRectMake(0, 0, estimatedCellSize.width, estimatedCellSize.height);
+  MDCSelfSizingStereoCell *cell = [[MDCSelfSizingStereoCell alloc] initWithFrame:initialCellFrame];
+  cell.titleLabel.text = oneLineString;
+  cell.detailLabel.text = oneLineString;
+  UICollectionViewLayoutAttributes *attributes = [[UICollectionViewLayoutAttributes alloc] init];
+  attributes.size = estimatedCellSize;
+  attributes =
+      [cell preferredLayoutAttributesFittingAttributes:attributes];
+  CGSize initialAttributeSize = attributes.size;
+
+  // When
+  cell.titleLabel.text = twoLineString;
+  cell.detailLabel.text = twoLineString;
+  [cell setNeedsLayout];
+  attributes =
+      [cell preferredLayoutAttributesFittingAttributes:attributes];
+
+  // Then
+  XCTAssert(attributes.size.height > initialAttributeSize.height);
+}
+
 @end


### PR DESCRIPTION
List cell self sizing wasn't working in iOS 13. This PR fixes it.

Here's an iOS 13 before photo:
![Simulator Screen Shot - iPhone Xʀ - 2019-06-04 at 10 20 50](https://user-images.githubusercontent.com/8020010/58887161-1a4c8080-86b3-11e9-960d-f5f73be17349.png)

Here's an iOS 13 after photo:
![Simulator Screen Shot - iPhone Xʀ - 2019-06-04 at 10 21 27](https://user-images.githubusercontent.com/8020010/58887160-1a4c8080-86b3-11e9-8399-991551b794af.png)

Here's an iOS 11 after photo:
![Simulator Screen Shot - iPhone 8 - 2019-06-04 at 10 25 35](https://user-images.githubusercontent.com/8020010/58887159-1a4c8080-86b3-11e9-80f6-6b23a0a7961c.png)

Closes #7533.
