### PR TITLE
[NavigationDrawer] Include safe area insets in content height

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -102,9 +102,9 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
- A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
- This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
- the contentViewController.
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include
+ the bottom safe area inset. This will remove the need for clients to calculate their content size
+ with the bottom safe area when setting the preferredContentSize of the contentViewController.
  Defaults to NO.
  */
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -102,6 +102,14 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
+ This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
+ the contentViewController.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
+
+/**
  A boolean value that indicates whether the drawer is currently the full height of the window.
  */
 @property(nonatomic, readonly) BOOL contentReachesFullscreen;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -76,6 +76,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
     bottomDrawerContainerViewController.maximumInitialDrawerHeight =
         self.maximumInitialDrawerHeight;
   }
+  bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight =
+      self.shouldIncludeSafeAreaInContentHeight;
   if ([self.presentedViewController isKindOfClass:[MDCBottomDrawerViewController class]]) {
     // If in fact the presentedViewController is an MDCBottomDrawerViewController,
     // we then know there is a content and an (optional) header view controller.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -83,6 +83,14 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
+ This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
+ the contentViewController.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
+
+/**
  The bottom drawer delegate.
  */
 @property(nonatomic, weak, nullable) id<MDCBottomDrawerViewControllerDelegate> delegate;

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -83,9 +83,9 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
- A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
- This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
- the contentViewController.
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include
+ the bottom safe area inset. This will remove the need for clients to calculate their content size
+ with the bottom safe area when setting the preferredContentSize of the contentViewController.
  Defaults to NO.
  */
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -176,6 +176,16 @@
   }
 }
 
+- (void)setShouldIncludeSafeAreaInContentHeight:(BOOL)shouldIncludeSafeAreaInContentHeight {
+  _shouldIncludeSafeAreaInContentHeight = shouldIncludeSafeAreaInContentHeight;
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+    (MDCBottomDrawerPresentationController *)self.presentationController;
+    bottomDrawerPresentationController.shouldIncludeSafeAreaInContentHeight =
+        shouldIncludeSafeAreaInContentHeight;
+  }
+}
+
 #pragma mark UIAccessibilityAction
 
 // Adds the Z gesture for dismissal.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -180,7 +180,7 @@
   _shouldIncludeSafeAreaInContentHeight = shouldIncludeSafeAreaInContentHeight;
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
     MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
