### PR TITLE
[Banner] Add intrinsicContentSize support with an example.

### DIFF
--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -40,7 +40,10 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":Banner",
+        "//components/Buttons",
+        "//components/Buttons:Theming",
         "//components/schemes/Color",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -1,0 +1,24 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface BannerAutolayoutExampleViewController : UIViewController
+
+@end
+
+@implementation BannerAutolayoutExampleViewController
+
+
+@end

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -15,17 +15,17 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialBanner.h"
-#import "MaterialButtons.h"
 #import "MaterialButtons+Theming.h"
-#import "MaterialContainerScheme.h"
+#import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 
 static NSString *const exampleText = @"Lorem ipsum dolor";
 
 @interface BannerAutolayoutExampleViewController : UIViewController
 
-@property (nonatomic, readwrite, strong) MDCContainerScheme *containerScheme;
-@property (nonatomic, readwrite, strong) MDCBannerView *bannerView;
+@property(nonatomic, readwrite, strong) MDCContainerScheme *containerScheme;
+@property(nonatomic, readwrite, strong) MDCBannerView *bannerView;
 
 @end
 
@@ -42,11 +42,15 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
   button.translatesAutoresizingMaskIntoConstraints = NO;
   [button applyTextThemeWithScheme:self.containerScheme];
   [button setTitle:@"Material Banner" forState:UIControlStateNormal];
-  [button addTarget:self action:@selector(didTapButton) forControlEvents:UIControlEventTouchUpInside];
+  [button addTarget:self
+                action:@selector(didTapButton)
+      forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:button];
-  NSLayoutConstraint *buttonConstraintCenterX = [button.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor];
+  NSLayoutConstraint *buttonConstraintCenterX =
+      [button.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor];
   buttonConstraintCenterX.active = YES;
-  NSLayoutConstraint *buttonConstraintCenterY = [button.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor];
+  NSLayoutConstraint *buttonConstraintCenterY =
+      [button.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor];
   buttonConstraintCenterY.active = YES;
 
   // Prepare Banner
