### PR TITLE
[Tabs] Make `-itemAtIndexPath:` safe

### DIFF
--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -523,7 +523,8 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (UITabBarItem *)itemAtIndexPath:(NSIndexPath *)indexPath {
-  if (indexPath && indexPath.section == 0 && indexPath.item >= 0 && (NSInteger)_items.count > indexPath.item) {
+  if (indexPath && indexPath.section == 0 && indexPath.item >= 0 &&
+      (NSInteger)_items.count > indexPath.item) {
     return _items[indexPath.item];
   }
   return nil;

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -357,7 +357,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
     id<MDCItemBarDelegate> delegate = self.delegate;
     if ([delegate respondsToSelector:@selector(itemBar:shouldSelectItem:)]) {
       UITabBarItem *item = [self itemAtIndexPath:indexPath];
-      return [delegate itemBar:self shouldSelectItem:item];
+      if (item) {
+        return [delegate itemBar:self shouldSelectItem:item];
+      }
     }
   }
   return YES;
@@ -368,6 +370,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   if (_collectionView == collectionView) {
     // Update selected item.
     UITabBarItem *item = [self itemAtIndexPath:indexPath];
+    if (!item) {
+      return;
+    }
     _selectedItem = item;
 
     // Notify delegate of new selection.
@@ -400,10 +405,12 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
   MDCItemBarCell *itemCell = [collectionView dequeueReusableCellWithReuseIdentifier:kItemReuseID
                                                                        forIndexPath:indexPath];
-  UITabBarItem *item = [self itemAtIndexPath:indexPath];
-
   [self configureCell:itemCell];
-  [itemCell updateWithItem:item atIndex:indexPath.item count:_items.count];
+
+  UITabBarItem *item = [self itemAtIndexPath:indexPath];
+  if (item) {
+    [itemCell updateWithItem:item atIndex:indexPath.item count:_items.count];
+  }
 
   return itemCell;
 }
@@ -416,6 +423,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   NSParameterAssert(_collectionView == collectionView);
 
   UITabBarItem *item = [self itemAtIndexPath:indexPath];
+  if (!item) {
+    return CGSizeZero;
+  }
 
   const CGFloat itemHeight = CGRectGetHeight(self.bounds);
   CGSize size = CGSizeMake(CGFLOAT_MAX, itemHeight);
@@ -631,6 +641,9 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 
   // Construct a context object describing the selected tab.
   UITabBarItem *item = [self itemAtIndexPath:indexPath];
+  if (!item) {
+    return;
+  }
   MDCTabBarPrivateIndicatorContext *context =
       [[MDCTabBarPrivateIndicatorContext alloc] initWithItem:item
                                                       bounds:selectionIndicatorBounds

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -523,7 +523,7 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (UITabBarItem *)itemAtIndexPath:(NSIndexPath *)indexPath {
-  if (_items && (NSInteger)_items.count > indexPath.item) {
+  if (indexPath && indexPath.section == 0 && indexPath.item >= 0 && (NSInteger)_items.count > indexPath.item) {
     return _items[indexPath.item];
   }
   return nil;

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -513,7 +513,10 @@ static void *kItemPropertyContext = &kItemPropertyContext;
 }
 
 - (UITabBarItem *)itemAtIndexPath:(NSIndexPath *)indexPath {
-  return _items[indexPath.item];
+  if (_items && (NSInteger)_items.count > indexPath.item) {
+    return _items[indexPath.item];
+  }
+  return nil;
 }
 
 - (NSInteger)indexForItem:(nullable UITabBarItem *)item {

--- a/components/Tabs/tests/unit/MDCItemBarTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarTests.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
+#import <UIKit/UIKit.h>
 
 #import "MDCItemBar.h"
 
@@ -28,22 +29,23 @@
 - (void)testItemAtIndexPath {
   // Given
   MDCItemBar *itemBar = [[MDCItemBar alloc] init];
-
-  // When
   UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first tab" image:nil tag:0];
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second tab" image:nil tag:0];
+
+  // When
   itemBar.items = @[ item1, item2 ];
-  NSIndexPath *indexPathForFirstItem = [NSIndexPath indexPathForItem:0 inSection:0];
-  NSIndexPath *indexPathForSecondItem = [NSIndexPath indexPathForItem:1 inSection:0];
-  NSIndexPath *indexPathForThirdItem = [NSIndexPath indexPathForItem:2 inSection:0];
 
   // Then
-  NSAssert([itemBar itemAtIndexPath:indexPathForFirstItem] != nil,
-           @"There should be an item for the NSIndexPath with item equal to 0");
-  NSAssert([itemBar itemAtIndexPath:indexPathForSecondItem] != nil,
-           @"There should be an item for the NSIndexPath with item equal to 1");
-  NSAssert([itemBar itemAtIndexPath:indexPathForThirdItem] == nil,
-           @"There should NOT be an item for the NSIndexPath with item equal to 2");
+  NSIndexPath *indexPathForFirstItem = [NSIndexPath indexPathForItem:0 inSection:0];
+  XCTAssertNotNil([itemBar itemAtIndexPath:indexPathForFirstItem]);
+  NSIndexPath *indexPathForSecondItem = [NSIndexPath indexPathForItem:1 inSection:0];
+  XCTAssertNotNil([itemBar itemAtIndexPath:indexPathForSecondItem]);
+  NSIndexPath *indexPathForThirdItem = [NSIndexPath indexPathForItem:2 inSection:0];
+  XCTAssertNil([itemBar itemAtIndexPath:indexPathForThirdItem]);
+  NSIndexPath *indexPathWithNonZeroSection = [NSIndexPath indexPathForItem:0 inSection:1];
+  XCTAssertNil([itemBar itemAtIndexPath:indexPathWithNonZeroSection]);
+  NSIndexPath *indexPathWithItemEqualToNegativeOne = [NSIndexPath indexPathForItem:-1 inSection:0];
+  XCTAssertNil([itemBar itemAtIndexPath:indexPathWithItemEqualToNegativeOne]);
 }
 
 @end

--- a/components/Tabs/tests/unit/MDCItemBarTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarTests.m
@@ -1,0 +1,49 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCItemBar.h"
+
+@interface MDCItemBar (Testing)
+- (UITabBarItem *)itemAtIndexPath:(NSIndexPath *)indexPath;
+@end
+
+@interface MDCItemBarTests : XCTestCase
+@end
+
+@implementation MDCItemBarTests
+
+- (void)testItemAtIndexPath {
+  // Given
+  MDCItemBar *itemBar = [[MDCItemBar alloc] init];
+
+  // When
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first tab" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second tab" image:nil tag:0];
+  itemBar.items = @[ item1, item2 ];
+  NSIndexPath *indexPathForFirstItem = [NSIndexPath indexPathForItem:0 inSection:0];
+  NSIndexPath *indexPathForSecondItem = [NSIndexPath indexPathForItem:1 inSection:0];
+  NSIndexPath *indexPathForThirdItem = [NSIndexPath indexPathForItem:2 inSection:0];
+
+  // Then
+  NSAssert([itemBar itemAtIndexPath:indexPathForFirstItem] != nil,
+           @"There should be an item for the NSIndexPath with item equal to 0");
+  NSAssert([itemBar itemAtIndexPath:indexPathForSecondItem] != nil,
+           @"There should be an item for the NSIndexPath with item equal to 1");
+  NSAssert([itemBar itemAtIndexPath:indexPathForThirdItem] == nil,
+           @"There should NOT be an item for the NSIndexPath with item equal to 2");
+}
+
+@end

--- a/components/Tabs/tests/unit/MDCItemBarTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarTests.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <XCTest/XCTest.h>
 #import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
 
 #import "MDCItemBar.h"
 


### PR DESCRIPTION
This PR makes the `-itemAtIndexPath:` method on MDCItemBar safe against out of bounds exceptions.

Related to #6275.