### PR TITLE
[Banner] Expose LayoutMode and add an automatic layout mode.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -192,6 +192,20 @@ static NSString *const exampleExtraLongText =
       exampleUseSelector:@selector(showMultiLineStackedButtonStyleBannerWithIcon)];
   [bannerExampleList addObject:exampleUseInfo6];
 
+  BannerExampleUseInfo *exampleUseInfo7 = [BannerExampleUseInfo
+                                           infoWithIdentifier:@"example7"
+                                           displayName:@"Long Text with One Action (Single Line Style)"
+                                           exampleUseTarget:self
+                                           exampleUseSelector:@selector(showSingleLineLongTextStyleBanner)];
+  [bannerExampleList addObject:exampleUseInfo7];
+
+  BannerExampleUseInfo *exampleUseInfo8 = [BannerExampleUseInfo
+                                           infoWithIdentifier:@"example8"
+                                           displayName:@"Long Text with One Action (Automatic Style)"
+                                           exampleUseTarget:self
+                                           exampleUseSelector:@selector(showMultilineLongTextStyleBanner)];
+  [bannerExampleList addObject:exampleUseInfo8];
+
   return [bannerExampleList copy];
 }
 
@@ -326,6 +340,65 @@ static NSString *const exampleExtraLongText =
                            compatibleWithTraitCollection:nil]
       imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   self.bannerView.imageView.tintColor = self.colorScheme.primaryColor;
