### PR TITLE
[schemes/Typography] Fix issue within the docs

### DIFF
--- a/components/schemes/Typography/README.md
+++ b/components/schemes/Typography/README.md
@@ -37,7 +37,6 @@ font or button font.
   - [Importing](#importing)
 - [Usage](#usage)
   - [Dynamic Type](#dynamic-type)
-- [Extensions](#extensions)
 
 - - -
 
@@ -115,9 +114,3 @@ Users configure text styles on fonts, such as caption and overline, included in 
 
 `useCurrentContentSizeCategoryWhenApplied` is a property on MDCTypographyScheme. This property only has an effect if the fonts stored on the typography scheme are scalable. It indicates whether the scalable font on the scheme should be adjusted with respect to the current content size category when it is applied on a component.
 
-
-## Extensions
-
-<!-- Template: Extensions should be called out separately from Usage docs.
-
--->

--- a/components/schemes/Typography/README.md
+++ b/components/schemes/Typography/README.md
@@ -8,7 +8,7 @@ path: /catalog/theming/typography/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme schemes/Typography -->
+<!-- This file was auto-generated using ./scripts/generate_readme schemes/Typography -->
 
 # Typography Scheme
 
@@ -107,18 +107,17 @@ import MaterialComponents.MaterialTypographyScheme
 
 ### Dynamic Type
 
- #### Overview
- Users configure text styles on fonts, such as caption and overline, included in a typography scheme. Then, these scalable fonts can be used for [Dynamic Type](../../Typography) for components. Some default versions of MDCTypographyScheme include scalable fonts. The inline documentation indicates whether a default version of MDCTypographyScheme consists of scalable fonts or not.
- 
- #### useCurrentContentSizeCategoryWhenApplied
- `useCurrentContentSizeCategoryWhenApplied` is a property on MDCTypographyScheme. This property only has an effect if the fonts stored on the typography scheme are scalable. It indicates whether the scalable font on the scheme should be adjusted with respect to the current content size category when it is applied on a component.
+#### Overview
+
+Users configure text styles on fonts, such as caption and overline, included in a typography scheme. Then, these scalable fonts can be used for [Dynamic Type](../../Typography) for components. Some default versions of MDCTypographyScheme include scalable fonts. The inline documentation indicates whether a default version of MDCTypographyScheme consists of scalable fonts or not.
+
+#### useCurrentContentSizeCategoryWhenApplied
+
+`useCurrentContentSizeCategoryWhenApplied` is a property on MDCTypographyScheme. This property only has an effect if the fonts stored on the typography scheme are scalable. It indicates whether the scalable font on the scheme should be adjusted with respect to the current content size category when it is applied on a component.
 
 
 ## Extensions
 
 <!-- Template: Extensions should be called out separately from Usage docs.
-
-<!-- Extracted from docs/typography-theming.md -->
-
 
 -->

--- a/components/schemes/Typography/docs/README.md
+++ b/components/schemes/Typography/docs/README.md
@@ -79,9 +79,3 @@ import MaterialComponents.MaterialTypographyScheme
 ## Usage
 
 - [Dynamic Type](dynamic-type.md)
-
-## Extensions
-
-<!-- Template: Extensions should be called out separately from Usage docs.
-
--->

--- a/components/schemes/Typography/docs/README.md
+++ b/components/schemes/Typography/docs/README.md
@@ -84,5 +84,4 @@ import MaterialComponents.MaterialTypographyScheme
 
 <!-- Template: Extensions should be called out separately from Usage docs.
 
-- [Typography Theming](typography-theming.md)
 -->

--- a/components/schemes/Typography/docs/dynamic-type.md
+++ b/components/schemes/Typography/docs/dynamic-type.md
@@ -1,7 +1,9 @@
 ### Dynamic Type
 
- #### Overview
- Users configure text styles on fonts, such as caption and overline, included in a typography scheme. Then, these scalable fonts can be used for [Dynamic Type](../../../Typography) for components. Some default versions of MDCTypographyScheme include scalable fonts. The inline documentation indicates whether a default version of MDCTypographyScheme consists of scalable fonts or not.
- 
- #### useCurrentContentSizeCategoryWhenApplied
- `useCurrentContentSizeCategoryWhenApplied` is a property on MDCTypographyScheme. This property only has an effect if the fonts stored on the typography scheme are scalable. It indicates whether the scalable font on the scheme should be adjusted with respect to the current content size category when it is applied on a component.
+#### Overview
+
+Users configure text styles on fonts, such as caption and overline, included in a typography scheme. Then, these scalable fonts can be used for [Dynamic Type](../../../Typography) for components. Some default versions of MDCTypographyScheme include scalable fonts. The inline documentation indicates whether a default version of MDCTypographyScheme consists of scalable fonts or not.
+
+#### useCurrentContentSizeCategoryWhenApplied
+
+`useCurrentContentSizeCategoryWhenApplied` is a property on MDCTypographyScheme. This property only has an effect if the fonts stored on the typography scheme are scalable. It indicates whether the scalable font on the scheme should be adjusted with respect to the current content size category when it is applied on a component.


### PR DESCRIPTION
The typography theming docs previously had a link to `typography-theming` but that file doesn't exist. This removes the extension section since the only extension file (`typography-theming`) doesn't exist. Additionally some formatting that results in the headers not being rendered correctly in some instances.