### PR TITLE
[Typography] Annotate mdc_adjustsFontForContentSizeCategory as to-be-deprecated.

### DIFF
--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -178,7 +178,9 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  */
 - (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults;
 
-#pragma mark - To be deprecated
+@end
+
+@interface MDCTypographyScheme (ToBeDeprecated)
 
 /**
  @warning Will eventually be deprecated and removed. Please use


### PR DESCRIPTION
Pre work for https://github.com/material-components/material-components-ios/issues/7618