+}
+
+- (void)showSingleLineLongTextStyleBanner {
+  if (self.bannerView) {
+    [self.bannerView removeFromSuperview];
+  }
+
+  MDCBannerView *bannerView = [[MDCBannerView alloc] init];
+  bannerView.bannerViewLayoutMode = MDCBannerViewLayoutModeSingleLine;
+  bannerView.textLabel.text = exampleLongText;
+  bannerView.backgroundColor = self.colorScheme.surfaceColor;
+  UIEdgeInsets margins = UIEdgeInsetsZero;
+  margins.left = exampleBannerContentPadding;
+  margins.right = exampleBannerContentPadding;
+  bannerView.layoutMargins = margins;
+  [self.view addSubview:bannerView];
+  self.bannerView = bannerView;
+
+  MDCButton *button = bannerView.leadingButton;
+  [button setTitle:@"Dismiss" forState:UIControlStateNormal];
+  button.uppercaseTitle = YES;
+  [button setTitleColor:self.colorScheme.primaryColor forState:UIControlStateNormal];
+  button.backgroundColor = self.colorScheme.surfaceColor;
+  bannerView.trailingButton.hidden = YES;
+  bannerView.imageView.hidden = YES;
+  bannerView.showsDivider = YES;
+
+  [button addTarget:self
+             action:@selector(dismissBanner)
+   forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)showMultilineLongTextStyleBanner {
+  if (self.bannerView) {
+    [self.bannerView removeFromSuperview];
+  }
+
+  MDCBannerView *bannerView = [[MDCBannerView alloc] init];
+  bannerView.textLabel.text = exampleLongText;
+  bannerView.backgroundColor = self.colorScheme.surfaceColor;
+  UIEdgeInsets margins = UIEdgeInsetsZero;
+  margins.left = exampleBannerContentPadding;
+  margins.right = exampleBannerContentPadding;
+  bannerView.layoutMargins = margins;
+  [self.view addSubview:bannerView];
+  self.bannerView = bannerView;
+
+  MDCButton *button = bannerView.leadingButton;
+  [button setTitle:@"Dismiss" forState:UIControlStateNormal];
+  button.uppercaseTitle = YES;
+  [button setTitleColor:self.colorScheme.primaryColor forState:UIControlStateNormal];
+  button.backgroundColor = self.colorScheme.surfaceColor;
+  bannerView.trailingButton.hidden = YES;
+  bannerView.imageView.hidden = YES;
+  bannerView.showsDivider = YES;
+
+  [button addTarget:self
+             action:@selector(dismissBanner)
+   forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)dismissBanner {

--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -348,7 +348,7 @@ static NSString *const exampleExtraLongText =
   }
 
   MDCBannerView *bannerView = [[MDCBannerView alloc] init];
-  bannerView.bannerViewLayoutMode = MDCBannerViewLayoutModeSingleLine;
+  bannerView.bannerViewLayoutMode = MDCBannerViewLayoutModeSingleRow;
   bannerView.textLabel.text = exampleLongText;
   bannerView.backgroundColor = self.colorScheme.surfaceColor;
   UIEdgeInsets margins = UIEdgeInsetsZero;

--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -192,18 +192,18 @@ static NSString *const exampleExtraLongText =
       exampleUseSelector:@selector(showMultiLineStackedButtonStyleBannerWithIcon)];
   [bannerExampleList addObject:exampleUseInfo6];
 
-  BannerExampleUseInfo *exampleUseInfo7 = [BannerExampleUseInfo
-                                           infoWithIdentifier:@"example7"
-                                           displayName:@"Long Text with One Action (Single Line Style)"
-                                           exampleUseTarget:self
-                                           exampleUseSelector:@selector(showSingleLineLongTextStyleBanner)];
+  BannerExampleUseInfo *exampleUseInfo7 =
+      [BannerExampleUseInfo infoWithIdentifier:@"example7"
+                                   displayName:@"Long Text with One Action (Single Line Style)"
+                              exampleUseTarget:self
+                            exampleUseSelector:@selector(showSingleLineLongTextStyleBanner)];
   [bannerExampleList addObject:exampleUseInfo7];
 
-  BannerExampleUseInfo *exampleUseInfo8 = [BannerExampleUseInfo
-                                           infoWithIdentifier:@"example8"
-                                           displayName:@"Long Text with One Action (Automatic Style)"
-                                           exampleUseTarget:self
-                                           exampleUseSelector:@selector(showMultilineLongTextStyleBanner)];
+  BannerExampleUseInfo *exampleUseInfo8 =
+      [BannerExampleUseInfo infoWithIdentifier:@"example8"
+                                   displayName:@"Long Text with One Action (Automatic Style)"
+                              exampleUseTarget:self
+                            exampleUseSelector:@selector(showMultilineLongTextStyleBanner)];
   [bannerExampleList addObject:exampleUseInfo8];
 
   return [bannerExampleList copy];
@@ -368,8 +368,8 @@ static NSString *const exampleExtraLongText =
   bannerView.showsDivider = YES;
 
   [button addTarget:self
-             action:@selector(dismissBanner)
-   forControlEvents:UIControlEventTouchUpInside];
+                action:@selector(dismissBanner)
+      forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)showMultilineLongTextStyleBanner {
@@ -397,8 +397,8 @@ static NSString *const exampleExtraLongText =
   bannerView.showsDivider = YES;
 
   [button addTarget:self
-             action:@selector(dismissBanner)
-   forControlEvents:UIControlEventTouchUpInside];
+                action:@selector(dismissBanner)
+      forControlEvents:UIControlEventTouchUpInside];
 }
 
 - (void)dismissBanner {

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -17,8 +17,9 @@
 #import "MaterialButtons.h"
 
 typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
-  MDCBannerViewLayoutModeAutomatic,               // Layout is set automatically based on how elements are configured on banner view
-  MDCBannerViewLayoutModeSingleLine,              // All elements on the same line, only supports one button
+  MDCBannerViewLayoutModeAutomatic,   // Layout is set automatically based on how elements are
+                                      // configured on banner view
+  MDCBannerViewLayoutModeSingleLine,  // All elements on the same line, only supports one button
   MDCBannerViewLayoutModeMultiLineStackedButton,  // Multiline, stacked button layout
   MDCBannerViewLayoutModeMultiLineAlignedButton,  // Multiline, all buttons on the same line
 };

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -16,7 +16,6 @@
 
 #import "MaterialButtons.h"
 
-
 /**
  @c MDCBannerViewLayoutMode specifies the layout mode of an MDCBannerView.
  */

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -20,9 +20,9 @@
  @c MDCBannerViewLayoutMode specifies the layout mode of an MDCBannerView.
  */
 typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
-  MDCBannerViewLayoutModeAutomatic,   // Layout is set automatically based on how elements are
-                                      // configured on banner view. One of three other layouts will
-                                      // be used internally.
+  MDCBannerViewLayoutModeAutomatic,  // Layout is set automatically based on how elements are
+                                     // configured on banner view. One of three other layouts will
+                                     // be used internally.
   MDCBannerViewLayoutModeSingleRow,  // All elements on the same row, only supports one button
   MDCBannerViewLayoutModeMultiRowStackedButton,  // Multilple rows with stacked button layout
   MDCBannerViewLayoutModeMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -16,6 +16,13 @@
 
 #import "MaterialButtons.h"
 
+typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
+  MDCBannerViewLayoutModeAutomatic,               // Layout is set automatically based on how elements are configured on banner view
+  MDCBannerViewLayoutModeSingleLine,              // All elements on the same line, only supports one button
+  MDCBannerViewLayoutModeMultiLineStackedButton,  // Multiline, stacked button layout
+  MDCBannerViewLayoutModeMultiLineAlignedButton,  // Multiline, all buttons on the same line
+};
+
 /**
  The MDCBannerView class creates and configures a view to represent a Material Banner.
 
@@ -23,6 +30,13 @@
  component usage.
  */
 __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
+
+/**
+ The layout mode of a @c MDCBannerView.
+
+ The default value is MDCBannerViewLayoutModeAutomatic.
+ */
+@property(nonatomic, readwrite, assign) MDCBannerViewLayoutMode bannerViewLayoutMode;
 
 /**
  A view that displays the text on a @c MDCBannerView
@@ -62,6 +76,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
 
  The default value is light grey.
  */
-@property(nonatomic, nonnull, strong) UIColor *dividerColor;
+@property(nonatomic, readwrite, strong, nonnull) UIColor *dividerColor;
 
 @end

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -19,15 +19,13 @@
 /**
  @c MDCBannerViewLayoutMode specifies the layout mode of an MDCBannerView.
  */
-// TODO: Replace Line with Row in MDCBannerViewLayoutMode enumeration.
-// https://github.com/material-components/material-components-ios/pull/7572#discussion_r293167592
 typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
   MDCBannerViewLayoutModeAutomatic,   // Layout is set automatically based on how elements are
                                       // configured on banner view. One of three other layouts will
                                       // be used internally.
-  MDCBannerViewLayoutModeSingleLine,  // All elements on the same line, only supports one button
-  MDCBannerViewLayoutModeMultiLineStackedButton,  // Multiline, stacked button layout
-  MDCBannerViewLayoutModeMultiLineAlignedButton,  // Multiline, all buttons on the same line
+  MDCBannerViewLayoutModeSingleRow,  // All elements on the same row, only supports one button
+  MDCBannerViewLayoutModeMultiRowStackedButton,  // Multilple rows with stacked button layout
+  MDCBannerViewLayoutModeMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally
 };
 
 /**

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -77,6 +77,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
 
  The default value is light grey.
  */
-@property(nonatomic, readwrite, strong, nonnull) UIColor *dividerColor;
+@property(nonatomic, nonnull, strong) UIColor *dividerColor;
 
 @end

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -16,9 +16,16 @@
 
 #import "MaterialButtons.h"
 
+
+/**
+ @c MDCBannerViewLayoutMode specifies the layout mode of an MDCBannerView.
+ */
+// TODO: Replace Line with Row in MDCBannerViewLayoutMode enumeration.
+// https://github.com/material-components/material-components-ios/pull/7572#discussion_r293167592
 typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
   MDCBannerViewLayoutModeAutomatic,   // Layout is set automatically based on how elements are
-                                      // configured on banner view
+                                      // configured on banner view. One of three other layouts will
+                                      // be used internally.
   MDCBannerViewLayoutModeSingleLine,  // All elements on the same line, only supports one button
   MDCBannerViewLayoutModeMultiLineStackedButton,  // Multiline, stacked button layout
   MDCBannerViewLayoutModeMultiLineAlignedButton,  // Multiline, all buttons on the same line

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -357,8 +357,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight +=
           leadingButtonSize.height + trailingButtonSize.height + kButtonVerticalIntervalSpace;
       break;
-    default:
-      break;
+      default:
+        break;
     }
   }
   if (self.showsDivider) {

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -357,9 +357,9 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight +=
           leadingButtonSize.height + trailingButtonSize.height + kButtonVerticalIntervalSpace;
       break;
-      default:
-        break;
     }
