### PR TITLE
{WIP} [Ripple] Adding disabled state to Ripple allowing correct theming of disabled states in Chips.

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -18,11 +18,14 @@
 
 #import "private/MDCChipView+Private.h"
 
-@implementation MDCChipCollectionViewCell
+@implementation MDCChipCollectionViewCell {
+  BOOL _isSelected;
+}
 
 - (instancetype)initWithFrame:(CGRect)rect {
   if (self = [super initWithFrame:rect]) {
     _chipView = [self createChipView];
+    _isSelected = NO;
     [self.contentView addSubview:_chipView];
   }
   return self;
@@ -71,7 +74,11 @@
 }
 
 - (void)setSelected:(BOOL)selected {
-  [super setSelected:selected];
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setSelected:selected];
+  }
+  _isSelected = selected;
 
   if (self.alwaysAnimateResize && [_chipView willChangeSizeWithSelectedValue:selected]) {
     // Since MDCChipView can resize when it is selected, if a resize will occur we need to delay our
@@ -82,10 +89,22 @@
   }
 }
 
-- (void)setHighlighted:(BOOL)highlighted {
-  [super setHighlighted:highlighted];
+- (BOOL)isSelected {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? _isSelected : [super isSelected];
+}
 
+- (void)setHighlighted:(BOOL)highlighted {
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setHighlighted:highlighted];
+  }
   _chipView.highlighted = highlighted;
+}
+
+- (BOOL)isHighlighted {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? self.chipView.highlighted : [super isHighlighted];
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -118,6 +118,15 @@
  */
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
+/**
+ Set this flag to YES to allow the chip to be in the selected state.
+ When YES, tapping a chip will automatically toggle the chip's selected state, applying all custom
+ theming related to the selected state (or combination of).
+
+ Defaults to NO.
+ */
+@property(nonatomic) BOOL allowsSelection;
+
 /*
  The color of the ink ripple.
  */

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -584,6 +584,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)setEnabled:(BOOL)enabled {
   [super setEnabled:enabled];
 
+  self.rippleView.enabled = enabled;
   [self updateState];
 }
 

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -276,6 +276,14 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 }
 
