### PR TITLE
[Banner] Rename layoutMode to layoutStyle.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -348,7 +348,7 @@ static NSString *const exampleExtraLongText =
   }
 
   MDCBannerView *bannerView = [[MDCBannerView alloc] init];
-  bannerView.bannerViewLayoutMode = MDCBannerViewLayoutModeSingleRow;
+  bannerView.bannerViewLayoutStyle = MDCBannerViewLayoutStyleSingleRow;
   bannerView.textLabel.text = exampleLongText;
   bannerView.backgroundColor = self.colorScheme.surfaceColor;
   UIEdgeInsets margins = UIEdgeInsetsZero;

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -17,16 +17,16 @@
 #import "MaterialButtons.h"
 
 /**
- @c MDCBannerViewLayoutMode specifies the layout mode of an MDCBannerView.
+ @c MDCBannerViewLayoutStyle specifies the layout style of an MDCBannerView.
  */
-typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
-  MDCBannerViewLayoutModeAutomatic,  // Layout is set automatically based on how elements are
+typedef NS_ENUM(NSInteger, MDCBannerViewLayoutStyle) {
+  MDCBannerViewLayoutStyleAutomatic,  // Layout is set automatically based on how elements are
                                      // configured on banner view. One of three other layouts will
                                      // be used internally.
-  MDCBannerViewLayoutModeSingleRow,  // All elements on the same row, only supports one button.
-                                     // trailingButton is hidden under this layout mode.
-  MDCBannerViewLayoutModeMultiRowStackedButton,  // Multilple rows with stacked button layout
-  MDCBannerViewLayoutModeMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally
+  MDCBannerViewLayoutStyleSingleRow,  // All elements on the same row, only supports one button.
+                                     // trailingButton is hidden under this layout style.
+  MDCBannerViewLayoutStyleMultiRowStackedButton,  // Multilple rows with stacked button layout
+  MDCBannerViewLayoutStyleMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally
 };
 
 /**
@@ -38,11 +38,11 @@ typedef NS_ENUM(NSInteger, MDCBannerViewLayoutMode) {
 __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
 
 /**
- The layout mode of a @c MDCBannerView.
+ The layout style of a @c MDCBannerView.
 
- The default value is MDCBannerViewLayoutModeAutomatic.
+ The default value is MDCBannerViewLayoutStyleAutomatic.
  */
-@property(nonatomic, readwrite, assign) MDCBannerViewLayoutMode bannerViewLayoutMode;
+@property(nonatomic, readwrite, assign) MDCBannerViewLayoutStyle bannerViewLayoutStyle;
 
 /**
  A view that displays the text on a @c MDCBannerView

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -21,10 +21,10 @@
  */
 typedef NS_ENUM(NSInteger, MDCBannerViewLayoutStyle) {
   MDCBannerViewLayoutStyleAutomatic,  // Layout is set automatically based on how elements are
-                                     // configured on banner view. One of three other layouts will
-                                     // be used internally.
+                                      // configured on banner view. One of three other layouts will
+                                      // be used internally.
   MDCBannerViewLayoutStyleSingleRow,  // All elements on the same row, only supports one button.
-                                     // trailingButton is hidden under this layout style.
+                                      // trailingButton is hidden under this layout style.
   MDCBannerViewLayoutStyleMultiRowStackedButton,  // Multilple rows with stacked button layout
   MDCBannerViewLayoutStyleMultiRowAlignedButton,  // Multiple rows with aligned buttons horizontally
 };

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -110,7 +110,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 - (void)commonBannerViewInit {
   self.backgroundColor = UIColor.whiteColor;
-  _bannerViewLayoutMode = MDCBannerViewLayoutModeAutomatic;
+  _bannerViewLayoutStyle = MDCBannerViewLayoutStyleAutomatic;
 
   // Create textLabel
   UILabel *textLabel = [[UILabel alloc] init];
@@ -164,10 +164,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   [self setupConstraints];
 }
 