+    default:
+      break;
   }
   if (self.showsDivider) {
     frameHeight += self.dividerHeight;

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -319,7 +319,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:size];
   CGFloat frameHeight = 0.0f;
   switch (layoutMode) {
-    case MDCBannerViewLayoutModeSingleLine: {
+    case MDCBannerViewLayoutModeSingleRow: {
       frameHeight += kTopPaddingSmall + kBottomPadding;
       CGFloat widthLimit = size.width;
       CGFloat marginsPadding = self.layoutMargins.left + self.layoutMargins.right;
@@ -341,7 +341,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight += maximumHeight;
       break;
     }
-    case MDCBannerViewLayoutModeMultiLineAlignedButton: {
+    case MDCBannerViewLayoutModeMultiRowAlignedButton: {
       frameHeight += kTopPaddingLarge + kBottomPadding;
       frameHeight += [self getFrameHeightOfImageViewAndTextLabelWithSizeToFit:size];
       CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
@@ -349,7 +349,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight += MAX(leadingButtonSize.height, trailingButtonSize.height);
       break;
     }
-    case MDCBannerViewLayoutModeMultiLineStackedButton: {
+    case MDCBannerViewLayoutModeMultiRowStackedButton: {
       frameHeight += kTopPaddingLarge + kBottomPadding;
       frameHeight += [self getFrameHeightOfImageViewAndTextLabelWithSizeToFit:size];
       CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
@@ -388,7 +388,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.buttonContainerConstraintTrailing.active = YES;
   self.buttonContainerConstraintBottom.active = YES;
 
-  if (layoutMode == MDCBannerViewLayoutModeSingleLine) {
+  if (layoutMode == MDCBannerViewLayoutModeSingleRow) {
     if (!self.imageView.hidden) {
       self.imageViewConstraintTopSmall.active = YES;
       self.imageViewConstraintBottom.active = YES;
@@ -426,7 +426,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
     self.leadingButtonConstraintTrailing.active = YES;
     self.leadingButtonConstraintCenterY.active = YES;
   } else {
-    if (layoutMode == MDCBannerViewLayoutModeMultiLineStackedButton) {
+    if (layoutMode == MDCBannerViewLayoutModeMultiRowStackedButton) {
       self.leadingButtonConstraintTrailing.active = YES;
       self.trailingButtonConstraintTop.active = YES;
     } else {
@@ -458,14 +458,14 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       remainingWidth -= kSpaceBetweenIconImageAndTextLabel;
     }
     layoutMode = [self isAbleToFitTextLabel:self.textLabel withWidthLimit:remainingWidth]
-                     ? MDCBannerViewLayoutModeSingleLine
-                     : MDCBannerViewLayoutModeMultiLineAlignedButton;
+                     ? MDCBannerViewLayoutModeSingleRow
+                     : MDCBannerViewLayoutModeMultiRowAlignedButton;
   } else {
     [self.trailingButton sizeToFit];
     CGFloat buttonWidth = [self widthSumForButtons:@[ self.leadingButton, self.trailingButton ]];
     remainingWidth -= buttonWidth;
-    layoutMode = (remainingWidth > 0) ? MDCBannerViewLayoutModeMultiLineAlignedButton
-                                      : MDCBannerViewLayoutModeMultiLineStackedButton;
+    layoutMode = (remainingWidth > 0) ? MDCBannerViewLayoutModeMultiRowAlignedButton
+                                      : MDCBannerViewLayoutModeMultiRowStackedButton;
   }
   return layoutMode;
 }


### PR DESCRIPTION
An MDCBannerViewLayoutMode variable was used to control the automatically calculated layout style previously. Because users need to manually control the layout style in some case, a `bannerViewLayoutMode` property is exposed to enable this functionality. An `MDCBannerViewLayoutModeAutomatic` enum has been added to preserve the original automatically layout behavior.

Two examples are added in this PR to show the difference between the automatic style mode and the manual style selection.

Screenshots:

Automatic:
![Simulator Screen Shot - iPhone 7 - 2019-06-12 at 16 30 47](https://user-images.githubusercontent.com/8836258/59384521-5ecdc100-8d30-11e9-941d-792d025f45ad.png)

Manual:
![Simulator Screen Shot - iPhone 7 - 2019-06-12 at 16 25 51](https://user-images.githubusercontent.com/8836258/59384533-64c3a200-8d30-11e9-9ead-7b99b08a4581.png)