@@ -59,13 +63,18 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
   MDCButton *actionButton = bannerView.leadingButton;
   [actionButton applyTextThemeWithScheme:self.containerScheme];
   [actionButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [actionButton addTarget:self action:@selector(didTapDismissOnBannerView) forControlEvents:UIControlEventTouchUpInside];
+  [actionButton addTarget:self
+                   action:@selector(didTapDismissOnBannerView)
+         forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:bannerView];
-  NSLayoutConstraint *bannerViewConstraintTop = [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
+  NSLayoutConstraint *bannerViewConstraintTop =
+      [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
   bannerViewConstraintTop.active = YES;
-  NSLayoutConstraint *bannerViewConstraintLeft = [bannerView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor];
+  NSLayoutConstraint *bannerViewConstraintLeft =
+      [bannerView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor];
   bannerViewConstraintLeft.active = YES;
-  NSLayoutConstraint *bannerViewConstraintRight = [bannerView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor];
+  NSLayoutConstraint *bannerViewConstraintRight =
+      [bannerView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor];
   bannerViewConstraintRight.active = YES;
   bannerView.hidden = YES;
   self.bannerView = bannerView;
@@ -83,10 +92,10 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
 
 + (NSDictionary *)catalogMetadata {
   return @{
-           @"breadcrumbs" : @[ @"Banner", @"Banner (Autolayout)" ],
-           @"primaryDemo" : @NO,
-           @"presentable" : @YES,
-           };
+    @"breadcrumbs" : @[ @"Banner", @"Banner (Autolayout)" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES,
+  };
 }
 
 @end

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -14,11 +14,79 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialBanner.h"
+#import "MaterialButtons.h"
+#import "MaterialButtons+Theming.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialColorScheme.h"
+
+static NSString *const exampleText = @"Lorem ipsum dolor";
+
 @interface BannerAutolayoutExampleViewController : UIViewController
+
+@property (nonatomic, readwrite, strong) MDCContainerScheme *containerScheme;
+@property (nonatomic, readwrite, strong) MDCBannerView *bannerView;
 
 @end
 
 @implementation BannerAutolayoutExampleViewController
 
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+
+  // Action Button
+  MDCButton *button = [[MDCButton alloc] init];
+  button.translatesAutoresizingMaskIntoConstraints = NO;
+  [button applyTextThemeWithScheme:self.containerScheme];
+  [button setTitle:@"Material Banner" forState:UIControlStateNormal];
+  [button addTarget:self action:@selector(didTapButton) forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:button];
+  NSLayoutConstraint *buttonConstraintCenterX = [button.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor];
+  buttonConstraintCenterX.active = YES;
+  NSLayoutConstraint *buttonConstraintCenterY = [button.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor];
+  buttonConstraintCenterY.active = YES;
+
+  // Prepare Banner
+  MDCBannerView *bannerView = [[MDCBannerView alloc] init];
+  bannerView.translatesAutoresizingMaskIntoConstraints = NO;
+  bannerView.textLabel.text = exampleText;
+  bannerView.trailingButton.hidden = YES;
+  bannerView.showsDivider = YES;
+  bannerView.layoutMargins = UIEdgeInsetsZero;
+  MDCButton *actionButton = bannerView.leadingButton;
+  [actionButton applyTextThemeWithScheme:self.containerScheme];
+  [actionButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [actionButton addTarget:self action:@selector(didTapDismissOnBannerView) forControlEvents:UIControlEventTouchUpInside];
+  [self.view addSubview:bannerView];
+  NSLayoutConstraint *bannerViewConstraintTop = [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
+  bannerViewConstraintTop.active = YES;
+  NSLayoutConstraint *bannerViewConstraintLeft = [bannerView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor];
+  bannerViewConstraintLeft.active = YES;
+  NSLayoutConstraint *bannerViewConstraintRight = [bannerView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor];
+  bannerViewConstraintRight.active = YES;
+  bannerView.hidden = YES;
+  self.bannerView = bannerView;
+}
+
+- (void)didTapButton {
+  self.bannerView.hidden = NO;
+}
+
+- (void)didTapDismissOnBannerView {
+  self.bannerView.hidden = YES;
+}
+
+#pragma mark - CBC
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+           @"breadcrumbs" : @[ @"Banner", @"Banner (Autolayout)" ],
+           @"primaryDemo" : @NO,
+           @"presentable" : @YES,
+           };
+}
 
 @end

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -76,7 +76,6 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
   NSLayoutConstraint *bannerViewConstraintRight =
       [bannerView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor];
   bannerViewConstraintRight.active = YES;
-  bannerView.preferredMaxLayoutWidth = CGRectGetWidth(self.view.bounds);
   bannerView.hidden = YES;
   self.bannerView = bannerView;
 }

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -76,6 +76,7 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
   NSLayoutConstraint *bannerViewConstraintRight =
       [bannerView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor];
   bannerViewConstraintRight.active = YES;
+  bannerView.preferredMaxLayoutWidth = CGRectGetWidth(self.view.bounds);
   bannerView.hidden = YES;
   self.bannerView = bannerView;
 }

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -84,13 +84,4 @@ __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
  */
 @property(nonatomic, readwrite, strong, nonnull) UIColor *dividerColor;
 
-/**
- The preferred maximum width for a @c MDCBannerView
- If the value of this property is not zero, it will be used when calculating the -intrinsicContentSize
- for constraint-based layout.
-
- The default value is zero.
- */
-@property(nonatomic, readwrite, assign) CGFloat preferredMaxLayoutWidth;
-
 @end

--- a/components/Banner/src/MDCBannerView.h
+++ b/components/Banner/src/MDCBannerView.h
@@ -84,4 +84,13 @@ __attribute__((objc_subclassing_restricted)) @interface MDCBannerView : UIView
  */
 @property(nonatomic, readwrite, strong, nonnull) UIColor *dividerColor;
 
