### PR TITLE
[ActionSheet] Simplify BottomSheet import.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <MaterialComponents/MaterialBottomSheet.h>
+#import "MaterialBottomSheet.h"
 
 @class MDCActionSheetAction;
 


### PR DESCRIPTION
Using framework-style imports within the same framework is causing
problems for some internal clients. Instead, use simpler file imports.

Closes #7551
