### PR TITLE
[ActionSheet] Fixes incorrect layout margins in MDCActionSheetController's table view pre iOS 12.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -149,6 +149,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 
   self.view.backgroundColor = self.backgroundColor;
   self.tableView.frame = self.view.bounds;
+  self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
   self.view.preservesSuperviewLayoutMargins = YES;
   if (@available(iOS 11.0, *)) {
     self.view.insetsLayoutMarginsFromSafeArea = NO;


### PR DESCRIPTION
UITableView.cellLayoutMarginsFollowReadableWidth defaults to true pre iOS 12, and false for iOS 12+. When this property is true, the layout margins of the table view cell's content view are set so that the content width is max ~680 points. This PR makes the behavior consistent across iOS versions by explicitly settings cellLayoutMarginsFollowReadableWidth to false.

| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-06-16 at 21 33 19](https://user-images.githubusercontent.com/7131294/59572953-72ee2700-907e-11e9-87fa-bf3eff3fe87a.png)|![Simulator Screen Shot - iPad Pro (10 5-inch) - 2019-06-16 at 21 32 52](https://user-images.githubusercontent.com/7131294/59572954-7681ae00-907e-11e9-91fb-53f2358cc951.png)|

