### PR TITLE
{WIP} [Ripple] Fixing Ripple to allow correct theming of selected+highlighted states in Chips.

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -18,11 +18,14 @@
 
 #import "private/MDCChipView+Private.h"
 
-@implementation MDCChipCollectionViewCell
+@implementation MDCChipCollectionViewCell {
+  BOOL _isSelected;
+}
 
 - (instancetype)initWithFrame:(CGRect)rect {
   if (self = [super initWithFrame:rect]) {
     _chipView = [self createChipView];
+    _isSelected = NO;
     [self.contentView addSubview:_chipView];
   }
   return self;
@@ -71,7 +74,11 @@
 }
 
 - (void)setSelected:(BOOL)selected {
-  [super setSelected:selected];
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setSelected:selected];
+  }
+  _isSelected = selected;
 
   if (self.alwaysAnimateResize && [_chipView willChangeSizeWithSelectedValue:selected]) {
     // Since MDCChipView can resize when it is selected, if a resize will occur we need to delay our
@@ -82,10 +89,22 @@
   }
 }
 
-- (void)setHighlighted:(BOOL)highlighted {
-  [super setHighlighted:highlighted];
+- (BOOL)isSelected {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? _isSelected : [super isSelected];
+}
 
+- (void)setHighlighted:(BOOL)highlighted {
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setHighlighted:highlighted];
+  }
   _chipView.highlighted = highlighted;
