### PR TITLE
[Typography] Add a traitEnvironment property to MDCTypographyScheme. WIP (proof of concept)

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -28,6 +28,13 @@ final class AppTheme {
     }
   }
 
+  static func containerScheme(resolvedWith traitCollection: UITraitCollection) -> MDCContainerScheming {
+    let resolved = DefaultContainerScheme()
+    resolved.typographyScheme = MDCTypographyScheme.resolve(resolved.typographyScheme,
+                                                            for: traitCollection)
+    return resolved
+  }
+
   static let didChangeGlobalThemeNotificationName =
     Notification.Name("MDCCatalogDidChangeGlobalTheme")
 

--- a/catalog/MDCCatalog/MDCCatalogWindow.swift
+++ b/catalog/MDCCatalog/MDCCatalogWindow.swift
@@ -100,6 +100,12 @@ class MDCCatalogWindow: MDCOverlayWindow {
                    animations: { view?.alpha = 0 },
                    completion: { _ in view?.removeFromSuperview() })
   }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    AppTheme.containerScheme = AppTheme.containerScheme(resolvedWith: traitCollection)
+  }
 }
 
 /** A circular view that represents a user's touch. */

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialThemes
 import UIKit
 
-private func schemeWithPalette(_ palette: MDCPalette) -> MDCContainerScheming {
+private func schemeWithPalette(_ palette: MDCPalette) -> MDCContainerScheme {
   let containerScheme = DefaultContainerScheme()
 
   let scheme = MDCSemanticColorScheme()
@@ -50,9 +50,9 @@ private func schemeWithPalette(_ palette: MDCPalette) -> MDCContainerScheming {
 private struct MDCColorThemeCellConfiguration {
   let name: String
   let mainColor: UIColor
-  let scheme: MDCContainerScheming
+  let scheme: MDCContainerScheme
 
-  init(name: String, mainColor: UIColor, scheme: MDCContainerScheming) {
+  init(name: String, mainColor: UIColor, scheme: MDCContainerScheme) {
     self.name = name
     self.mainColor = mainColor
     self.scheme = scheme
@@ -100,7 +100,6 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -129,6 +128,15 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
     palettesCollectionView.dataSource = self
     palettesCollectionView.backgroundColor = .white
     view.addSubview(palettesCollectionView)
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    colorSchemeConfigurations.forEach { config in
+      config.scheme.typographyScheme = MDCTypographyScheme.resolve(config.scheme.typographyScheme,
+                                                                   for: traitCollection)
+    }
   }
 
   func positionCollectionView() {

--- a/components/Typography/src/UIFont+MaterialScalable.h
+++ b/components/Typography/src/UIFont+MaterialScalable.h
@@ -65,6 +65,23 @@ typedef NSDictionary<UIContentSizeCategory, NSNumber *> *MDCScalingCurve;
     (nonnull id<UITraitEnvironment>)traitEnvironment;
 
 /**
+ Returns a font with the same family, weight and traits, but whose point size is based on the given
+ trait collection's preferred content size category.
+
+ If the device is running iOS 9 and not in an extension, then @c traitCollection will be
+ ignored and the UIApplication sharedApplication's preferredContentSizeCategory will be used
+ instead.
+
+ If the device is running iOS 9 and in an extension, then @c traitCollection will be
+ ignored and the returned font will be scaled with UIContentSizeCategoryLarge.
+
+ @param traitCollection The trait collection that should be used to resolve the fonts.
+ @return A font whose point size is determined by @c mdc_scalingCurve for the
+ @c traitCollection's corresponding content size category, or self if @c mdc_scalingCurve is nil.
+ */
+- (nonnull UIFont *)mdc_scaledFontForTraitCollection:(nonnull UITraitCollection *)traitCollection;
+
+/**
  Returns a font with the same family, weight and traits, but whose point size is based on the
  default size category of UIContentSizeCategoryLarge and the corresponding value from
  @c mdc_scalingCurve.

--- a/components/Typography/src/UIFont+MaterialScalable.m
+++ b/components/Typography/src/UIFont+MaterialScalable.m
@@ -59,9 +59,13 @@ static char MDCFontScaleObjectKey;
 }
 
 - (UIFont *)mdc_scaledFontForTraitEnvironment:(id<UITraitEnvironment>)traitEnvironment {
+  return [self mdc_scaledFontForTraitCollection:traitEnvironment.traitCollection];
+}
+
+- (nonnull UIFont *)mdc_scaledFontForTraitCollection:(nonnull UITraitCollection *)traitCollection {
   UIContentSizeCategory sizeCategory = UIContentSizeCategoryLarge;
   if (@available(iOS 10.0, *)) {
-    sizeCategory = traitEnvironment.traitCollection.preferredContentSizeCategory;
+    sizeCategory = traitCollection.preferredContentSizeCategory;
   } else if ([UIApplication mdc_safeSharedApplication]) {
     sizeCategory = [UIApplication mdc_safeSharedApplication].preferredContentSizeCategory;
   }

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -15,6 +15,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@class MDCSemanticColorScheme;
+
 /**
  A simple color scheme that provides semantic context for the colors it uses. There are no optional
  properties and all colors must be provided, supporting more reliable color theming.
@@ -86,6 +88,24 @@
  */
 @property(readonly, assign, nonatomic) BOOL elevationOverlayEnabledForDarkMode;
 
+@optional
+
+/**
+ Returns a mutable copy of the receiver.
+
+ @note This protocol will eventually require conformance to NSMutableCopying and this method will
+ become required.
+ */
+- (nonnull MDCSemanticColorScheme *)mutableCopy;
+
+/**
+ Returns a mutable copy of the receiver with the given zone.
+
+ @note This method's protocol will eventually require conformance to NSMutableCopying and this
+ method will become required.
+ */
+- (nonnull id)mutableCopyWithZone:(nullable NSZone *)zone;
+
 @end
 
 /**
@@ -110,7 +130,7 @@ typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
  A simple implementation of @c MDCColorScheming that provides Material default color values from
  which basic customizations can be made.
  */
-@interface MDCSemanticColorScheme : NSObject <MDCColorScheming, NSCopying>
+@interface MDCSemanticColorScheme : NSObject <MDCColorScheming, NSCopying, NSMutableCopying>
 
 // Redeclare protocol properties as readwrite
 @property(nonnull, readwrite, copy, nonatomic) UIColor *primaryColor;

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -119,9 +119,9 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
                          alpha:alpha + bAlpha * (1 - alpha)];
 }
 
-#pragma mark - NSCopying
+#pragma mark - NSMutableCopying
 
-- (id)copyWithZone:(NSZone *)zone {
+- (id)mutableCopyWithZone:(NSZone *)zone {
   MDCSemanticColorScheme *copy = [[MDCSemanticColorScheme alloc] init];
   copy.primaryColor = self.primaryColor;
   copy.primaryColorVariant = self.primaryColorVariant;
@@ -133,8 +133,13 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
   copy.onSecondaryColor = self.onSecondaryColor;
   copy.onSurfaceColor = self.onSurfaceColor;
   copy.onBackgroundColor = self.onBackgroundColor;
-
   return copy;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  return [self mutableCopyWithZone:zone];
 }
 
 @end

--- a/components/schemes/Container/src/MDCContainerScheme.h
+++ b/components/schemes/Container/src/MDCContainerScheme.h
@@ -18,6 +18,8 @@
 #import <MaterialComponents/MaterialShapeScheme.h>
 #import <MaterialComponents/MaterialTypographyScheme.h>
 
+@class MDCContainerScheme;
+
 /**
  A container scheme that exposes properties for all supported Material Theming subsystem schemes.
  */
@@ -38,6 +40,24 @@
  */
 @property(nonatomic, nullable, readonly) id<MDCShapeScheming> shapeScheme;
 
+@optional
+
+/**
+ Returns a mutable copy of the receiver.
+
+ @note This protocol will eventually require conformance to NSMutableCopying and this method will
+ become required.
+ */
+- (nonnull MDCContainerScheme *)mutableCopy;
+
+/**
+ Returns a mutable copy of the receiver with the given zone.
+
+ @note This method's protocol will eventually require conformance to NSMutableCopying and this
+ method will become required.
+ */
+- (nonnull id)mutableCopyWithZone:(nullable NSZone *)zone;
+
 @end
 
 /**
@@ -45,7 +65,7 @@
  schemes values for theming systems.
  */
 __attribute__((objc_subclassing_restricted)) @interface MDCContainerScheme
-    : NSObject<MDCContainerScheming>
+    : NSObject<MDCContainerScheming, NSMutableCopying>
 
 /**
  Defaults to @c MDCColorSchemeDefaultsMaterial201804
@@ -61,5 +81,17 @@ __attribute__((objc_subclassing_restricted)) @interface MDCContainerScheme
  Defaults to @c nil
  */
 @property(nonatomic, nullable, readwrite) MDCShapeScheme *shapeScheme;
+
+@end
+
+@interface MDCContainerScheme (TraitCollectionSupport)
+
+/**
+ Returns a copy of this scheme configured with the given trait collection.
+
+ @see MDCTypographyScheme's +resolveScheme:forTraitCollection: for more details.
+ */
++ (nonnull MDCContainerScheme *)resolveScheme:(nonnull id<MDCContainerScheming>)scheme
+                           forTraitCollection:(nonnull UITraitCollection *)traitCollection;
 
 @end

--- a/components/schemes/Container/src/MDCContainerScheme.m
+++ b/components/schemes/Container/src/MDCContainerScheme.m
@@ -27,4 +27,34 @@
   return self;
 }
 
++ (MDCContainerScheme *)resolveScheme:(id<MDCContainerScheming>)scheme
+                   forTraitCollection:(UITraitCollection *)traitCollection {
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.typographyScheme = [MDCTypographyScheme resolveScheme:scheme.typographyScheme
+                                                     forTraitCollection:traitCollection];
+  return containerScheme;
+}
+
+#pragma mark - NSMutableCopying
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+  MDCContainerScheme *copy = [[MDCContainerScheme alloc] init];
+  copy.colorScheme = [self.colorScheme mutableCopy];
+  copy.typographyScheme = [self.typographyScheme mutableCopy];
+  copy.shapeScheme = [self.shapeScheme mutableCopy];
+  return copy;
+}
+
+@end
+
+@implementation MDCContainerScheme (TraitCollectionSupport)
+
++ (MDCContainerScheme *)resolveScheme:(id<MDCContainerScheming>)scheme
+                   forTraitCollection:(UITraitCollection *)traitCollection {
+  MDCContainerScheme *copy = [scheme mutableCopy];
+  copy.typographyScheme = [MDCTypographyScheme resolveScheme:copy.typographyScheme
+                                          forTraitCollection:traitCollection];
+  return copy;
+}
+
 @end

--- a/components/schemes/Shape/src/MDCShapeScheme.h
+++ b/components/schemes/Shape/src/MDCShapeScheme.h
@@ -16,6 +16,8 @@
 #import <UIKit/UIKit.h>
 #import "MDCShapeCategory.h"
 
+@class MDCShapeScheme;
+
 /**
  A simple shape scheme that provides semantic meaning.
  Each MDCShapeCategory is mapped to a component.
@@ -40,6 +42,24 @@
  */
 @property(nonnull, readonly, nonatomic) MDCShapeCategory *largeComponentShape;
 
+@optional
+
+/**
+ Returns a mutable copy of the receiver.
+
+ @note This method's protocol will eventually require conformance to NSMutableCopying and this
+ method will become required.
+ */
+- (nonnull MDCShapeScheme *)mutableCopy;
+
+/**
+ Returns a mutable copy of the receiver with the given zone.
+
+ @note This method's protocol will eventually require conformance to NSMutableCopying and this
+ method will become required.
+ */
+- (nonnull id)mutableCopyWithZone:(nullable NSZone *)zone;
+
 @end
 
 /**
@@ -56,7 +76,7 @@ typedef NS_ENUM(NSInteger, MDCShapeSchemeDefaults) {
  A simple implementation of @c MDCShapeScheming that provides Material default shape values from
  which basic customizations can be made.
  */
-@interface MDCShapeScheme : NSObject <MDCShapeScheming>
+@interface MDCShapeScheme : NSObject <MDCShapeScheming, NSMutableCopying>
 
 // Redeclare protocol properties as readwrite
 @property(nonnull, readwrite, nonatomic) MDCShapeCategory *smallComponentShape;

--- a/components/schemes/Shape/src/MDCShapeScheme.m
+++ b/components/schemes/Shape/src/MDCShapeScheme.m
@@ -37,4 +37,14 @@
   return self;
 }
 
+#pragma mark - NSMutableCopying
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+  MDCShapeScheme *copy = [[MDCShapeScheme alloc] init];
+  copy.smallComponentShape = self.smallComponentShape;
+  copy.mediumComponentShape = self.mediumComponentShape;
+  copy.largeComponentShape = self.largeComponentShape;
+  return copy;
+}
+
 @end

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -180,6 +180,33 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 
 @end
 
+@interface MDCTypographyScheme (TraitCollectionSupport)
+
+/**
+ Returns a copy of this typography scheme configured with the given trait collection.
+
+ Each font will be adjusted to the same family, weight and traits, but their point size will be
+ based on the given trait collection's preferred content size category and each font's attached
+ @c mdc_scalingCurve.
+
+ If the device is running iOS 9 and not in an extension, then @c traitCollection will be
+ ignored and the UIApplication sharedApplication's preferredContentSizeCategory will be used
+ instead.
+
+ If the device is running iOS 9 and in an extension, then @c traitCollection will be
+ ignored and the returned font will be scaled with UIContentSizeCategoryLarge.
+
+ @param traitCollection The trait collection that should be used to resolve the fonts.
+ @return A copy of this instance where each font's point size is determined by its
+ @c mdc_scalingCurve for the @c traitCollection's corresponding content size category, or if the
+ font has no @c mdc_scalingCurve then the font will not be modified.
+ @seealso MDCFontScaler
+ */
++ (nonnull MDCTypographyScheme *)resolveScheme:(nonnull id<MDCTypographyScheming>)scheme
+                            forTraitCollection:(nonnull UITraitCollection *)traitCollection;
+
+@end
+
 @interface MDCTypographyScheme (ToBeDeprecated)
 
 /**

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -178,16 +178,18 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  */
 - (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults;
 
-/**
- Initializes the typography scheme with the values associated with the given defaults and fonts
- resolved with the given trait collection.
- */
-- (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults
-                         traitCollection:(nonnull UITraitCollection *)traitCollection;
-
 @end
 
 @interface MDCTypographyScheme (TraitCollectionSupport)
+
+/**
+ Initializes the typography scheme with the values associated with the given defaults and fonts
+ resolved with the given trait collection.
+
+ @see MDCTypographyScheme's +resolveScheme:forTraitCollection: for more details.
+ */
+- (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults
+                         traitCollection:(nonnull UITraitCollection *)traitCollection;
 
 /**
  Returns a copy of this typography scheme configured with the given trait collection.

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -178,6 +178,13 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  */
 - (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults;
 
+/**
+ Initializes the typography scheme with the values associated with the given defaults and fonts
+ resolved with the given trait collection.
+ */
+- (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults
+                         traitCollection:(nonnull UITraitCollection *)traitCollection;
+
 @end
 
 @interface MDCTypographyScheme (TraitCollectionSupport)

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class MDCTypographyScheme;
+
 /**
  A simple typography scheme that provides semantic fonts. There are no optional
  properties, all fonts must be provided, supporting more reliable typography theming.
@@ -110,6 +112,22 @@
  */
 @property(nonatomic, assign, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 
+/**
+ Returns a mutable copy of the receiver.
+
+ @note This protocol will eventually require conformance to NSMutableCopying and this method will
+ become required.
+ */
+- (nonnull MDCTypographyScheme *)mutableCopy;
+
+/**
+ Returns a mutable copy of the receiver with the given zone.
+
+ @note This method's protocol will eventually require conformance to NSMutableCopying and this
+ method will become required.
+ */
+- (nonnull id)mutableCopyWithZone:(nullable NSZone *)zone;
+
 @end
 
 /**
@@ -135,7 +153,7 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
  A simple implementation of @c MDCTypographyScheming that provides Material default fonts
  from which basic customizations can be made.
  */
-@interface MDCTypographyScheme : NSObject <MDCTypographyScheming, NSCopying>
+@interface MDCTypographyScheme : NSObject <MDCTypographyScheming, NSCopying, NSMutableCopying>
 
 // Redeclare protocol properties as readwrite
 @property(nonatomic, nonnull, readwrite, copy) UIFont *headline1;

--- a/components/schemes/Typography/src/MDCTypographyScheme.m
+++ b/components/schemes/Typography/src/MDCTypographyScheme.m
@@ -118,6 +118,15 @@
   return self;
 }
 
+- (instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults
+                 traitCollection:(UITraitCollection *)traitCollection {
+  self = [self initWithDefaults:defaults];
+  if (self) {
+    [MDCTypographyScheme mutateScheme:self forTraitCollection:traitCollection];
+  }
+  return self;
+}
+
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
@@ -152,20 +161,25 @@
                     forTraitCollection:(UITraitCollection *)traitCollection {
   MDCTypographyScheme *resolved =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
-  resolved.headline1 = [scheme.headline1 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.headline2 = [scheme.headline2 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.headline3 = [scheme.headline3 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.headline4 = [scheme.headline4 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.headline5 = [scheme.headline5 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.headline6 = [scheme.headline6 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.subtitle1 = [scheme.subtitle1 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.subtitle2 = [scheme.subtitle2 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.body1 = [scheme.body1 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.body2 = [scheme.body2 mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.caption = [scheme.caption mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.button = [scheme.button mdc_scaledFontForTraitCollection:traitCollection];
-  resolved.overline = [scheme.overline mdc_scaledFontForTraitCollection:traitCollection];
+  [self mutateScheme:resolved forTraitCollection:traitCollection];
   return resolved;
+}
+
++ (void)mutateScheme:(MDCTypographyScheme *)scheme
+    forTraitCollection:(UITraitCollection *)traitCollection {
+  scheme.headline1 = [scheme.headline1 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.headline2 = [scheme.headline2 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.headline3 = [scheme.headline3 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.headline4 = [scheme.headline4 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.headline5 = [scheme.headline5 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.headline6 = [scheme.headline6 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.subtitle1 = [scheme.subtitle1 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.subtitle2 = [scheme.subtitle2 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.body1 = [scheme.body1 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.body2 = [scheme.body2 mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.caption = [scheme.caption mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.button = [scheme.button mdc_scaledFontForTraitCollection:traitCollection];
+  scheme.overline = [scheme.overline mdc_scaledFontForTraitCollection:traitCollection];
 }
 
 @end

--- a/components/schemes/Typography/src/MDCTypographyScheme.m
+++ b/components/schemes/Typography/src/MDCTypographyScheme.m
@@ -148,4 +148,24 @@
   self.useCurrentContentSizeCategoryWhenApplied = mdc_adjustsFontForContentSizeCategory;
 }
 
++ (MDCTypographyScheme *)resolveScheme:(id<MDCTypographyScheming>)scheme
+                    forTraitCollection:(UITraitCollection *)traitCollection {
+  MDCTypographyScheme *resolved =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
+  resolved.headline1 = [scheme.headline1 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.headline2 = [scheme.headline2 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.headline3 = [scheme.headline3 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.headline4 = [scheme.headline4 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.headline5 = [scheme.headline5 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.headline6 = [scheme.headline6 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.subtitle1 = [scheme.subtitle1 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.subtitle2 = [scheme.subtitle2 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.body1 = [scheme.body1 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.body2 = [scheme.body2 mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.caption = [scheme.caption mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.button = [scheme.button mdc_scaledFontForTraitCollection:traitCollection];
+  resolved.overline = [scheme.overline mdc_scaledFontForTraitCollection:traitCollection];
+  return resolved;
+}
+
 @end

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -192,4 +192,77 @@
   XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
+- (void)test201902ScalesOniOS10AndUpWhenTraitEnvironmentIsProvided {
+  if (@available(iOS 10.0, *)) {
+    // Given
+    MDCTypographyScheme *schemeWithNoTraitCollection =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
+
+    // When
+    UITraitCollection *traitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraExtraExtraLarge];
+    id<MDCTypographyScheming> scheme =
+        [MDCTypographyScheme resolveScheme:schemeWithNoTraitCollection
+                        forTraitCollection:traitCollection];
+
+    // Then
+    XCTAssertGreaterThanOrEqual(scheme.headline1.pointSize,
+                                schemeWithNoTraitCollection.headline1.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.headline2.pointSize,
+                                schemeWithNoTraitCollection.headline2.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.headline3.pointSize,
+                                schemeWithNoTraitCollection.headline3.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.headline4.pointSize,
+                                schemeWithNoTraitCollection.headline4.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.headline5.pointSize,
+                                schemeWithNoTraitCollection.headline5.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.headline6.pointSize,
+                                schemeWithNoTraitCollection.headline6.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.subtitle1.pointSize,
+                                schemeWithNoTraitCollection.subtitle1.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.subtitle2.pointSize,
+                                schemeWithNoTraitCollection.subtitle2.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.body1.pointSize,
+                                schemeWithNoTraitCollection.body1.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.body2.pointSize,
+                                schemeWithNoTraitCollection.body2.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.caption.pointSize,
+                                schemeWithNoTraitCollection.caption.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.button.pointSize,
+                                schemeWithNoTraitCollection.button.pointSize);
+    XCTAssertGreaterThanOrEqual(scheme.overline.pointSize,
+                                schemeWithNoTraitCollection.overline.pointSize);
+  }
+}
+
+- (void)test201804DoesNotScaleOniOS10AndUpWhenTraitEnvironmentIsProvided {
+  if (@available(iOS 10.0, *)) {
+    // Given
+    MDCTypographyScheme *schemeWithNoTraitCollection =
+        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+
+    // When
+    UITraitCollection *traitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraLarge];
+    id<MDCTypographyScheming> scheme =
+        [MDCTypographyScheme resolveScheme:schemeWithNoTraitCollection
+                        forTraitCollection:traitCollection];
+
+    // Then
+    XCTAssertEqual(scheme.headline1.pointSize, schemeWithNoTraitCollection.headline1.pointSize);
+    XCTAssertEqual(scheme.headline2.pointSize, schemeWithNoTraitCollection.headline2.pointSize);
+    XCTAssertEqual(scheme.headline3.pointSize, schemeWithNoTraitCollection.headline3.pointSize);
+    XCTAssertEqual(scheme.headline4.pointSize, schemeWithNoTraitCollection.headline4.pointSize);
+    XCTAssertEqual(scheme.headline5.pointSize, schemeWithNoTraitCollection.headline5.pointSize);
+    XCTAssertEqual(scheme.headline6.pointSize, schemeWithNoTraitCollection.headline6.pointSize);
+    XCTAssertEqual(scheme.subtitle1.pointSize, schemeWithNoTraitCollection.subtitle1.pointSize);
+    XCTAssertEqual(scheme.subtitle2.pointSize, schemeWithNoTraitCollection.subtitle2.pointSize);
+    XCTAssertEqual(scheme.body1.pointSize, schemeWithNoTraitCollection.body1.pointSize);
+    XCTAssertEqual(scheme.body2.pointSize, schemeWithNoTraitCollection.body2.pointSize);
+    XCTAssertEqual(scheme.caption.pointSize, schemeWithNoTraitCollection.caption.pointSize);
+    XCTAssertEqual(scheme.button.pointSize, schemeWithNoTraitCollection.button.pointSize);
+    XCTAssertEqual(scheme.overline.pointSize, schemeWithNoTraitCollection.overline.pointSize);
+  }
+}
+
 @end


### PR DESCRIPTION
This PR is a work in progress.

Design doc: [go/material-ios-theming-with-trait-collections](http://go/material-ios-theming-with-trait-collections)

Closes https://github.com/material-components/material-components-ios/issues/7622
