### PR TITLE
[TextFields] MDCTextInputControllerOutlinedTextArea border width fix (#7587)

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.m
@@ -131,6 +131,7 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
       (self.isDisplayingCharacterCountError || self.isDisplayingErrorText) ? self.errorColor
                                                                            : borderColor;
   self.textInput.borderView.borderPath.lineWidth = self.textInput.isEditing ? 2 : 1;
+  [self.textInput.borderView setNeedsLayout];
 }
 
 - (void)updateLayout {


### PR DESCRIPTION
Fixes border width not changing to 2 points wide when editing field (issue #7587)

## Screenshots
**Tested Device:** iPhone 6, iOS 12.3.1
### Before
[Editing](https://user-images.githubusercontent.com/179335/59697846-8f907900-91bc-11e9-9eb9-46601ecfbfe9.PNG)
[Not Editing](https://user-images.githubusercontent.com/179335/59697849-8f907900-91bc-11e9-9f94-18e84ea76d64.PNG)

### After
[Editing](https://user-images.githubusercontent.com/179335/59698057-e5fdb780-91bc-11e9-99bd-5a921c78a442.PNG)
