### PR TITLE
[Banner] Fix horizontal constraint between text label and button.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -136,6 +136,8 @@ static NSString *const exampleExtraLongText =
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
+  self.contentView.frame = self.view.bounds;
+
   CGSize bannerViewSize = [self.bannerView sizeThatFits:self.view.bounds.size];
   // Adjust bannerViewContainer's frame
   CGFloat topAreaInset = 0.0f;
@@ -144,6 +146,7 @@ static NSString *const exampleExtraLongText =
   }
   self.bannerView.frame =
       CGRectMake(0.0f, topAreaInset, bannerViewSize.width, bannerViewSize.height);
+  [self.bannerView setNeedsUpdateConstraints];
 }
 
 #pragma mark - Internal helpers

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -60,9 +60,9 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 // Buttons constraints
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintLeading;
 @property(nonatomic, readwrite, strong)
-    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabel;
+    NSLayoutConstraint *buttonContainerConstraintWidthWithLeadingButton;
 @property(nonatomic, readwrite, strong)
-    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabelGreater;
+    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabel;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTopWithMargin;
 @property(nonatomic, readwrite, strong)
@@ -220,28 +220,23 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.textLabelConstraintLeadingWithMargin =
       [self.textLabel.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
                                                    constant:kLeadingPadding];
-  [self.textLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh - 1
-                                                  forAxis:UILayoutConstraintAxisHorizontal];
 }
 
 - (void)setUpButtonContainerConstraints {
   self.buttonContainerConstraintLeading = [self.buttonContainerView.leadingAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
                      constant:kLeadingPadding];
+  self.buttonContainerConstraintWidthWithLeadingButton = [self.buttonContainerView.widthAnchor constraintEqualToAnchor:self.leadingButton.widthAnchor];
   self.buttonContainerConstraintTrailing = [self.buttonContainerView.trailingAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
                      constant:-kTrailingPadding];
   self.buttonContainerConstraintBottom = [self.buttonContainerView.bottomAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
                      constant:-kBottomPadding];
-  self.buttonContainerConstraintLeadingWithTextLabel = [self.buttonContainerView.leadingAnchor
-      constraintEqualToAnchor:self.textLabel.trailingAnchor
-                     constant:kHorizontalSpaceBetweenTextLabelAndButton];
-  self.buttonContainerConstraintLeadingWithTextLabel.priority = UILayoutPriorityDefaultHigh;
-  self.buttonContainerConstraintLeadingWithTextLabelGreater =
+  self.buttonContainerConstraintLeadingWithTextLabel =
       [self.buttonContainerView.leadingAnchor
-          constraintGreaterThanOrEqualToAnchor:self.textLabel.trailingAnchor
-                                      constant:kHorizontalSpaceBetweenTextLabelAndButton];
+          constraintEqualToAnchor:self.textLabel.trailingAnchor
+       constant:kHorizontalSpaceBetweenTextLabelAndButton];
   self.buttonContainerConstraintTopWithMargin =
       [self.buttonContainerView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
                                                          constant:kTopPaddingSmall];
@@ -269,6 +264,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.leadingButtonConstraintTrailingWithTrailingButton =
       [self.leadingButton.trailingAnchor constraintEqualToAnchor:self.trailingButton.leadingAnchor
                                                         constant:-kButtonHorizontalIntervalSpace];
+  [self.leadingButton setContentCompressionResistancePriority:UILayoutPriorityRequired
+                                                      forAxis:UILayoutConstraintAxisHorizontal];
+  [self.leadingButton setContentHuggingPriority:UILayoutPriorityRequired
+                                         forAxis:UILayoutConstraintAxisHorizontal];
   self.trailingButtonConstraintBottom = [self.trailingButton.bottomAnchor
       constraintEqualToAnchor:self.buttonContainerView.bottomAnchor];
   self.trailingButtonConstraintTop =
@@ -276,6 +275,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
                                                     constant:kButtonVerticalIntervalSpace];
   self.trailingButtonConstraintTrailing = [self.trailingButton.trailingAnchor
       constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
+  [self.trailingButton setContentCompressionResistancePriority:UILayoutPriorityRequired
+                                                      forAxis:UILayoutConstraintAxisHorizontal];
+  [self.trailingButton setContentHuggingPriority:UILayoutPriorityRequired
+                                         forAxis:UILayoutConstraintAxisHorizontal];
 }
 
 - (void)setUpDividerConstraints {
@@ -299,8 +302,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.textLabelConstraintTop.active = NO;
   self.textLabelConstraintCenterY.active = NO;
   self.buttonContainerConstraintLeading.active = NO;
+  self.buttonContainerConstraintWidthWithLeadingButton.active = NO;
   self.buttonContainerConstraintLeadingWithTextLabel.active = NO;
-  self.buttonContainerConstraintLeadingWithTextLabelGreater.active = NO;
   self.buttonContainerConstraintTrailing.active = NO;
   self.buttonContainerConstraintTopWithMargin.active = NO;
   self.buttonContainerConstraintTopWithImageViewGreater.active = NO;
@@ -402,8 +405,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       self.imageViewConstraintBottom.active = YES;
     }
     self.textLabelConstraintCenterY.active = YES;
+    self.buttonContainerConstraintWidthWithLeadingButton.active = YES;
     self.buttonContainerConstraintLeadingWithTextLabel.active = YES;