-- (void)setBannerViewLayoutMode:(MDCBannerViewLayoutMode)bannerViewLayoutMode {
-  _bannerViewLayoutMode = bannerViewLayoutMode;
-  if (bannerViewLayoutMode == MDCBannerViewLayoutModeSingleRow) {
-    // Only leadingButton is supported in MDCBannerViewLayoutModeSingleRow mode.
+- (void)setBannerViewLayoutStyle:(MDCBannerViewLayoutStyle)bannerViewLayoutStyle {
+  _bannerViewLayoutStyle = bannerViewLayoutStyle;
+  if (bannerViewLayoutStyle == MDCBannerViewLayoutStyleSingleRow) {
+    // Only leadingButton is supported in MDCBannerViewLayoutStyleSingleRow.
     self.trailingButton.hidden = YES;
   }
 }
@@ -324,10 +324,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 #pragma mark - UIView overrides
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:size];
+  MDCBannerViewLayoutStyle layoutStyle = [self layoutStyleForSizeToFit:size];
   CGFloat frameHeight = 0.0f;
-  switch (layoutMode) {
-    case MDCBannerViewLayoutModeSingleRow: {
+  switch (layoutStyle) {
+    case MDCBannerViewLayoutStyleSingleRow: {
       frameHeight += kTopPaddingSmall + kBottomPadding;
       CGFloat widthLimit = size.width;
       CGFloat marginsPadding = self.layoutMargins.left + self.layoutMargins.right;
@@ -349,7 +349,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight += maximumHeight;
       break;
     }
-    case MDCBannerViewLayoutModeMultiRowAlignedButton: {
+    case MDCBannerViewLayoutStyleMultiRowAlignedButton: {
       frameHeight += kTopPaddingLarge + kBottomPadding;
       frameHeight += [self getFrameHeightOfImageViewAndTextLabelWithSizeToFit:size];
       CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
@@ -357,7 +357,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       frameHeight += MAX(leadingButtonSize.height, trailingButtonSize.height);
       break;
     }
-    case MDCBannerViewLayoutModeMultiRowStackedButton: {
+    case MDCBannerViewLayoutStyleMultiRowStackedButton: {
       frameHeight += kTopPaddingLarge + kBottomPadding;
       frameHeight += [self getFrameHeightOfImageViewAndTextLabelWithSizeToFit:size];
       CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
@@ -376,15 +376,15 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 }
 
 - (void)updateConstraints {
-  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
-  [self updateConstraintsWithLayoutMode:layoutMode];
+  MDCBannerViewLayoutStyle layoutStyle = [self layoutStyleForSizeToFit:self.bounds.size];
+  [self updateConstraintsWithLayoutStyle:layoutStyle];
 
   [super updateConstraints];
 }
 
 #pragma mark - Layout methods
 
-- (void)updateConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode {
+- (void)updateConstraintsWithLayoutStyle:(MDCBannerViewLayoutStyle)layoutStyle {
   [self deactivateAllConstraints];
 
   if (!self.imageView.hidden) {
@@ -396,7 +396,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.buttonContainerConstraintTrailing.active = YES;
   self.buttonContainerConstraintBottom.active = YES;
 
-  if (layoutMode == MDCBannerViewLayoutModeSingleRow) {
+  if (layoutStyle == MDCBannerViewLayoutStyleSingleRow) {
     if (!self.imageView.hidden) {
       self.imageViewConstraintTopSmall.active = YES;
       self.imageViewConstraintBottom.active = YES;
@@ -416,7 +416,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
     self.buttonContainerConstraintTopWithTextLabel.active = YES;
     self.buttonContainerConstraintLeading.active = YES;
   }
-  [self updateButtonsConstraintsWithLayoutMode:layoutMode];
+  [self updateButtonsConstraintsWithLayoutStyle:layoutStyle];
 
   if (self.showsDivider) {
     self.dividerConstraintWidth.active = YES;
@@ -428,13 +428,13 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 #pragma mark - Layout helpers
 
-- (void)updateButtonsConstraintsWithLayoutMode:(MDCBannerViewLayoutMode)layoutMode {
+- (void)updateButtonsConstraintsWithLayoutStyle:(MDCBannerViewLayoutStyle)layoutStyle {
   if (self.trailingButton.hidden) {
     self.leadingButtonConstraintLeading.active = YES;
     self.leadingButtonConstraintTrailing.active = YES;
     self.leadingButtonConstraintCenterY.active = YES;
   } else {
-    if (layoutMode == MDCBannerViewLayoutModeMultiRowStackedButton) {
+    if (layoutStyle == MDCBannerViewLayoutStyleMultiRowStackedButton) {
       self.leadingButtonConstraintTrailing.active = YES;
       self.trailingButtonConstraintTop.active = YES;
     } else {
@@ -447,12 +447,12 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   }
 }
 
-- (MDCBannerViewLayoutMode)layoutModeForSizeToFit:(CGSize)sizeToFit {
-  if (self.bannerViewLayoutMode != MDCBannerViewLayoutModeAutomatic) {
-    return self.bannerViewLayoutMode;
+- (MDCBannerViewLayoutStyle)layoutStyleForSizeToFit:(CGSize)sizeToFit {
+  if (self.bannerViewLayoutStyle != MDCBannerViewLayoutStyleAutomatic) {
+    return self.bannerViewLayoutStyle;
   }
 
-  MDCBannerViewLayoutMode layoutMode;
+  MDCBannerViewLayoutStyle layoutStyle;
   CGFloat remainingWidth = sizeToFit.width;
   CGFloat marginsPadding = self.layoutMargins.left + self.layoutMargins.right;
   remainingWidth -= marginsPadding;
@@ -465,17 +465,17 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       remainingWidth -= kImageViewSideLength;
       remainingWidth -= kSpaceBetweenIconImageAndTextLabel;
     }
-    layoutMode = [self isAbleToFitTextLabel:self.textLabel withWidthLimit:remainingWidth]
-                     ? MDCBannerViewLayoutModeSingleRow
-                     : MDCBannerViewLayoutModeMultiRowAlignedButton;
+    layoutStyle = [self isAbleToFitTextLabel:self.textLabel withWidthLimit:remainingWidth]
+                     ? MDCBannerViewLayoutStyleSingleRow
+                     : MDCBannerViewLayoutStyleMultiRowAlignedButton;
   } else {
     [self.trailingButton sizeToFit];
     CGFloat buttonWidth = [self widthSumForButtons:@[ self.leadingButton, self.trailingButton ]];
     remainingWidth -= buttonWidth;
-    layoutMode = (remainingWidth > 0) ? MDCBannerViewLayoutModeMultiRowAlignedButton
-                                      : MDCBannerViewLayoutModeMultiRowStackedButton;
+    layoutStyle = (remainingWidth > 0) ? MDCBannerViewLayoutStyleMultiRowAlignedButton
+                                      : MDCBannerViewLayoutStyleMultiRowStackedButton;
   }
-  return layoutMode;
+  return layoutStyle;
 }
 
 - (CGFloat)getFrameHeightOfImageViewAndTextLabelWithSizeToFit:(CGSize)sizeToFit {

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -466,14 +466,14 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       remainingWidth -= kSpaceBetweenIconImageAndTextLabel;
     }
     layoutStyle = [self isAbleToFitTextLabel:self.textLabel withWidthLimit:remainingWidth]
-                     ? MDCBannerViewLayoutStyleSingleRow
-                     : MDCBannerViewLayoutStyleMultiRowAlignedButton;
+                      ? MDCBannerViewLayoutStyleSingleRow
+                      : MDCBannerViewLayoutStyleMultiRowAlignedButton;
   } else {
     [self.trailingButton sizeToFit];
     CGFloat buttonWidth = [self widthSumForButtons:@[ self.leadingButton, self.trailingButton ]];
     remainingWidth -= buttonWidth;
     layoutStyle = (remainingWidth > 0) ? MDCBannerViewLayoutStyleMultiRowAlignedButton
-                                      : MDCBannerViewLayoutStyleMultiRowStackedButton;
+                                       : MDCBannerViewLayoutStyleMultiRowStackedButton;
   }
   return layoutStyle;
 }


### PR DESCRIPTION
The reason behind this renaming is the difference between different layout modes is more visual style difference. There is no functional difference between them. The `style` name is also more aligned to UIKit's naming on visual style properties.

Up for discussion.