-    (MDCBottomDrawerPresentationController *)self.presentationController;
+        (MDCBottomDrawerPresentationController *)self.presentationController;
     bottomDrawerPresentationController.shouldIncludeSafeAreaInContentHeight =
         shouldIncludeSafeAreaInContentHeight;
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -131,9 +131,9 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
- A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
- This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
- the contentViewController.
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include
+ the bottom safe area inset. This will remove the need for clients to calculate their content size
+ with the bottom safe area when setting the preferredContentSize of the contentViewController.
  Defaults to NO.
  */
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -131,6 +131,14 @@
 @property(nonatomic, assign) CGFloat maximumInitialDrawerHeight;
 
 /**
+ A flag allowing clients to opt-in to the drawer adding additional height to the content to include the bottom safe area inset.
+ This will remove the need for clients to calculate their content size with the bottom safe area when setting the preferredContentSize of
+ the contentViewController.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
+
+/**
  Sets the content offset Y of the drawer's content. If contentOffsetY is set to 0, the
  drawer will scroll to the start of its content.
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -514,7 +514,11 @@ static UIColor *DrawerShadowColor(void) {
   CGFloat totalHeight = self.headerViewController.preferredContentSize.height +
                         _contentVCPreferredContentSizeHeightCached;
   const CGFloat maximumInitialHeight = _maximumInitialDrawerHeight;
-  if (totalHeight > maximumInitialHeight) {
+  if (totalHeight > maximumInitialHeight ||
+      MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
+    // Have the drawer height stay its current size in cases where the content preferred content
+    // size is still not updated, or when the content height and header height are bigger than the
+    // initial height.
     totalHeight = maximumInitialHeight;
   }
   return totalHeight;

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -750,9 +750,8 @@ static UIColor *DrawerShadowColor(void) {
 - (void)cacheLayoutCalculationsWithAddedContentHeight:(CGFloat)addedContentHeight {
   CGFloat contentHeaderHeight = self.contentHeaderHeight;
   CGFloat containerHeight = self.presentingViewBounds.size.height;
-  CGFloat contentHeight =
-      self.contentViewController.preferredContentSize.height +
-      [self bottomSafeAreaInsetsToAdjustContainerHeight];
+  CGFloat contentHeight = self.contentViewController.preferredContentSize.height +
+                          [self bottomSafeAreaInsetsToAdjustContainerHeight];
   if ([self shouldPresentFullScreen]) {
     contentHeight = MAX(contentHeight, containerHeight - self.topHeaderHeight);
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -515,13 +515,23 @@ static UIColor *DrawerShadowColor(void) {
                         _contentVCPreferredContentSizeHeightCached;
   const CGFloat maximumInitialHeight = _maximumInitialDrawerHeight;
   if (totalHeight > maximumInitialHeight ||
-      MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached, 0)) {
+      MDCCGFloatEqual(_contentVCPreferredContentSizeHeightCached,
+                      [self bottomSafeAreaInsetsToAdjustContainerHeight])) {
     // Have the drawer height stay its current size in cases where the content preferred content
     // size is still not updated, or when the content height and header height are bigger than the
     // initial height.
     totalHeight = maximumInitialHeight;
   }
   return totalHeight;
+}
+
+- (CGFloat)bottomSafeAreaInsetsToAdjustContainerHeight {
+  if (@available(iOS 11.0, *)) {
+    if (self.shouldIncludeSafeAreaInContentHeight) {
+      return self.view.safeAreaInsets.bottom;
+    }
+  }
+  return 0;
 }
 
 #pragma mark Set ups (Private)
@@ -740,7 +750,9 @@ static UIColor *DrawerShadowColor(void) {
 - (void)cacheLayoutCalculationsWithAddedContentHeight:(CGFloat)addedContentHeight {
   CGFloat contentHeaderHeight = self.contentHeaderHeight;
   CGFloat containerHeight = self.presentingViewBounds.size.height;
-  CGFloat contentHeight = self.contentViewController.preferredContentSize.height;
+  CGFloat contentHeight =
+      self.contentViewController.preferredContentSize.height +
+      [self bottomSafeAreaInsetsToAdjustContainerHeight];
   if ([self shouldPresentFullScreen]) {
     contentHeight = MAX(contentHeight, containerHeight - self.topHeaderHeight);
   }

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -723,4 +723,17 @@
   XCTAssertEqualWithAccuracy(self.fakeBottomDrawer.headerShadowLayer.elevation, 4, 0.001);
 }
 
+- (void)testMaximumInitialDrawerHeightWhenPreferredContentSizeIsntUpdatedYet {
+  // Given
+  CGRect fakeRect = CGRectMake(0, 0, 250, 500);
+  self.fakeBottomDrawer.originalPresentingViewController.view.bounds = fakeRect;
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(250, 0);
+
+  // When
+  CGFloat drawerHeight = [self.fakeBottomDrawer calculateMaximumInitialDrawerHeight];
+
+  // Then
+  XCTAssertEqualWithAccuracy(drawerHeight, 250, 0.001);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -736,4 +736,18 @@
   XCTAssertEqualWithAccuracy(drawerHeight, 250, 0.001);
 }
 
+- (void)testSettingShouldIncludeSafeAreaInContentHeight {
+  // Given
+  self.drawerViewController.shouldIncludeSafeAreaInContentHeight = YES;
+
+  // When
+  MDCBottomDrawerPresentationController *presentationController =
+      (MDCBottomDrawerPresentationController *)self.drawerViewController.presentationController;
+  [presentationController presentationTransitionWillBegin];
+
+  // Then
+  XCTAssertTrue(presentationController.shouldIncludeSafeAreaInContentHeight);
+  XCTAssertTrue(presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -747,7 +747,8 @@
 
   // Then
   XCTAssertTrue(presentationController.shouldIncludeSafeAreaInContentHeight);
-  XCTAssertTrue(presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight);
+  XCTAssertTrue(presentationController.bottomDrawerContainerViewController
+                    .shouldIncludeSafeAreaInContentHeight);
 }
 
 @end


### PR DESCRIPTION
This adds a new opt-in flag for clients to tell the drawer to add the bottom safe area inset to the content height. That way the content can be seen correctly without overlapping on the bottom safe area.

This issue has been reported by an internal client and helps with bug: b/123500336 .

This is a follow up PR to https://github.com/material-components/material-components-ios/pull/7544 