-    self.buttonContainerConstraintLeadingWithTextLabelGreater.active = YES;
     self.buttonContainerConstraintTopWithMargin.active = YES;
   } else {
     if (!self.imageView.hidden) {

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -61,8 +61,9 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintLeading;
 @property(nonatomic, readwrite, strong)
     NSLayoutConstraint *buttonContainerConstraintWidthWithLeadingButton;
-@property(nonatomic, readwrite, strong)
-    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabel; // The horizontal constraint between button container and text label.
+@property(nonatomic, readwrite, strong) NSLayoutConstraint
+    *buttonContainerConstraintLeadingWithTextLabel;  // The horizontal constraint between button
+                                                     // container and text label.
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTopWithMargin;
 @property(nonatomic, readwrite, strong)

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -62,7 +62,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong)
     NSLayoutConstraint *buttonContainerConstraintWidthWithLeadingButton;
 @property(nonatomic, readwrite, strong)
-    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabel;
+    NSLayoutConstraint *buttonContainerConstraintLeadingWithTextLabel; // The horizontal constraint between button container and text label.
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTopWithMargin;
 @property(nonatomic, readwrite, strong)

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -226,17 +226,17 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.buttonContainerConstraintLeading = [self.buttonContainerView.leadingAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor
                      constant:kLeadingPadding];
-  self.buttonContainerConstraintWidthWithLeadingButton = [self.buttonContainerView.widthAnchor constraintEqualToAnchor:self.leadingButton.widthAnchor];
+  self.buttonContainerConstraintWidthWithLeadingButton =
+      [self.buttonContainerView.widthAnchor constraintEqualToAnchor:self.leadingButton.widthAnchor];
   self.buttonContainerConstraintTrailing = [self.buttonContainerView.trailingAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor
                      constant:-kTrailingPadding];
   self.buttonContainerConstraintBottom = [self.buttonContainerView.bottomAnchor
       constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor
                      constant:-kBottomPadding];
-  self.buttonContainerConstraintLeadingWithTextLabel =
-      [self.buttonContainerView.leadingAnchor
-          constraintEqualToAnchor:self.textLabel.trailingAnchor
-       constant:kHorizontalSpaceBetweenTextLabelAndButton];
+  self.buttonContainerConstraintLeadingWithTextLabel = [self.buttonContainerView.leadingAnchor
+      constraintEqualToAnchor:self.textLabel.trailingAnchor
+                     constant:kHorizontalSpaceBetweenTextLabelAndButton];
   self.buttonContainerConstraintTopWithMargin =
       [self.buttonContainerView.topAnchor constraintEqualToAnchor:self.layoutMarginsGuide.topAnchor
                                                          constant:kTopPaddingSmall];
@@ -267,7 +267,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   [self.leadingButton setContentCompressionResistancePriority:UILayoutPriorityRequired
                                                       forAxis:UILayoutConstraintAxisHorizontal];
   [self.leadingButton setContentHuggingPriority:UILayoutPriorityRequired
-                                         forAxis:UILayoutConstraintAxisHorizontal];
+                                        forAxis:UILayoutConstraintAxisHorizontal];
   self.trailingButtonConstraintBottom = [self.trailingButton.bottomAnchor
       constraintEqualToAnchor:self.buttonContainerView.bottomAnchor];
   self.trailingButtonConstraintTop =
@@ -276,7 +276,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.trailingButtonConstraintTrailing = [self.trailingButton.trailingAnchor
       constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
   [self.trailingButton setContentCompressionResistancePriority:UILayoutPriorityRequired
-                                                      forAxis:UILayoutConstraintAxisHorizontal];
+                                                       forAxis:UILayoutConstraintAxisHorizontal];
   [self.trailingButton setContentHuggingPriority:UILayoutPriorityRequired
                                          forAxis:UILayoutConstraintAxisHorizontal];
 }

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -64,6 +64,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong) NSLayoutConstraint
     *buttonContainerConstraintLeadingWithTextLabel;  // The horizontal constraint between button
                                                      // container and text label.
+
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTopWithMargin;
 @property(nonatomic, readwrite, strong)

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -64,7 +64,6 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong) NSLayoutConstraint
     *buttonContainerConstraintLeadingWithTextLabel;  // The horizontal constraint between button
                                                      // container and text label.
-
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *buttonContainerConstraintTopWithMargin;
 @property(nonatomic, readwrite, strong)


### PR DESCRIPTION
Fix the issue that label are not correctly laid out and shrunk because of low compression priority.

An example content view update issue is fixed to show a correct example screenshot.

Note: this issue doesn't happen on iPhone X and only happens on iPhone 7.

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 7 - 2019-06-19 at 13 34 37](https://user-images.githubusercontent.com/8836258/59788415-a6f16400-9299-11e9-8e67-dbf9f23f0b03.png) | ![Simulator Screen Shot - iPhone 7 - 2019-06-19 at 13 31 35](https://user-images.githubusercontent.com/8836258/59788440-b96b9d80-9299-11e9-9599-9f77695552d1.png) |
|![Simulator Screen Shot - iPhone 7 - 2019-06-19 at 13 34 38](https://user-images.githubusercontent.com/8836258/59788417-ab1d8180-9299-11e9-9171-ce32ef64d9f9.png) |   ![Simulator Screen Shot - iPhone 7 - 2019-06-19 at 13 31 36](https://user-images.githubusercontent.com/8836258/59788451-bffa1500-9299-11e9-93a7-37aa4ab80869.png) |
