### PR TITLE
[Ripple][Chips] New RippleAllowsSelection API in MDCChipView

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -119,16 +119,16 @@
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
 /**
- When RippleBehavior is enabled, this property enables selection when a Chip is tap.
- When selection is allowed, tapping a chip automatically (after a momentary ripple animation)
- toggles the chip's selected state. When selection is not allowed, tapping a chip creates a
- momentary ripple animation while the chip remains unselected.
+ Enabling the selection of the Chip on tap (when RippleBehavior is enabled).
+ When rippleAllowsSelection is enabled, tapping a chip automatically toggles the chip's selected
+ state (after a short ripple animation). When disabled, tapping a chip creates a momentary ripple
+ animation while the chip remains unselected.
 
  @note: This property is ignored when RippleBehavior is disabled.
 
  Defaults to: Yes.
  */
-@property(nonatomic) BOOL allowsSelection;
+@property(nonatomic) BOOL rippleAllowsSelection;
 
 /*
  The color of the ink ripple.

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -118,6 +118,17 @@
  */
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
+/**
+ Set this flag to YES/true to allow the chip to be in the selected state when tapped.
+ When selection is allowed, tapping a chip automatically (after a momentary ripple animation)
+ toggles the chip's selected state, applying all custom theming related to the selected state (or
+ combination of). When selection is not allowed, tapping a chip creates a momentary ripple
+ animation while the chip remains unselected.
+
+ Defaults to: Yes.
+ */
+@property(nonatomic) BOOL allowsSelection;
+
 /*
  The color of the ink ripple.
  */

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -119,11 +119,12 @@
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
 /**
- Set this flag to YES/true to allow the chip to be in the selected state when tapped.
+ When RippleBehavior is enabled, this property enables selection when a Chip is tap.
  When selection is allowed, tapping a chip automatically (after a momentary ripple animation)
- toggles the chip's selected state, applying all custom theming related to the selected state (or
- combination of). When selection is not allowed, tapping a chip creates a momentary ripple
- animation while the chip remains unselected.
+ toggles the chip's selected state. When selection is not allowed, tapping a chip creates a
+ momentary ripple animation while the chip remains unselected.
+
+ @note: This property is ignored when RippleBehavior is disabled.
 
  Defaults to: Yes.
  */

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -133,7 +133,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)commonMDCChipViewInit {
   _minimumSize = kMDCChipMinimumSizeDefault;
-  self.allowsSelection = YES;
+  self.rippleAllowsSelection = YES;
   self.isAccessibilityElement = YES;
   _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }
@@ -277,11 +277,11 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   }
 }
 
-- (BOOL)allowsSelection {
+- (BOOL)rippleAllowsSelection {
   return self.rippleView.allowsSelection;
 }
 
-- (void)setAllowsSelection:(BOOL)allowsSelection {
+- (void)setRippleAllowsSelection:(BOOL)allowsSelection {
   self.rippleView.allowsSelection = allowsSelection;
 }
 
@@ -613,11 +613,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (void)setSelected:(BOOL)selected {
-  if (!self.allowsSelection) {
-    // If we disallow selection we don't want to apply any visual or state changes for selection.
-    return;
-  }
-
   [super setSelected:selected];
 
   self.rippleView.selected = selected;

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -133,6 +133,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)commonMDCChipViewInit {
   _minimumSize = kMDCChipMinimumSizeDefault;
+  self.allowsSelection = YES;
   self.isAccessibilityElement = YES;
   _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }
@@ -274,6 +275,14 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
     [self.rippleView removeFromSuperview];
     [self insertSubview:self.inkView belowSubview:self.imageView];
   }
+}
+
+- (BOOL)allowsSelection {
+  return self.rippleView.allowsSelection;
+}
+
+- (void)setAllowsSelection:(BOOL)allowsSelection {
+  self.rippleView.allowsSelection = allowsSelection;
 }
 
 #pragma mark - Dynamic Type Support
