### PR TITLE
[NavigationDrawer] Allow Drawer height to keep current height if content height is 0.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -514,7 +514,11 @@ static UIColor *DrawerShadowColor(void) {
   CGFloat totalHeight = self.headerViewController.preferredContentSize.height +
                         _contentVCPreferredContentSizeHeightCached;
   const CGFloat maximumInitialHeight = _maximumInitialDrawerHeight;
-  if (totalHeight > maximumInitialHeight) {
+  if (totalHeight > maximumInitialHeight ||
+      MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
+    // Have the drawer height stay its current size in cases where the content preferred content
+    // size is still not updated, or when the content height and header height are bigger than the
+    // initial height.
     totalHeight = maximumInitialHeight;
   }
   return totalHeight;

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -723,4 +723,17 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.headerShadowLayer.elevation, 4, 0.001);
 }
 
+- (void)testMaximumInitialDrawerHeightWhenPreferredContentSizeIsntUpdatedYet {
+  // Given
+  CGRect fakeRect = CGRectMake(0, 0, 250, 500);
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = fakeRect;
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(250, 0);
+
+  // When
+  CGFloat drawerHeight = [self.fakeBottomDrawer calculateMaximumInitialDrawerHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(drawerHeight, 250, 0.001);
+}
+
 @end


### PR DESCRIPTION
In some cases, clients may have their contentViewController's preferredContentSize only update later in the lifecycle. In cases like that, the _preferredContentSize property may still be 0. Before this change, it would cause the drawer to be much smaller than it should be. This resolves the problem by not updating the drawer height if the content height is still 0.

This has been reported by 2 internal clients so far.
Related bugs: b/123500336 , #7369 