### PR TITLE
[Tabs] Revert revert of #7518

### DIFF
--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -14,6 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MDCTabBarDisplayDelegate.h"
 #import "MaterialAppBar.h"
 #import "MaterialButtons.h"
 #import "MaterialCollections.h"
@@ -72,6 +73,8 @@
   self.tabBar.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
   [self.tabBar sizeToFit];
+
+  self.tabBar.displayDelegate = self;
 }
 
 - (void)changeAlignment:(id)sender {
@@ -130,6 +133,16 @@
       // Unsupported
       break;
   }
+}
+
+#pragma mark - MDCTabBarDisplayDelegate
+
+- (void)tabBar:(MDCTabBar *)tabBar willDisplayItem:(UITabBarItem *)item {
+  NSLog(@"Will display item: %@", item.title);
+}
+
+- (void)tabBar:(MDCTabBar *)tabBar didEndDisplayingItem:(nonnull UITabBarItem *)item {
+  NSLog(@"Did end displaying item: %@", item.title);
 }
 
 @end

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.h
@@ -19,12 +19,13 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MDCTabBarDisplayDelegate.h"
 #import "MaterialAppBar.h"
 #import "MaterialCollections.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTabs.h"
 
-@interface TabBarTextOnlyExample : MDCCollectionViewController
+@interface TabBarTextOnlyExample : MDCCollectionViewController <MDCTabBarDisplayDelegate>
 
 @property(nonatomic, nullable) MDCAppBarViewController *appBarViewController;
 @property(nonatomic, nullable) MDCSemanticColorScheme *colorScheme;

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -16,6 +16,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MDCTabBarDisplayDelegate.h"
 #import "MDCTabBarExtendedAlignment.h"
 #import "MDCTabBarIndicatorTemplate.h"
 #import "MDCTabBarSizeClassDelegate.h"
