### PR TITLE
[Ripple] Fixing default state values in Ripple

### DIFF
--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -75,6 +75,11 @@ static UIColor *RippleSelectedColor(void) {
 
 - (UIColor *)rippleColorForState:(MDCRippleState)state {
   UIColor *rippleColor = _rippleColors[@(state)];
+  if (rippleColor == nil && (state & MDCRippleStateDragged) != 0) {
+    rippleColor = _rippleColors[@(MDCRippleStateDragged)];
+  } else if (rippleColor == nil && (state & MDCRippleStateSelected) != 0) {
+    rippleColor = _rippleColors[@(MDCRippleStateSelected)];
+  }
 
   if (rippleColor == nil) {
     rippleColor = _rippleColors[@(MDCRippleStateNormal)];

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -75,11 +75,6 @@ static UIColor *RippleSelectedColor(void) {
 
 - (UIColor *)rippleColorForState:(MDCRippleState)state {
   UIColor *rippleColor = _rippleColors[@(state)];
-  if (rippleColor == nil && (state & MDCRippleStateDragged) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateDragged)];
-  } else if (rippleColor == nil && (state & MDCRippleStateSelected) != 0) {
-    rippleColor = _rippleColors[@(MDCRippleStateSelected)];
-  }
 
   if (rippleColor == nil) {
     rippleColor = _rippleColors[@(MDCRippleStateNormal)];
@@ -172,7 +167,7 @@ static UIColor *RippleSelectedColor(void) {
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
-    if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
+    if ((!self.allowsSelection || self.selected) && !self.dragged && !_tapWentOutsideOfBounds) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.
       [self updateRippleColor];

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -172,7 +172,25 @@ static UIColor *RippleSelectedColor(void) {
     [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
-    if ((!self.allowsSelection || self.selected) && !self.dragged && !_tapWentOutsideOfBounds) {
+    // In cases where the ripple stops being highlighted, we can only dissolve the ripple if we are
+    // not going into selection (as in that case it will stay and become a selected color and be an
+    // overlay), or when it is already selected and therefore it means it will stay selected and
+    // the ripple should act similarly to going in and out of highlighted and offer a standard
+    // ripple touch feedback on top of the selected overlay.
+    BOOL notAllowingSelectionOrAlreadySelected = !self.allowsSelection || self.selected;
+
+    // We should dissolve the ripple in these cases:
+    // 1. where this is a normal tap going in and out of highlighted indicating a ripple effect,
+    //    same goes to when there is already a selected overlay on top of it.
+    // 2. when also we aren't currently in dragged because in dragged we keep the overlay there and
+    //    when dragged is set to NO it releases all the overlays.
+    // 3. lastly also when the tap isn't currently out of the bounds of the surface, as in that case
+    //    the behavior of the ripple returns to its original state as releasing outside the bounds
+    //    acts as "no action was done".
+    BOOL shouldDissolveRipple =
+        notAllowingSelectionOrAlreadySelected && !self.dragged && !_tapWentOutsideOfBounds;
+
+    if (shouldDissolveRipple) {
       // We dissolve the ripple when highlighted is NO, unless we are going into
       // selection or dragging.
       [self updateRippleColor];

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -87,12 +87,41 @@
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateNormal], UIColor.redColor);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      UIColor.blueColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateSelected | MDCRippleStateHighlighted)],
-      UIColor.greenColor);
+      [rippleView rippleColorForState:MDCRippleStateNormal]);
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateHighlighted],
                         UIColor.redColor);
+}
+
+- (void)testSetRippleColorForStateCombinations {
+  // Given
+  MDCStatefulRippleView *rippleView1 = [[MDCStatefulRippleView alloc] init];
+  MDCStatefulRippleView *rippleView2 = [[MDCStatefulRippleView alloc] init];
+
+  // When
+  for (int i = 0; i < 8; i++) {
+    [rippleView1 setRippleColor:nil forState:(NSInteger)i];
+    [rippleView2 setRippleColor:nil forState:(NSInteger)i];
+  }
+  [rippleView1 setRippleColor:UIColor.blueColor forState:MDCRippleStateDragged];
+  [rippleView1 setRippleColor:UIColor.greenColor forState:MDCRippleStateHighlighted];
+  [rippleView1 setRippleColor:UIColor.redColor forState:MDCRippleStateNormal];
+
+  [rippleView2 setRippleColor:UIColor.blueColor forState:MDCRippleStateDragged];
+  [rippleView2 setRippleColor:UIColor.greenColor forState:MDCRippleStateHighlighted];
+  [rippleView2 setRippleColor:UIColor.redColor forState:MDCRippleStateNormal];
+  [rippleView2 setRippleColor:UIColor.purpleColor
+                     forState:MDCRippleStateDragged | MDCRippleStateHighlighted];
+
+  // Then
+  XCTAssertEqualObjects(
+      [rippleView1 rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
+      UIColor.redColor);
+  XCTAssertEqualObjects(
+      [rippleView2 rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
+      UIColor.purpleColor);
 }
 
 - (void)testAllowsSelection {

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -87,41 +87,12 @@
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateNormal], UIColor.redColor);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      [rippleView rippleColorForState:MDCRippleStateNormal]);
+      UIColor.blueColor);
   XCTAssertEqualObjects(
       [rippleView rippleColorForState:(MDCRippleStateSelected | MDCRippleStateHighlighted)],
-      [rippleView rippleColorForState:MDCRippleStateNormal]);
+      UIColor.greenColor);
   XCTAssertEqualObjects([rippleView rippleColorForState:MDCRippleStateHighlighted],
                         UIColor.redColor);
-}
-
-- (void)testSetRippleColorForStateCombinations {
-  // Given
-  MDCStatefulRippleView *rippleView1 = [[MDCStatefulRippleView alloc] init];
-  MDCStatefulRippleView *rippleView2 = [[MDCStatefulRippleView alloc] init];
-
-  // When
-  for (int i = 0; i < 8; i++) {
-    [rippleView1 setRippleColor:nil forState:(NSInteger)i];
-    [rippleView2 setRippleColor:nil forState:(NSInteger)i];
-  }
-  [rippleView1 setRippleColor:UIColor.blueColor forState:MDCRippleStateDragged];
-  [rippleView1 setRippleColor:UIColor.greenColor forState:MDCRippleStateHighlighted];
-  [rippleView1 setRippleColor:UIColor.redColor forState:MDCRippleStateNormal];
-
-  [rippleView2 setRippleColor:UIColor.blueColor forState:MDCRippleStateDragged];
-  [rippleView2 setRippleColor:UIColor.greenColor forState:MDCRippleStateHighlighted];
-  [rippleView2 setRippleColor:UIColor.redColor forState:MDCRippleStateNormal];
-  [rippleView2 setRippleColor:UIColor.purpleColor
-                     forState:MDCRippleStateDragged | MDCRippleStateHighlighted];
-
-  // Then
-  XCTAssertEqualObjects(
-      [rippleView1 rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      UIColor.redColor);
-  XCTAssertEqualObjects(
-      [rippleView2 rippleColorForState:(MDCRippleStateDragged | MDCRippleStateHighlighted)],
-      UIColor.purpleColor);
 }
 
 - (void)testAllowsSelection {


### PR DESCRIPTION
To align with UIKit/UIControl behavior, the default colors for state combinations like Dragged+<state> and Selected+<state> are defaulted to the normal state, instead of the dragged/selected states (unless these are manually customized, for which the customized values is returned).

Issue: b/133759923 - Incorrect ripple color for the highlighted + selected state in Chips