### PR TITLE
[Snackbar] Remove dead code from Ink

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -105,11 +105,6 @@ static const CGFloat kMinimumHeight = 48;
  */
 static const NSInteger kButtonTagStart = 20000;
 
-/**
- The ink radius of the action button.
- */
-static const CGFloat kButtonInkRadius = 64;
-
 static const MDCFontTextStyle kMessageTextStyle = MDCFontTextStyleBody1;
 static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
@@ -170,9 +165,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
-    self.inkMaxRippleRadius = kButtonInkRadius;
     self.inkColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.06];
-    self.inkStyle = MDCInkStyleUnbounded;
 
     CGFloat buttonContentPadding =
         MDCSnackbarMessage.usesLegacySnackbar ? kLegacyButtonPadding : kButtonPadding;


### PR DESCRIPTION
Ink was set to be unbounded for the Snackbar buttons, even though the buttons should have a bounded behavior. Luckily (or not), Ink's unbounded style wasn't working, and therefore the Ink stayed bounded. Removing the unbounded code in this PR.