+- (BOOL)allowsSelection {
+  return !self.enableRippleBehavior || self.rippleView.allowsSelection;
+}
+
+- (void)setAllowsSelection:(BOOL)allowsSelection {
+  self.rippleView.allowsSelection = allowsSelection;
+}
+
 #pragma mark - Dynamic Type Support
 
 - (BOOL)mdc_adjustsFontForContentSizeCategory {
@@ -421,7 +429,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 - (void)setInkColor:(UIColor *)inkColor forState:(UIControlState)state {
   _inkColors[@(state)] = inkColor;
 
-  NSNumber *rippleState = [self rippleStateForControlState:state];
+  NSNumber *rippleState = [self.rippleView rippleStateForControlState:state];
   if (rippleState) {
     [self.rippleView setRippleColor:inkColor forState:rippleState.integerValue];
   }
@@ -432,7 +440,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)updateInkColor {
   UIColor *inkColor = [self inkColorForState:self.state];
-  self.inkView.inkColor = inkColor ? inkColor : self.inkView.defaultInkColor;
+  self.inkView.inkColor = inkColor ?: self.inkView.defaultInkColor;
 }
 
 - (void)updateRippleColor {
@@ -440,26 +448,9 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   // MDCStatefulRippleView sets the ripple color internally when its state changes.
   // If that specific state isn't supported by the stateful ripple, then we directly set the
   // ripple view's color to the requested color.
-  if (![self rippleStateForControlState:self.state]) {
+  if (![self.rippleView rippleStateForControlState:self.state]) {
     self.rippleView.rippleColor =
         rippleColor ?: [UIColor colorWithWhite:1 alpha:MDCChipViewRippleDefaultOpacity];
-  }
-}
-
-- (NSNumber *)rippleStateForControlState:(UIControlState)state {
-  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
-  // we return nil for non-supported ripple states.
-  switch (state) {
-    case UIControlStateNormal:
-      return [NSNumber numberWithInteger:MDCRippleStateNormal];
-    case UIControlStateHighlighted:
-      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
-    case UIControlStateSelected:
-      return [NSNumber numberWithInteger:MDCRippleStateSelected];
-    case (UIControlStateHighlighted | UIControlStateSelected):
-      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
-    default:
-      return nil;
   }
 }
 

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -22,12 +22,14 @@
  - MDCRippleStateHighlighted: The ripple is activated and shown.
  - MDCRippleStateSelected: The ripple is in the selected state.
  - MDCRippleStateDragged: The ripple is in the dragged state.
+ - MDCRippleStateDisabled: The ripple is in the disabled state.
  */
 typedef NS_OPTIONS(NSInteger, MDCRippleState) {
   MDCRippleStateNormal = 0,
   MDCRippleStateHighlighted = 1 << 0,
   MDCRippleStateSelected = 1 << 1,
   MDCRippleStateDragged = 1 << 2,
+  MDCRippleStateDisabled = 1 << 3,
 };
 
 /**
@@ -46,6 +48,14 @@ typedef NS_OPTIONS(NSInteger, MDCRippleState) {
  configured/set alongside the UIKit APIs (i.e. UIControlState or cell's setSelected/setHighlighted).
  */
 __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : MDCRippleView
+
+/**
+ This BOOL is set to YES if the ripple is currently enabled, or NO otherwise.
+ Setting this property to NO enables theming of disabled state combinations.
+
+ Defaults to YES.
+ */
+@property(nonatomic, getter=isEnabled) BOOL enabled;
 
 /**
  This BOOL is set to YES if the ripple is currently selected, or NO otherwise.

--- a/components/Ripple/src/MDCStatefulRippleView.h
+++ b/components/Ripple/src/MDCStatefulRippleView.h
@@ -86,6 +86,21 @@ __attribute__((objc_subclassing_restricted)) @interface MDCStatefulRippleView : 
 @property(nonatomic) BOOL allowsSelection;
 
 /**
+ Returns the matching MDCRippleState combination corresponding to the given UIControlState
+ combination.
+
+ Only states shared by both MDCRippleState and UIControlState are considered. If the given
+ UIControlState is not a valid Ripple state, nil is returned. In the given state is a combination
+ that includes both valid and non-valid states, the non valid Ripple states are ignored, returning
+ a Ripple state that reflects only the valid states.
+
+ @param state The UIControlState state combination for which a matcing Ripple state is requested.
+ @return The matching MDCRippleState state (or combination). Use .integerValue to get the integer
+         value of the state out of the returned Number value.
+ */
+- (nullable NSNumber *)rippleStateForControlState:(UIControlState)state;
+
+/**
  Sets the color of the ripple for state.
 
  @param rippleColor The ripple color to set the ripple to.

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -75,11 +75,6 @@ static UIColor *RippleSelectedColor(void) {
 
 - (UIColor *)rippleColorForState:(MDCRippleState)state {
   UIColor *rippleColor = _rippleColors[@(state)];
-  if (rippleColor == nil && (state & MDCRippleStateDragged) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateDragged)];
-  } else if (rippleColor == nil && (state & MDCRippleStateSelected) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateSelected)];
-  }
 
   if (rippleColor == nil) {
     rippleColor = _rippleColors[@(MDCRippleStateNormal)];
@@ -172,7 +167,7 @@ static UIColor *RippleSelectedColor(void) {
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
-    if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
+    if ((!self.allowsSelection || self.selected) && !self.dragged && !_tapWentOutsideOfBounds) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.
       [self updateRippleColor];
@@ -200,6 +195,23 @@ static UIColor *RippleSelectedColor(void) {
     // If we are no longer dragging, we cancel all the ripples.
     [self updateRippleColor];
     [self cancelAllRipplesAnimated:YES completion:nil];
+  }
+}
+
+- (NSNumber *)rippleStateForControlState:(UIControlState)state {
+  // We check to see if MDCRippleState conforms to a UIControlState and return it, otherwise
+  // we return nil for non-supported ripple states.
+  switch (state) {
+    case UIControlStateNormal:
+      return [NSNumber numberWithInteger:MDCRippleStateNormal];
+    case UIControlStateHighlighted:
+      return [NSNumber numberWithInteger:MDCRippleStateHighlighted];
+    case UIControlStateSelected:
+      return [NSNumber numberWithInteger:MDCRippleStateSelected];
+    case (UIControlStateHighlighted | UIControlStateSelected):
+      return [NSNumber numberWithInteger:(MDCRippleStateHighlighted | MDCRippleStateSelected)];
+    default:
+      return nil;
   }
 }
 

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -87,10 +87,10 @@
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateNormal], UIColor.redColor);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      UIColor.blueColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateSelected | MDCRippleStateHighlighted)],
-      UIColor.greenColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateHighlighted],
                         UIColor.redColor);
 }


### PR DESCRIPTION
# Description
Adding disabled state to Ripple allowing correct theming of disabled states in Chips.

MDCStatfulRippleView now has a new MDCRippleStateDisabled enumeration, allowing it to accept the disabled state in all its APIs.  A new "enabled" setter and getter were added as well to allow correct state management.

Before: (note the selected+disabled chip):

![image](https://user-images.githubusercontent.com/2329102/59481004-a176c280-8e30-11e9-9ff6-5c095daeab56.png)

After:

![image](https://user-images.githubusercontent.com/2329102/59481658-25ca4500-8e33-11e9-97b0-ca37373b4030.png)

Ink:

![image](https://user-images.githubusercontent.com/2329102/59481136-1fd36480-8e31-11e9-99ba-10364197c8fe.png)

[TODO]: (1) Explore difference between ripple and ink.  (2) The ripple animation for selecting and also for de-selecting a chip seems a little off with this change.

This is a followup to PR #7581.

# Issues
b/135129945 - Incorrect ripple color for the disabled state in Chips