+/**
+ The preferred maximum width for a @c MDCBannerView
+ If the value of this property is not zero, it will be used when calculating the -intrinsicContentSize
+ for constraint-based layout.
+
+ The default value is zero.
+ */
+@property(nonatomic, readwrite, assign) CGFloat preferredMaxLayoutWidth;
+
 @end

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -111,7 +111,6 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 - (void)commonBannerViewInit {
   self.backgroundColor = UIColor.whiteColor;
   _bannerViewLayoutMode = MDCBannerViewLayoutModeAutomatic;
-  _preferredMaxLayoutWidth = 0;
 
   // Create textLabel
   UILabel *textLabel = [[UILabel alloc] init];
@@ -179,11 +178,6 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 - (UIColor *)dividerColor {
   return self.divider.backgroundColor;
-}
-
-- (void)setPreferredMaxLayoutWidth:(CGFloat)preferredMaxLayoutWidth {
-  _preferredMaxLayoutWidth = preferredMaxLayoutWidth;
-  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Constraints Helpers
@@ -382,32 +376,20 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 }
 
 - (CGSize)intrinsicContentSize {
-  CGSize sizeToFit = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-  if (self.preferredMaxLayoutWidth > 0) {
-    sizeToFit.width = self.preferredMaxLayoutWidth;
-  }
-  CGFloat intrinsicContentHeight = [self sizeThatFits:sizeToFit].height;
-  if (self.preferredMaxLayoutWidth > 0) {
-    return CGSizeMake(self.preferredMaxLayoutWidth, intrinsicContentHeight);
-  } else {
-    return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicContentHeight);
-  }
+  CGFloat intrinsicContentHeight = [self sizeThatFits:self.bounds.size].height;
+  return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicContentHeight);
 }
 
 - (void)updateConstraints {
-  CGSize sizeToFit = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-  if (self.translatesAutoresizingMaskIntoConstraints) {
-    sizeToFit = self.bounds.size;
-  } else {
-    if (self.preferredMaxLayoutWidth > 0) {
-      sizeToFit.width = self.preferredMaxLayoutWidth;
-    }
-  }
-
-  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:sizeToFit];
+  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
   [self updateConstraintsWithLayoutMode:layoutMode];
 
   [super updateConstraints];
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Layout methods

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -111,6 +111,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 - (void)commonBannerViewInit {
   self.backgroundColor = UIColor.whiteColor;
   _bannerViewLayoutMode = MDCBannerViewLayoutModeAutomatic;
+  _preferredMaxLayoutWidth = 0;
 
   // Create textLabel
   UILabel *textLabel = [[UILabel alloc] init];
@@ -178,6 +179,11 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 - (UIColor *)dividerColor {
   return self.divider.backgroundColor;
+}
+
+- (void)setPreferredMaxLayoutWidth:(CGFloat)preferredMaxLayoutWidth {
+  _preferredMaxLayoutWidth = preferredMaxLayoutWidth;
+  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Constraints Helpers
@@ -376,20 +382,32 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 }
 
 - (CGSize)intrinsicContentSize {
-  CGFloat intrinsicContentHeight = [self sizeThatFits:self.bounds.size].height;
-  return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicContentHeight);
+  CGSize sizeToFit = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+  if (self.preferredMaxLayoutWidth > 0) {
+    sizeToFit.width = self.preferredMaxLayoutWidth;
+  }
+  CGFloat intrinsicContentHeight = [self sizeThatFits:sizeToFit].height;
+  if (self.preferredMaxLayoutWidth > 0) {
+    return CGSizeMake(self.preferredMaxLayoutWidth, intrinsicContentHeight);
+  } else {
+    return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicContentHeight);
+  }
 }
 
 - (void)updateConstraints {
-  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
+  CGSize sizeToFit = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+  if (self.translatesAutoresizingMaskIntoConstraints) {
+    sizeToFit = self.bounds.size;
+  } else {
+    if (self.preferredMaxLayoutWidth > 0) {
+      sizeToFit.width = self.preferredMaxLayoutWidth;
+    }
+  }
+
+  MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:sizeToFit];
   [self updateConstraintsWithLayoutMode:layoutMode];
 
   [super updateConstraints];
-}
-
-- (void)layoutSubviews {
-  [super layoutSubviews];
-  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Layout methods

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -375,11 +375,21 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   return CGSizeMake(size.width, frameHeight);
 }
 
+- (CGSize)intrinsicContentSize {
+  CGFloat intrinsicContentHeight = [self sizeThatFits:self.bounds.size].height;
+  return CGSizeMake(UIViewNoIntrinsicMetric, intrinsicContentHeight);
+}
+
 - (void)updateConstraints {
   MDCBannerViewLayoutMode layoutMode = [self layoutModeForSizeToFit:self.bounds.size];
   [self updateConstraintsWithLayoutMode:layoutMode];
 
   [super updateConstraints];
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Layout methods


### PR DESCRIPTION
Previously, `intrinsicContentSize` was not supported in MDCBannerView, which means users have to specify layout constraints for width and height manually. After adding `intrinsicContentSize` support, users will only need to specify width constraints for banner to show it properly. This implementation and behavior matches UITextView.

Screenshot:
![Simulator Screen Shot - iPhone 7 - 2019-06-17 at 17 18 30](https://user-images.githubusercontent.com/8836258/59637507-f3b32e80-9123-11e9-8133-7108c1a7824e.png)
