### PR TITLE
[Buttons] Add support for `inkMaxRippleRadius` when `enableRippleBehavior` is set to YES

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -539,12 +539,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self.rippleView setRippleColor:inkColor forState:MDCRippleStateHighlighted];
 }
 
-- (CGFloat)inkMaxRippleRadius {
-  return _inkView.maxRippleRadius;
-}
-
 - (void)setInkMaxRippleRadius:(CGFloat)inkMaxRippleRadius {
+  _inkMaxRippleRadius = inkMaxRippleRadius;
   _inkView.maxRippleRadius = inkMaxRippleRadius;
+  self.rippleView.maximumRadius = inkMaxRippleRadius;
 }
 
 - (void)setEnableRippleBehavior:(BOOL)enableRippleBehavior {

--- a/components/Buttons/tests/unit/ButtonRippleTests.m
+++ b/components/Buttons/tests/unit/ButtonRippleTests.m
@@ -125,6 +125,17 @@
   XCTAssertEqual(self.button.rippleView.rippleStyle, MDCRippleStyleBounded);
 }
 
+- (void)testSetInkMaxRippleRadiusSetsRippleViewMaximumRadius {
+  // Given
+  CGFloat fakeRadius = 10;
+
+  // When
+  self.button.inkMaxRippleRadius = fakeRadius;
+
+  // Then
+  XCTAssertEqual(self.button.rippleView.maximumRadius, fakeRadius);
+}
+
 #pragma mark - Touch tests
 
 - (void)testSettingHighlightedUpdatesRippleTheming {


### PR DESCRIPTION
This changes adds support for `inkMaxRippleRadius` when `enableRippleBehavior` is set to `YES`. This was previously not added because Ripple didn't support `maximumRadius` when it was integrated in `Buttons` in #7087. Since `maximumRadius` was added in #7357 this should now be set in Buttons. The getter was removed from Buttons since this is currently setting two properties and then returning one. When we remove ink this could potentially cause a problem if we didn't update the getter. By setting an ivar this should help protect us against our future selfs when ink is removed. 