### PR TITLE
[AppBar] Update example to have accessibility elements

### DIFF
--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -115,6 +115,7 @@ extension AppBarTypicalUseSwiftExample {
     let cell = self.tableView.dequeueReusableCell(withIdentifier: "cell") ??
         UITableViewCell(style: .default, reuseIdentifier: "cell")
       cell.layoutMargins = .zero
+      cell.textLabel?.text = "\(indexPath.row)"
       cell.selectionStyle = .none
       return cell
   }


### PR DESCRIPTION
This change adds text to the cell labels within this example so that there are other accessibility elements for VoiceOver to select in this example.