### PR TITLE
[Banner] Drop iOS 9 annotation from MDCBannerView.

### DIFF
--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -22,7 +22,6 @@
  The [Material Guideline](https://material.io/design/components/banners.html) has more details on
  component usage.
  */
-NS_CLASS_AVAILABLE_IOS(9_0)
 __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
 
 /**

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -121,10 +121,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   // Create imageView
   UIImageView *imageView = [[UIImageView alloc] init];
   imageView.translatesAutoresizingMaskIntoConstraints = NO;
-  if (@available(iOS 9.0, *)) {
-    [imageView.widthAnchor constraintEqualToConstant:kImageViewSideLength].active = YES;
-    [imageView.heightAnchor constraintEqualToConstant:kImageViewSideLength].active = YES;
-  }
+  [imageView.widthAnchor constraintEqualToConstant:kImageViewSideLength].active = YES;
+  [imageView.heightAnchor constraintEqualToConstant:kImageViewSideLength].active = YES;
   imageView.contentMode = UIViewContentModeCenter;
   imageView.clipsToBounds = YES;
   imageView.hidden = YES;
@@ -156,106 +154,96 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 #pragma mark - Constraints Helpers
 
 - (void)setupConstraints {
-  if (@available(iOS 9.0, *)) {
-    [self setUpImageViewConstraints];
-    [self setUpTextLabelConstraints];
-    [self setUpButtonContainerConstraints];
-    [self setUpButtonsConstraints];
-  }
+  [self setUpImageViewConstraints];
+  [self setUpTextLabelConstraints];
+  [self setUpButtonContainerConstraints];
+  [self setUpButtonsConstraints];
 }
 
-- (void)setUpImageViewConstraints NS_AVAILABLE_IOS(9_0) {
-  if (@available(iOS 9.0, *)) {
-    self.imageViewConstraintLeading =
-        [self.imageView.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
-                                                     constant:kLeadingPadding];
-    self.imageViewConstraintTopSmall =
-        [self.imageView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
-                                                 constant:kTopPaddingSmall];
-    self.imageViewConstraintTopLarge =
-        [self.imageView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
-                                                 constant:kTopPaddingLarge];
-    self.imageViewConstraintBottom =
-        [self.imageView.bottomAnchor constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
-                                                    constant:-kBottomPadding];
-  }
+- (void)setUpImageViewConstraints {
+  self.imageViewConstraintLeading =
+      [self.imageView.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
+                                                   constant:kLeadingPadding];
+  self.imageViewConstraintTopSmall =
+      [self.imageView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
+                                               constant:kTopPaddingSmall];
+  self.imageViewConstraintTopLarge =
+      [self.imageView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
+                                               constant:kTopPaddingLarge];
+  self.imageViewConstraintBottom =
+      [self.imageView.bottomAnchor constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
+                                                  constant:-kBottomPadding];
 }
 
-- (void)setUpTextLabelConstraints NS_AVAILABLE_IOS(9_0) {
-  if (@available(iOS 9.0, *)) {
-    self.textLabelConstraintTop =
-        [self.textLabel.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
-                                                 constant:kTopPaddingLarge];
-    self.textLabelConstraintCenterY = [self.textLabel.centerYAnchor
-        constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
-    self.textLabelConstraintTrailing = [self.textLabel.trailingAnchor
-        constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
-                       constant:-kTrailingPadding];
-    self.textLabelConstraintLeadingWithImage =
-        [self.textLabel.leadingAnchor constraintEqualToAnchor:self.imageView.trailingAnchor
-                                                     constant:kSpaceBetweenIconImageAndTextLabel];
-    self.textLabelConstraintLeadingWithMargin =
-        [self.textLabel.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
-                                                     constant:kLeadingPadding];
-  }
+- (void)setUpTextLabelConstraints {
+  self.textLabelConstraintTop =
+      [self.textLabel.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
+                                               constant:kTopPaddingLarge];
+  self.textLabelConstraintCenterY =
+      [self.textLabel.centerYAnchor constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
+  self.textLabelConstraintTrailing =
+      [self.textLabel.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
+                                                    constant:-kTrailingPadding];
+  self.textLabelConstraintLeadingWithImage =
+      [self.textLabel.leadingAnchor constraintEqualToAnchor:self.imageView.trailingAnchor
+                                                   constant:kSpaceBetweenIconImageAndTextLabel];
+  self.textLabelConstraintLeadingWithMargin =
+      [self.textLabel.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
+                                                   constant:kLeadingPadding];
 }
 
-- (void)setUpButtonContainerConstraints NS_AVAILABLE_IOS(9_0) {
-  if (@available(iOS 9.0, *)) {
-    self.buttonContainerConstraintLeading = [self.buttonContainerView.leadingAnchor
-        constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
-                       constant:kLeadingPadding];
-    self.buttonContainerConstraintTrailing = [self.buttonContainerView.trailingAnchor
-        constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
-                       constant:-kTrailingPadding];
-    self.buttonContainerConstraintBottom = [self.buttonContainerView.bottomAnchor
-        constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
-                       constant:-kBottomPadding];
-    self.buttonContainerConstraintLeadingWithTextLabel = [self.buttonContainerView.leadingAnchor
-        constraintEqualToAnchor:self.textLabel.trailingAnchor
-                       constant:kHorizontalSpaceBetweenTextLabelAndButton];
-    self.buttonContainerConstraintLeadingWithTextLabel.priority = UILayoutPriorityDefaultHigh;
-    self.buttonContainerConstraintLeadingWithTextLabelGreater =
-        [self.buttonContainerView.leadingAnchor
-            constraintGreaterThanOrEqualToAnchor:self.textLabel.trailingAnchor
-                                        constant:kHorizontalSpaceBetweenTextLabelAndButton];
-    self.buttonContainerConstraintTopWithMargin = [self.buttonContainerView.topAnchor
-        constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
-                       constant:kTopPaddingSmall];
-    self.buttonContainerConstraintTopWithImageViewGreater = [self.buttonContainerView.topAnchor
-        constraintGreaterThanOrEqualToAnchor:self.imageView.bottomAnchor
-                                    constant:kVerticalSpaceBetweenButtonAndTextLabel];
-    self.buttonContainerConstraintTopWithTextLabel = [self.buttonContainerView.topAnchor
-        constraintEqualToAnchor:self.textLabel.bottomAnchor
-                       constant:kVerticalSpaceBetweenButtonAndTextLabel];
-    self.buttonContainerConstraintTopWithTextLabel.priority = UILayoutPriorityDefaultLow;
-    self.buttonContainerConstraintTopWithTextLabelGreater = [self.buttonContainerView.topAnchor
-        constraintGreaterThanOrEqualToAnchor:self.textLabel.bottomAnchor
-                                    constant:kVerticalSpaceBetweenButtonAndTextLabel];
-  }
+- (void)setUpButtonContainerConstraints {
+  self.buttonContainerConstraintLeading = [self.buttonContainerView.leadingAnchor
+      constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
+                     constant:kLeadingPadding];
+  self.buttonContainerConstraintTrailing = [self.buttonContainerView.trailingAnchor
+      constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
+                     constant:-kTrailingPadding];
+  self.buttonContainerConstraintBottom = [self.buttonContainerView.bottomAnchor
+      constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
+                     constant:-kBottomPadding];
+  self.buttonContainerConstraintLeadingWithTextLabel = [self.buttonContainerView.leadingAnchor
+      constraintEqualToAnchor:self.textLabel.trailingAnchor
+                     constant:kHorizontalSpaceBetweenTextLabelAndButton];
+  self.buttonContainerConstraintLeadingWithTextLabel.priority = UILayoutPriorityDefaultHigh;
+  self.buttonContainerConstraintLeadingWithTextLabelGreater =
+      [self.buttonContainerView.leadingAnchor
+          constraintGreaterThanOrEqualToAnchor:self.textLabel.trailingAnchor
+                                      constant:kHorizontalSpaceBetweenTextLabelAndButton];
+  self.buttonContainerConstraintTopWithMargin =
+      [self.buttonContainerView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
+                                                         constant:kTopPaddingSmall];
+  self.buttonContainerConstraintTopWithImageViewGreater = [self.buttonContainerView.topAnchor
+      constraintGreaterThanOrEqualToAnchor:self.imageView.bottomAnchor
+                                  constant:kVerticalSpaceBetweenButtonAndTextLabel];
+  self.buttonContainerConstraintTopWithTextLabel = [self.buttonContainerView.topAnchor
+      constraintEqualToAnchor:self.textLabel.bottomAnchor
+                     constant:kVerticalSpaceBetweenButtonAndTextLabel];
+  self.buttonContainerConstraintTopWithTextLabel.priority = UILayoutPriorityDefaultLow;
+  self.buttonContainerConstraintTopWithTextLabelGreater = [self.buttonContainerView.topAnchor
+      constraintGreaterThanOrEqualToAnchor:self.textLabel.bottomAnchor
+                                  constant:kVerticalSpaceBetweenButtonAndTextLabel];
 }
 
-- (void)setUpButtonsConstraints NS_AVAILABLE_IOS(9_0) {
-  if (@available(iOS 9.0, *)) {
-    self.leadingButtonConstraintLeading = [self.leadingButton.leadingAnchor
-        constraintGreaterThanOrEqualToAnchor:self.buttonContainerView.leadingAnchor];
-    self.leadingButtonConstraintTop =
-        [self.leadingButton.topAnchor constraintEqualToAnchor:self.buttonContainerView.topAnchor];
-    self.leadingButtonConstraintTrailing = [self.leadingButton.trailingAnchor
-        constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
-    self.leadingButtonConstraintCenterY = [self.leadingButton.centerYAnchor
-        constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
-    self.leadingButtonConstraintTrailingWithTrailingButton =
-        [self.leadingButton.trailingAnchor constraintEqualToAnchor:self.trailingButton.leadingAnchor
-                                                          constant:-kButtonHorizontalIntervalSpace];
-    self.trailingButtonConstraintBottom = [self.trailingButton.bottomAnchor
-        constraintEqualToAnchor:self.buttonContainerView.bottomAnchor];
-    self.trailingButtonConstraintTop =
-        [self.trailingButton.topAnchor constraintEqualToAnchor:self.leadingButton.bottomAnchor
-                                                      constant:kButtonVerticalIntervalSpace];
-    self.trailingButtonConstraintTrailing = [self.trailingButton.trailingAnchor
-        constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
-  }
+- (void)setUpButtonsConstraints {
+  self.leadingButtonConstraintLeading = [self.leadingButton.leadingAnchor
+      constraintGreaterThanOrEqualToAnchor:self.buttonContainerView.leadingAnchor];
+  self.leadingButtonConstraintTop =
+      [self.leadingButton.topAnchor constraintEqualToAnchor:self.buttonContainerView.topAnchor];
+  self.leadingButtonConstraintTrailing = [self.leadingButton.trailingAnchor
+      constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
+  self.leadingButtonConstraintCenterY = [self.leadingButton.centerYAnchor
+      constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
+  self.leadingButtonConstraintTrailingWithTrailingButton =
+      [self.leadingButton.trailingAnchor constraintEqualToAnchor:self.trailingButton.leadingAnchor
+                                                        constant:-kButtonHorizontalIntervalSpace];
+  self.trailingButtonConstraintBottom = [self.trailingButton.bottomAnchor
+      constraintEqualToAnchor:self.buttonContainerView.bottomAnchor];
+  self.trailingButtonConstraintTop =
+      [self.trailingButton.topAnchor constraintEqualToAnchor:self.leadingButton.bottomAnchor
+                                                    constant:kButtonVerticalIntervalSpace];
+  self.trailingButtonConstraintTrailing = [self.trailingButton.trailingAnchor
+      constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
 }
 
 - (void)deactivateAllConstraints {
@@ -326,17 +314,15 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 }
 
 - (void)updateConstraints {
-  if (@available(iOS 9.0, *)) {
-    MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
-    [self updateConstraintsWithLayoutMode:layoutMode];
-  }
+  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
+  [self updateConstraintsWithLayoutMode:layoutMode];
 
   [super updateConstraints];
 }
 
 #pragma mark - Layout methods
 
-- (void)updateConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode NS_AVAILABLE_IOS(9_0) {
+- (void)updateConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode {
   [self deactivateAllConstraints];
 
   if (!self.imageView.hidden) {
@@ -373,8 +359,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 #pragma mark - Layout helpers
 
-- (void)updateButtonsConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode
-    NS_AVAILABLE_IOS(9_0) {
+- (void)updateButtonsConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode {
   if (self.trailingButton.hidden) {
     self.leadingButtonConstraintTrailing.active = YES;
     self.leadingButtonConstraintCenterY.active = YES;


### PR DESCRIPTION
After fully dropping iOS8 support in Material iOS library, the annotation of OS availability is not necessary in each component. This PR drops those ones for MDCBannerView. 