### PR TITLE
[Banner] set trailingButton default to hidden under SingleRow layout mode.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -363,7 +363,6 @@ static NSString *const exampleExtraLongText =
   button.uppercaseTitle = YES;
   [button setTitleColor:self.colorScheme.primaryColor forState:UIControlStateNormal];
   button.backgroundColor = self.colorScheme.surfaceColor;
-  bannerView.trailingButton.hidden = YES;
   bannerView.imageView.hidden = YES;
   bannerView.showsDivider = YES;
 

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -23,7 +23,8 @@ typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
   MDCBannerViewLayoutModeAutomatic,  // Layout is set automatically based on how elements are
                                      // configured on banner view. One of three other layouts will
                                      // be used internally.
-  MDCBannerViewLayoutModeSingleRow,  // All elements on the same row, only supports one button
+  MDCBannerViewLayoutModeSingleRow,  // All elements on the same row, only supports one button.
+                                     // trailingButton is hidden under this layout mode.
   MDCBannerViewLayoutModeMultiRowStackedButton,  // Multilple rows with stacked button layout
   MDCBannerViewLayoutModeMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally
 };

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -164,6 +164,14 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   [self setupConstraints];
 }
 
+- (void)setBannerViewLayoutMode:(MDCBannerViewLayoutMode)bannerViewLayoutMode {
+  _bannerViewLayoutMode = bannerViewLayoutMode;
+  if (bannerViewLayoutMode == MDCBannerViewLayoutModeSingleRow) {
+    // Only leadingButton is supported in MDCBannerViewLayoutModeSingleRow mode.
+    self.trailingButton.hidden = YES;
+  }
+}
+
 - (void)setDividerColor:(UIColor *)dividerColor {
   self.divider.backgroundColor = dividerColor;
 }


### PR DESCRIPTION
Only one button (leading button) is allowed under Single Row mode. This PR is meant for reducing configuration steps for clients.