### PR TITLE
[BottomNavigation] Default `sizeThatFitsIncludesSafeArea` to `NO`.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -152,17 +152,6 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 @property(nonatomic, assign) CGFloat itemsContentHorizontalMargin;
 
 /**
- Flag to allow clients to gradually correct the size/position of the Bottom Navigation bar relative
- to the safe area on iOS 11+.
-
- NOTE: In an upcoming release, this flag will be removed and the default behavior will be to exclude
- the safe area in size calculations.
-
- Defaults to @c YES.
- */
-@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea;
-
-/**
  NSLayoutAnchor for the bottom of the bar items.
 
  @note It is recommended that this anchor be constrained to the bottom of the safe area layout guide
@@ -203,6 +192,22 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
  @param item A UITabBarItem
  */
 - (nullable UIView *)viewForItem:(nonnull UITabBarItem *)item;
+
+@end
+
+/** APIs that will be deprecated in the near future. No new code should rely on these APIs. */
+@interface MDCBottomNavigationBar (ToBeDeprecated)
+
+/**
+ Flag to allow clients to gradually correct the size/position of the Bottom Navigation bar relative
+ to the safe area on iOS 11+.
+
+ NOTE: In an upcoming release, this flag will be removed and the default behavior will be to exclude
+ the safe area in size calculations.
+
+ Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea;
 
 @end
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -56,6 +56,9 @@ static NSString *const kOfAnnouncement = @"of";
 
 @interface MDCBottomNavigationBar () <MDCInkTouchControllerDelegate>
 
+// Declared in MDCBottomNavigationBar (ToBeDeprecated)
+@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea;
+
 @property(nonatomic, assign) BOOL itemsDistributed;
 @property(nonatomic, readonly) BOOL isTitleBelowIcon;
 @property(nonatomic, assign) CGFloat maxLandscapeClusterContainerWidth;
@@ -100,7 +103,7 @@ static NSString *const kOfAnnouncement = @"of";
   _itemsDistributed = YES;
   _barTintColor = [UIColor whiteColor];
   _truncatesLongTitles = YES;
-  _sizeThatFitsIncludesSafeArea = YES;
+  _sizeThatFitsIncludesSafeArea = NO;
   _titlesNumberOfLines = 1;
 
   // Remove any unarchived subviews and reconfigure the view hierarchy

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -326,8 +326,6 @@
       [[MDCSafeAreaCustomizingBottomNavigationBar alloc] initWithFrame:barFrame];
   bottomNavBar.test_safeAreaInsets = UIEdgeInsetsZero;
   CGSize initialSize = [bottomNavBar sizeThatFits:barFrame.size];
-  UIEdgeInsets safeAreaInsets = UIEdgeInsetsMake(20, 20, 20, 20);
-  CGSize expectedSize = CGSizeMake(initialSize.width, initialSize.height + safeAreaInsets.bottom);
 
   // When
   bottomNavBar.test_safeAreaInsets = UIEdgeInsetsMake(20, 20, 20, 20);
@@ -336,13 +334,8 @@
   CGSize finalSize = [bottomNavBar sizeThatFits:barFrame.size];
   XCTAssertFalse(CGSizeEqualToSize(finalSize, CGSizeZero),
                  "sizeThatFits: should not return CGSizeZero");
-  if (@available(iOS 11.0, *)) {
-    XCTAssertTrue(CGSizeEqualToSize(finalSize, expectedSize), @"(%@) is not equal to (%@)",
-                  NSStringFromCGSize(finalSize), NSStringFromCGSize(expectedSize));
-  } else {
-    XCTAssertTrue(CGSizeEqualToSize(finalSize, initialSize), @"(%@) is not equal to (%@)",
-                  NSStringFromCGSize(finalSize), NSStringFromCGSize(initialSize));
-  }
+  XCTAssertTrue(CGSizeEqualToSize(finalSize, initialSize), @"(%@) is not equal to (%@)",
+                NSStringFromCGSize(finalSize), NSStringFromCGSize(initialSize));
 }
 
 - (void)testSizeThatFitsExplicitlyIncludesSafeArea {


### PR DESCRIPTION
Flipping the default value of the flag to `NO` as part of the
migration/deprecation process. Internal clients were migrated
previously, but a few new instances might have appeared.

Part of #6716

## Release note

This should have no impact on the release. All client teams were migrated previously. Any breakage in the release could be mitigated by:

```
self.bottomNavigationBar.sizeThatFitsIncludesSafeArea = YES;
```