@@ -432,7 +441,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (void)updateInkColor {
   UIColor *inkColor = [self inkColorForState:self.state];
-  self.inkView.inkColor = inkColor ? inkColor : self.inkView.defaultInkColor;
+  self.inkView.inkColor = inkColor ?: self.inkView.defaultInkColor;
 }
 
 - (void)updateRippleColor {
@@ -604,6 +613,11 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (void)setSelected:(BOOL)selected {
+  if (!self.allowsSelection) {
+    // If we disallow selection we don't want to apply any visual or state changes for selection.
+    return;
+  }
+
   [super setSelected:selected];
 
   self.rippleView.selected = selected;

--- a/components/Chips/tests/unit/ChipViewRippleTests.m
+++ b/components/Chips/tests/unit/ChipViewRippleTests.m
@@ -59,7 +59,8 @@
   XCTAssertEqual(self.chipView.rippleView.rippleStyle, MDCRippleStyleBounded);
   XCTAssertFalse(self.chipView.enableRippleBehavior);
   XCTAssertNil(self.chipView.rippleView.superview);
-  XCTAssertFalse(self.chipView.rippleView.allowsSelection);
+  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertTrue(self.chipView.rippleView.allowsSelection);
   CGRect chipViewBounds = CGRectStandardize(self.chipView.bounds);
   CGRect rippleBounds = CGRectStandardize(self.chipView.rippleView.bounds);
   XCTAssertTrue(CGRectEqualToRect(chipViewBounds, rippleBounds), @"%@ is not equal to %@",
@@ -89,6 +90,34 @@
   // Then
   XCTAssertEqualObjects(self.chipView.inkView.superview, self.chipView);
   XCTAssertNil(self.chipView.rippleView.superview);
+}
+
+- (void)testAllowsSelectionDefaultState {
+  // Then
+  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertFalse(self.chipView.selected);
+  XCTAssertFalse(self.chipView.highlighted);
+}
+
+- (void)testSelectionIsAllowedByDefault {
+  // When
+  self.chipView.selected = YES;
+
+  // Then
+  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertTrue(self.chipView.selected);
+  XCTAssertFalse(self.chipView.highlighted);
+}
+
+- (void)testNotAllowingSelection {
+  // When
+  self.chipView.allowsSelection = NO;
+  self.chipView.selected = YES;
+
+  // Then
+  XCTAssertFalse(self.chipView.allowsSelection);
+  XCTAssertFalse(self.chipView.selected);
+  XCTAssertFalse(self.chipView.highlighted);
 }
 
 /**

--- a/components/Chips/tests/unit/ChipViewRippleTests.m
+++ b/components/Chips/tests/unit/ChipViewRippleTests.m
@@ -59,7 +59,7 @@
   XCTAssertEqual(self.chipView.rippleView.rippleStyle, MDCRippleStyleBounded);
   XCTAssertFalse(self.chipView.enableRippleBehavior);
   XCTAssertNil(self.chipView.rippleView.superview);
-  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertTrue(self.chipView.rippleAllowsSelection);
   XCTAssertTrue(self.chipView.rippleView.allowsSelection);
   CGRect chipViewBounds = CGRectStandardize(self.chipView.bounds);
   CGRect rippleBounds = CGRectStandardize(self.chipView.rippleView.bounds);
@@ -94,7 +94,7 @@
 
 - (void)testAllowsSelectionDefaultState {
   // Then
-  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertTrue(self.chipView.rippleAllowsSelection);
   XCTAssertFalse(self.chipView.selected);
   XCTAssertFalse(self.chipView.highlighted);
 }
@@ -104,19 +104,20 @@
   self.chipView.selected = YES;
 
   // Then
-  XCTAssertTrue(self.chipView.allowsSelection);
+  XCTAssertTrue(self.chipView.rippleAllowsSelection);
   XCTAssertTrue(self.chipView.selected);
   XCTAssertFalse(self.chipView.highlighted);
 }
 
 - (void)testNotAllowingSelection {
   // When
-  self.chipView.allowsSelection = NO;
+  self.chipView.rippleAllowsSelection = NO;
   self.chipView.selected = YES;
 
   // Then
-  XCTAssertFalse(self.chipView.allowsSelection);
-  XCTAssertFalse(self.chipView.selected);
+  XCTAssertFalse(self.chipView.rippleAllowsSelection);
+  XCTAssertFalse(self.chipView.rippleView.allowsSelection);
+  XCTAssertTrue(self.chipView.selected);
   XCTAssertFalse(self.chipView.highlighted);
 }
 


### PR DESCRIPTION
Adding "allowsSelection" to MDCChipView, which enables toggling selection of the RippleView.

Similarly to UICollectionView's API, by enabling allowSelection on the Chip, once it is tapped, the chip state will go from normal to highlighted to selected, rather than from normal to highlighted and then back to normal. This is a desired behavior in certain types of chips (for instance: Input or Filter Chips), and by redirecting the new API to the MDCStatefulRippleView's allowSelection flag, we are enabling this toggle behavior in Chips.

Note: Setting the default value to YES, to avoid changing exiting expectation in Chips (as evident from this test: ChipAccessibilityTests).

Issue: b/133759923 - Incorrect ripple color for the highlighted + selected state in Chips