### PR TITLE
[BottomSheet] Add respondsToSelector check in BottomSheet accessibility escape

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -93,8 +93,10 @@
   [self
       dismissViewControllerAnimated:YES
                          completion:^{
-                           if ([weakSelf.delegate respondsToSelector:@selector(bottomSheetControllerDidDismissBottomSheet:)]) {
-                             [weakSelf.delegate bottomSheetControllerDidDismissBottomSheet:weakSelf];
+                           if ([weakSelf.delegate respondsToSelector:@selector
+                                                  (bottomSheetControllerDidDismissBottomSheet:)]) {
+                             [weakSelf.delegate
+                                 bottomSheetControllerDidDismissBottomSheet:weakSelf];
                            }
                          }];
   return YES;

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -90,16 +90,16 @@
     return NO;
   }
   __weak MDCBottomSheetController *weakSelf = self;
-  [self
-      dismissViewControllerAnimated:YES
-                         completion:^{
-                           __strong MDCBottomSheetController *strongSelf = weakSelf;
-                           if ([strongSelf.delegate respondsToSelector:@selector
-                                                  (bottomSheetControllerDidDismissBottomSheet:)]) {
-                             [strongSelf.delegate
-                                 bottomSheetControllerDidDismissBottomSheet:strongSelf];
-                           }
-                         }];
+  [self dismissViewControllerAnimated:YES
+                           completion:^{
+                             __strong MDCBottomSheetController *strongSelf = weakSelf;
+                             if ([strongSelf.delegate
+                                     respondsToSelector:@selector
+                                     (bottomSheetControllerDidDismissBottomSheet:)]) {
+                               [strongSelf.delegate
+                                   bottomSheetControllerDidDismissBottomSheet:strongSelf];
+                             }
+                           }];
   return YES;
 }
 

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -93,7 +93,9 @@
   [self
       dismissViewControllerAnimated:YES
                          completion:^{
-                           [weakSelf.delegate bottomSheetControllerDidDismissBottomSheet:weakSelf];
+                           if ([weakSelf.delegate respondsToSelector:@selector(bottomSheetControllerDidDismissBottomSheet:)]) {
+                             [weakSelf.delegate bottomSheetControllerDidDismissBottomSheet:weakSelf];
+                           }
                          }];
   return YES;
 }

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -93,7 +93,7 @@
   [self
       dismissViewControllerAnimated:YES
                          completion:^{
-                           __strong typeof(weakSelf) strongSelf = weakSelf;
+                           __strong __typeof(weakSelf) strongSelf = weakSelf;
                            if ([strongSelf.delegate respondsToSelector:@selector
                                                   (bottomSheetControllerDidDismissBottomSheet:)]) {
                              [strongSelf.delegate

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -89,11 +89,11 @@
   if (!self.dismissOnBackgroundTap) {
     return NO;
   }
-  __weak __typeof(self) weakSelf = self;
+  __weak MDCBottomSheetController *weakSelf = self;
   [self
       dismissViewControllerAnimated:YES
                          completion:^{
-                           __strong __typeof(weakSelf) strongSelf = weakSelf;
+                           __strong MDCBottomSheetController *strongSelf = weakSelf;
                            if ([strongSelf.delegate respondsToSelector:@selector
                                                   (bottomSheetControllerDidDismissBottomSheet:)]) {
                              [strongSelf.delegate

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -93,10 +93,11 @@
   [self
       dismissViewControllerAnimated:YES
                          completion:^{
-                           if ([weakSelf.delegate respondsToSelector:@selector
+                           __strong typeof(weakSelf) strongSelf = weakSelf;
+                           if ([strongSelf.delegate respondsToSelector:@selector
                                                   (bottomSheetControllerDidDismissBottomSheet:)]) {
-                             [weakSelf.delegate
-                                 bottomSheetControllerDidDismissBottomSheet:weakSelf];
+                             [strongSelf.delegate
+                                 bottomSheetControllerDidDismissBottomSheet:strongSelf];
                            }
                          }];
   return YES;


### PR DESCRIPTION
This PR fixes a crash by adding a respondsToSelector check to the BottomSheet accessibility escape.

Closes #7569.