### PR TITLE
[Ripple][Chips] Redirecting ChipCell selected & highlighted states to Ripple

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -18,11 +18,14 @@
 
 #import "private/MDCChipView+Private.h"
 
-@implementation MDCChipCollectionViewCell
+@implementation MDCChipCollectionViewCell {
+  BOOL _isSelected;
+}
 
 - (instancetype)initWithFrame:(CGRect)rect {
   if (self = [super initWithFrame:rect]) {
     _chipView = [self createChipView];
+    _isSelected = NO;
     [self.contentView addSubview:_chipView];
   }
   return self;
@@ -71,7 +74,11 @@
 }
 
 - (void)setSelected:(BOOL)selected {
-  [super setSelected:selected];
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setSelected:selected];
+  }
+  _isSelected = selected;
 
   if (self.alwaysAnimateResize && [_chipView willChangeSizeWithSelectedValue:selected]) {
     // Since MDCChipView can resize when it is selected, if a resize will occur we need to delay our
@@ -82,10 +89,22 @@
   }
 }
 
-- (void)setHighlighted:(BOOL)highlighted {
-  [super setHighlighted:highlighted];
+- (BOOL)isSelected {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? _isSelected : [super isSelected];
+}
 
+- (void)setHighlighted:(BOOL)highlighted {
+  // Skipping state management in the current cell. States is managed in self.chipView instead.
+  if (!self.chipView.enableRippleBehavior) {
+    [super setHighlighted:highlighted];
+  }
   _chipView.highlighted = highlighted;
+}
+
+- (BOOL)isHighlighted {
+  // Using self.chipView as the "source of truth" for states when ripple is enabled.
+  return self.chipView.enableRippleBehavior ? self.chipView.highlighted : [super isHighlighted];
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {

--- a/components/Chips/tests/unit/ChipCollectionViewCellTests.m
+++ b/components/Chips/tests/unit/ChipCollectionViewCellTests.m
@@ -1,0 +1,60 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialChips.h"
+
+#import <XCTest/XCTest.h>
+
+@interface ChipCollectionViewCellTests : XCTestCase
+@property(nonatomic, nullable) MDCChipCollectionViewCell *chipCell;
+@end
+
+@implementation ChipCollectionViewCellTests
+
+- (void)setUp {
+  UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+  UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero
+                                                        collectionViewLayout:layout];
+  [collectionView registerClass:[MDCChipCollectionViewCell class]
+      forCellWithReuseIdentifier:@"cell"];
+  NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
+  self.chipCell = [collectionView dequeueReusableCellWithReuseIdentifier:@"cell"
+                                                            forIndexPath:indexPath];
+}
+
+- (void)tearDown {
+  self.chipCell = nil;
+}
+
+- (void)testChipCellsAreSelectableAndHighlightable {
+  // Then (Before)
+  XCTAssertFalse(self.chipCell.selected);
+  XCTAssertFalse(self.chipCell.chipView.selected);
+
+  XCTAssertFalse(self.chipCell.highlighted);
+  XCTAssertFalse(self.chipCell.chipView.highlighted);
+
+  // When
+  self.chipCell.highlighted = YES;
+  self.chipCell.selected = YES;
+
+  // Then (After)
+  XCTAssertTrue(self.chipCell.selected);
+  XCTAssertTrue(self.chipCell.chipView.selected);
+
+  XCTAssertTrue(self.chipCell.highlighted);
+  XCTAssertTrue(self.chipCell.chipView.highlighted);
+}
+
+@end


### PR DESCRIPTION
Redirecting default behavior of selected and highlighted states from ChipCells to its child Chip view.

When Ripple is enabled, removing the notion of the ChipCell maintaining its own state system and passing that to its subview the chipView. This causes complications like when the cell is selected, UIKit turns all of its subviews (including the chipView) to highlighted. Therefore we don't call super for setSelected and setHighlighted, but rather just passthrough the state to the chipView which is the core component.

Issue: b/133759923 - Incorrect ripple color for the highlighted + selected state in Chips