@@ -80,6 +81,10 @@ static MDCItemBarAlignment MDCItemBarAlignmentForTabBarAlignment(
 
 @interface MDCTabBar ()
 @property(nonatomic, weak, nullable) id<MDCTabBarSizeClassDelegate> sizeClassDelegate;
+@end
+
+@interface MDCTabBar ()
+@property(nonatomic, weak, nullable) id<MDCTabBarDisplayDelegate> displayDelegate;
 @end
 
 @interface MDCTabBar () <MDCItemBarDelegate>

--- a/components/Tabs/src/MDCTabBarDisplayDelegate.h
+++ b/components/Tabs/src/MDCTabBarDisplayDelegate.h
@@ -1,0 +1,46 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "MDCTabBar.h"
+
+/**
+ An additional delegate protocol for MDCTabBar that provides information about when UITabBarItems
+ are about to be displayed and when they stop being displayed.
+ */
+@protocol MDCTabBarDisplayDelegate
+
+/**
+ This method is called sometime before the tab's view is displayed.
+ */
+- (void)tabBar:(nonnull MDCTabBar *)tabBar willDisplayItem:(nonnull UITabBarItem *)item;
+
+/**
+ This method is called sometime after the tab's view has stopped being displayed.
+ */
+- (void)tabBar:(nonnull MDCTabBar *)tabBar didEndDisplayingItem:(nonnull UITabBarItem *)item;
+
+@end
+
+@interface MDCTabBar (MDCTabBarDisplayDelegate)
+
+/**
+ A delegate that allows implementers to receive updates on when UITabBarItems are about to be
+ displayed and when they stop being displayed.
+
+ @note This property may be removed in a future version and should be used with that understanding.
+ */
+@property(nonatomic, weak, nullable) NSObject<MDCTabBarDisplayDelegate> *displayDelegate;
+
+@end

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -18,6 +18,7 @@
 
 #import "MDCItemBarCell.h"
 #import "MDCItemBarStyle.h"
+#import "MDCTabBarDisplayDelegate.h"
 #import "MDCTabBarIndicatorAttributes.h"
 #import "MDCTabBarIndicatorTemplate.h"
 #import "MDCTabBarIndicatorView.h"
@@ -406,6 +407,20 @@ static void *kItemPropertyContext = &kItemPropertyContext;
   [itemCell updateWithItem:item atIndex:indexPath.item count:_items.count];
 
   return itemCell;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+       willDisplayCell:(UICollectionViewCell *)cell
+    forItemAtIndexPath:(NSIndexPath *)indexPath {
+  UITabBarItem *item = [self itemAtIndexPath:indexPath];
+  [self.tabBar.displayDelegate tabBar:self.tabBar willDisplayItem:item];
+}
+
+- (void)collectionView:(UICollectionView *)collectionView
+    didEndDisplayingCell:(UICollectionViewCell *)cell
+      forItemAtIndexPath:(NSIndexPath *)indexPath {
+  UITabBarItem *item = [self itemAtIndexPath:indexPath];
+  [self.tabBar.displayDelegate tabBar:self.tabBar didEndDisplayingItem:item];
 }
 
 #pragma mark - UICollectionViewDelegateFlowLayout

--- a/components/Tabs/src/private/MDCItemBar.m
+++ b/components/Tabs/src/private/MDCItemBar.m
@@ -413,14 +413,18 @@ static void *kItemPropertyContext = &kItemPropertyContext;
        willDisplayCell:(UICollectionViewCell *)cell
     forItemAtIndexPath:(NSIndexPath *)indexPath {
   UITabBarItem *item = [self itemAtIndexPath:indexPath];
-  [self.tabBar.displayDelegate tabBar:self.tabBar willDisplayItem:item];
+  if (item) {
+    [self.tabBar.displayDelegate tabBar:self.tabBar willDisplayItem:item];
+  }
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
     didEndDisplayingCell:(UICollectionViewCell *)cell
       forItemAtIndexPath:(NSIndexPath *)indexPath {
   UITabBarItem *item = [self itemAtIndexPath:indexPath];
-  [self.tabBar.displayDelegate tabBar:self.tabBar didEndDisplayingItem:item];
+  if (item) {
+    [self.tabBar.displayDelegate tabBar:self.tabBar didEndDisplayingItem:item];
+  }
 }
 
 #pragma mark - UICollectionViewDelegateFlowLayout

--- a/components/Tabs/tests/unit/MDCTabBarDisplayDelegateTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarDisplayDelegateTests.m
@@ -1,0 +1,86 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCItemBar.h"
+#import "MDCTabBarDisplayDelegate.h"
+#import "MaterialTabs.h"
+
+@interface MDCTabBarDisplayDelegate : NSObject <MDCTabBarDisplayDelegate>
+@property(nonatomic, assign) BOOL willDisplayItemWasCalled;
+@property(nonatomic, assign) BOOL didEndDisplayingItemWasCalled;
+@end
+
+@implementation MDCTabBarDisplayDelegate
+
+- (void)tabBar:(MDCTabBar *)tabBar willDisplayItem:(UITabBarItem *)item {
+  self.willDisplayItemWasCalled = YES;
+}
+
+- (void)tabBar:(MDCTabBar *)tabBar didEndDisplayingItem:(UITabBarItem *)item {
+  self.didEndDisplayingItemWasCalled = YES;
+}
+
+@end
+
+@interface MDCTabBarDisplayDelegateTests : XCTestCase
+@end
+
+@implementation MDCTabBarDisplayDelegateTests
+
+- (void)testMDCTabBarDisplayDelegateTabBarWillDisplayItemWhenViewHasBeenLaidOut {
+  // Given
+  MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
+  MDCTabBarDisplayDelegate *displayDelegate = [[MDCTabBarDisplayDelegate alloc] init];
+  tabBar.displayDelegate = displayDelegate;
+  CGFloat tabBarHeight = [MDCTabBar defaultHeightForItemAppearance:tabBar.itemAppearance];
+  tabBar.frame = CGRectMake(0, 0, 200, tabBarHeight);
+
+  // When
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first tab" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second tab" image:nil tag:0];
+  tabBar.items = @[ item1, item2 ];
+  [tabBar setNeedsLayout];
+  [tabBar layoutIfNeeded];
+
+  // Then
+  XCTAssertTrue(displayDelegate.willDisplayItemWasCalled);
+}
+
+- (void)testMDCTabBarDisplayDelegateTabBarDidEndDisplayingItemWhenViewHasBeenLaidOut {
+  // Given
+  MDCTabBar *tabBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
+  MDCTabBarDisplayDelegate *displayDelegate = [[MDCTabBarDisplayDelegate alloc] init];
+  tabBar.displayDelegate = displayDelegate;
+  CGFloat tabBarHeight = [MDCTabBar defaultHeightForItemAppearance:tabBar.itemAppearance];
+  tabBar.frame = CGRectMake(0, 0, 200, tabBarHeight);
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"first tab" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"second tab" image:nil tag:0];
+  tabBar.items = @[ item1, item2 ];
+  [tabBar setNeedsLayout];
+  [tabBar layoutIfNeeded];
+
+  // When
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"third tab" image:nil tag:0];
+  UITabBarItem *item4 = [[UITabBarItem alloc] initWithTitle:@"fourth tab" image:nil tag:0];
+  tabBar.items = @[ item3, item4 ];
+  [tabBar setNeedsLayout];
+  [tabBar layoutIfNeeded];
+
+  // Then
+  XCTAssertTrue(displayDelegate.didEndDisplayingItemWasCalled);
+}
+
+@end


### PR DESCRIPTION
This PR un-reverts #7518 and makes it so that the delegate methods introduced in #7518 are only called if the items are nonnull.

#7555 should be merged in first.

Closes #6275.