### PR TITLE
[Banner] apply constraints to trailingButton even it is hidden.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -426,7 +426,6 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 - (void)updateButtonsConstraintsWithLayoutStyle:(MDCBannerViewLayoutStyle)layoutStyle {
   if (self.trailingButton.hidden) {
-    self.leadingButtonConstraintLeading.active = YES;
     self.leadingButtonConstraintTrailing.active = YES;
     self.leadingButtonConstraintCenterY.active = YES;
   } else {
@@ -437,10 +436,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       self.leadingButtonConstraintTrailingWithTrailingButton.active = YES;
     }
     self.leadingButtonConstraintTop.active = YES;
-    self.leadingButtonConstraintLeading.active = YES;
-    self.trailingButtonConstraintTrailing.active = YES;
-    self.trailingButtonConstraintBottom.active = YES;
   }
+  self.leadingButtonConstraintLeading.active = YES;
+  self.trailingButtonConstraintTrailing.active = YES;
+  self.trailingButtonConstraintBottom.active = YES;
 }
 
 - (MDCBannerViewLayoutStyle)layoutStyleForSizeToFit:(CGSize)sizeToFit {


### PR DESCRIPTION
TrailingButton shows missing position constraints because no constraint was active when it is hidden.

| Before | After |
| --- | --- |
| <img width="1235" alt="Screen Shot 2019-06-19 at 3 49 18 PM" src="https://user-images.githubusercontent.com/8836258/59796048-a3b2a400-92aa-11e9-8d8b-085adbea481f.png"> | <img width="1301" alt="Screen Shot 2019-06-19 at 3 50 32 PM" src="https://user-images.githubusercontent.com/8836258/59796054-a7462b00-92aa-11e9-8e87-713603ec0ed3.png"> |