+}
+
+- (BOOL)isHighlighted {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? self.chipView.highlighted : [super isHighlighted];
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -118,6 +118,15 @@
  */
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
+/**
+ Set this flag to YES to allow the chip to be in the selected state.
+ When YES, tapping a chip will automatically toggle the chip's selected state, applying all custom
+ theming related to the selected state (or combination of).
+
+ Defaults to NO.
+ */
+@property(nonatomic) BOOL allowsSelection;
+
 /*
  The color of the ink ripple.
  */

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -429,7 +429,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)setInkColor:(UIColor *)inkColor forState:(UIControlState)state {
   _inkColors[@(state)] = inkColor;
 
-  NSNumber *rippleState = [self.rippleView rippleStateForControlState:state];
+  NSNumber *rippleState = [self rippleStateForControlState:state];
   if (rippleState) {
     [self.rippleView setRippleColor:inkColor forState:rippleState.integerValue];
   }
@@ -448,9 +448,26 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   // MDCStatefulRippleView sets the ripple color internally when its state changes.
   // If that specific state isn't supported by the stateful ripple, then we directly set the
   // ripple view's color to the requested color.
-  if (![self.rippleView rippleStateForControlState:self.state]) {
+  if (![self rippleStateForControlState:self.state]) {
     self.rippleView.rippleColor =
         rippleColor ?: [UIColor colorWithWhite:1 alpha:MDCChipViewRippleDefaultOpacity];
+  }
+}
+
+- (NSNumber *)rippleStateForControlState:(UIControlState)state {
+  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
+  // we return nil for non-supported ripple states.
+  switch (state) {
+    case UIControlStateNormal:
+      return [NSNumber numberWithInteger:MDCRippleStateNormal];
+    case UIControlStateHighlighted:
+      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
+    case UIControlStateSelected:
+      return [NSNumber numberWithInteger:MDCRippleStateSelected];
+    case (UIControlStateHighlighted | UIControlStateSelected):
+      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
+    default:
+      return nil;
   }
 }
 

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -277,7 +277,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (BOOL)allowsSelection {
-  return !self.enableRippleBehavior || self.rippleView.allowsSelection;
+  return self.rippleView.allowsSelection;
 }
 
 - (void)setAllowsSelection:(BOOL)allowsSelection {

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -276,6 +276,14 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 }
 
+- (BOOL)allowsSelection {
+  return !self.enableRippleBehavior || self.rippleView.allowsSelection;
+}
+
+- (void)setAllowsSelection:(BOOL)allowsSelection {
+  self.rippleView.allowsSelection = allowsSelection;
+}
+
 #pragma mark - Dynamic Type Support
 
 - (BOOL)mdc_adjustsFontForContentSizeCategory {
@@ -421,7 +429,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)setInkColor:(UIColor *)inkColor forState:(UIControlState)state {
   _inkColors[@(state)] = inkColor;
 
-  NSNumber *rippleState = [self rippleStateForControlState:state];
+  NSNumber *rippleState = [self.rippleView rippleStateForControlState:state];
   if (rippleState) {
     [self.rippleView setRippleColor:inkColor forState:rippleState.integerValue];
   }
@@ -432,7 +440,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)updateInkColor {
   UIColor *inkColor = [self inkColorForState:self.state];
-  self.inkView.inkColor = inkColor ? inkColor : self.inkView.defaultInkColor;
+  self.inkView.inkColor = inkColor ?: self.inkView.defaultInkColor;
 }
 
 - (void)updateRippleColor {
@@ -440,26 +448,9 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   // MDCStatefulRippleView sets the ripple color internally when its state changes.
   // If that specific state isn't supported by the stateful ripple, then we directly set the
   // ripple view's color to the requested color.
-  if (![self rippleStateForControlState:self.state]) {
+  if (![self.rippleView rippleStateForControlState:self.state]) {
     self.rippleView.rippleColor =
         rippleColor ?: [UIColor colorWithWhite:1 alpha:MDCChipViewRippleDefaultOpacity];
-  }
-}
-
-- (NSNumber *)rippleStateForControlState:(UIControlState)state {
-  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
-  // we return nil for non-supported ripple states.
-  switch (state) {
-    case UIControlStateNormal:
-      return [NSNumber numberWithInteger:MDCRippleStateNormal];
-    case UIControlStateHighlighted:
-      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
-    case UIControlStateSelected:
-      return [NSNumber numberWithInteger:MDCRippleStateSelected];
-    case (UIControlStateHighlighted | UIControlStateSelected):
-      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
-    default:
-      return nil;
   }
 }
 

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -86,6 +86,21 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
 @property(nonatomic) BOOL allowsSelection;
 
 /**
+ Returns the matching MDCRippleState combination corresponding to the given UIControlState
+ combination.
+
+ Only states shared by both MDCRippleState and UIControlState are considered. If the given
+ UIControlState is not a valid Ripple state, nil is returned. In the given state is a combination
+ that includes both valid and non-valid states, the non valid Ripple states are ignored, returning
+ a Ripple state that reflects only the valid states.
+
+ @param state The UIControlState state combination for which a matcing Ripple state is requested.
+ @return The matching MDCRippleState state (or combination). Use .integerValue to get the integer
+         value of the state out of the returned Number value.
+ */
+- (nullable NSNumber *)rippleStateForControlState:(UIControlState)state;
+
+/**
  Sets the color of the ripple for state.
 
  @param rippleColor The ripple color to set the ripple to.

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -86,21 +86,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
 @property(nonatomic) BOOL allowsSelection;
 
 /**
- Returns the matching MDCRippleState combination corresponding to the given UIControlState
- combination.
-
- Only states shared by both MDCRippleState and UIControlState are considered. If the given
- UIControlState is not a valid Ripple state, nil is returned. In the given state is a combination
- that includes both valid and non-valid states, the non valid Ripple states are ignored, returning
- a Ripple state that reflects only the valid states.
-
- @param state The UIControlState state combination for which a matcing Ripple state is requested.
- @return The matching MDCRippleState state (or combination). Use .integerValue to get the integer
-         value of the state out of the returned Number value.
- */
-- (nullable NSNumber *)rippleStateForControlState:(UIControlState)state;
-
-/**
  Sets the color of the ripple for state.
 
  @param rippleColor The ripple color to set the ripple to.

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -198,23 +198,6 @@ static UIColor *RippleSelectedColor(void) {
   }
 }
 
-- (NSNumber *)rippleStateForControlState:(UIControlState)state {
-  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
-  // we return nil for non-supported ripple states.
-  switch (state) {
-    case UIControlStateNormal:
-      return [NSNumber numberWithInteger:MDCRippleStateNormal];
-    case UIControlStateHighlighted:
-      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
-    case UIControlStateSelected:
-      return [NSNumber numberWithInteger:MDCRippleStateSelected];
-    case (UIControlStateHighlighted | UIControlStateSelected):
-      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
-    default:
-      return nil;
-  }
-}
-
 #pragma mark - Superview Touch Handling
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -75,11 +75,6 @@ static UIColor *RippleSelectedColor(void) {
 
 - (UIColor *)rippleColorForState:(MDCRippleState)state {
   UIColor *rippleColor = _rippleColors[@(state)];
-  if (rippleColor == nil && (state & MDCRippleStateDragged) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateDragged)];
-  } else if (rippleColor == nil && (state & MDCRippleStateSelected) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateSelected)];
-  }
 
   if (rippleColor == nil) {
     rippleColor = _rippleColors[@(MDCRippleStateNormal)];
@@ -172,7 +167,7 @@ static UIColor *RippleSelectedColor(void) {
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
-    if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
+    if ((!self.allowsSelection || self.selected) && !self.dragged && !_tapWentOutsideOfBounds) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.
       [self updateRippleColor];
@@ -200,6 +195,23 @@ static UIColor *RippleSelectedColor(void) {
     // If we are no longer dragging, we cancel all the ripples.
     [self updateRippleColor];
     [self cancelAllRipplesAnimated:YES completion:nil];
+  }
+}
+
+- (NSNumber *)rippleStateForControlState:(UIControlState)state {
+  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
+  // we return nil for non-supported ripple states.
+  switch (state) {
+    case UIControlStateNormal:
+      return [NSNumber numberWithInteger:MDCRippleStateNormal];
+    case UIControlStateHighlighted:
+      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
+    case UIControlStateSelected:
+      return [NSNumber numberWithInteger:MDCRippleStateSelected];
+    case (UIControlStateHighlighted | UIControlStateSelected):
+      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
+    default:
+      return nil;
   }
 }
 

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -87,10 +87,10 @@
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateNormal], UIColor.redColor);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      UIColor.blueColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateSelected | MDCRippleStateHighlighted)],
-      UIColor.greenColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateHighlighted],
                         UIColor.redColor);
 }


### PR DESCRIPTION
# Description
Fixing Ripple to allow correct theming of selected and highlighted states in Chips.

1. Adding "allowsSelection" to MDCChipView, which enables toggling selection of the RippleView.
2. Moving rippleStateForControlState: method from MDCChipView to MDCStatefulRippleView,  so it can be shared by multiple components.
3. Removing state management from MDCChipCollectionCell, directing all states setters/getters to its MDCChipView instance.
4. To align with UIKit/UIControl behavior, we remove the default colors for Dragged and Selected states in MDCStatfulRippleView. The Default is now taken from the Normal state.

Additional Fixes to ChipCells, StatefulRippleView and Chips:

5. StatefulRippleView: Fix case where when allowsSelection is turned on in the ripple, but the collectionView is using the notion of allowMultipleSelection = NO, we don't want that if the Ripple is selected and is then tapped on again, that it will have 2 selected layers. This makes sure that the additional ripple layer dissolves right after if the ripple is already selected.

6. ChipCells: When Ripple is enabled I have removed the notion of the ChipCell maintaining its own state system and passing that to its subview the chipView. This causes complications like when the cell is selected, UIKit turns all of its subviews (including the chipView) to highlighted. Therefore we don't call super for setSelected and setHighlighted, but rather just passthrough the state to the chipView which is the core component.


# Issues
b/133759923 - Incorrect ripple color for the highlighted + selected state in Chips
PRs:  #7609   |   #7613   |   #7616