### PR TITLE
[Tabs2] Add example view controller.

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/project.pbxproj
+++ b/catalog/MDCCatalog.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		66CD19292072A54000DE6340 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CD19282072A54000DE6340 /* AppTheme.swift */; };
 		66D3389520730A3E00FFA1AB /* MDCThemePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D3389420730A3E00FFA1AB /* MDCThemePickerViewController.swift */; };
 		75F4516F2130AB879A7EDBD5 /* Pods_MDCCatalog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A55EA1CC69E40D5EF866144 /* Pods_MDCCatalog.framework */; };
+		A77B0FE922BBDBB400C0CEB3 /* MDCTabBarViewTypicalExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A77B0FE822BBDBB400C0CEB3 /* MDCTabBarViewTypicalExampleViewController.m */; };
 		DE309CF31C8DEB8400E73247 /* MDCCatalogComponentsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE309CF21C8DEB8400E73247 /* MDCCatalogComponentsController.swift */; };
 		DEF64EA41C8DEE83007C4EA0 /* MDCCatalogCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF64EA31C8DEE83007C4EA0 /* MDCCatalogCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
@@ -122,6 +123,7 @@
 		88AB955E76304B684707293E /* Pods_MDCActionExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MDCActionExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90B4FE989AA27838D0FB6A13 /* Pods-MDCCatalog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MDCCatalog.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MDCCatalog/Pods-MDCCatalog.debug.xcconfig"; sourceTree = "<group>"; };
 		93314CA227FB65FEC87098C3 /* EarlGrey.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EarlGrey.framework; path = Pods/EarlGrey/EarlGrey/EarlGrey.framework; sourceTree = SOURCE_ROOT; };
+		A77B0FE822BBDBB400C0CEB3 /* MDCTabBarViewTypicalExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MDCTabBarViewTypicalExampleViewController.m; path = ../../components/Tabs2/examples/MDCTabBarViewTypicalExampleViewController.m; sourceTree = "<group>"; };
 		BB375464F626CD555584A27F /* Pods_MDCSnapshotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MDCSnapshotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C250A4553B960CD6E1604CB7 /* Pods-MDCCatalog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MDCCatalog.release.xcconfig"; path = "Pods/Target Support Files/Pods-MDCCatalog/Pods-MDCCatalog.release.xcconfig"; sourceTree = "<group>"; };
 		D0ECF9608E1CF6AA39139933 /* Pods-MDCSnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MDCSnapshotTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MDCSnapshotTests/Pods-MDCSnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				66D3389420730A3E00FFA1AB /* MDCThemePickerViewController.swift */,
 				5CBA08362090E4DF009EA9D0 /* MDCMenuViewController.swift */,
 				665A34DE1C6BDAE700962055 /* Resources */,
+				A77B0FE822BBDBB400C0CEB3 /* MDCTabBarViewTypicalExampleViewController.m */,
 			);
 			path = MDCCatalog;
 			sourceTree = "<group>";
@@ -498,6 +501,7 @@
 				66CD19292072A54000DE6340 /* AppTheme.swift in Sources */,
 				664524B91C6BA62A001ADBF8 /* MDCNodeListViewController.swift in Sources */,
 				64F6D8811F91522A00AA4B24 /* MDCCatalogDebugAlert.swift in Sources */,
+				A77B0FE922BBDBB400C0CEB3 /* MDCTabBarViewTypicalExampleViewController.m in Sources */,
 				5CBA08372090E4DF009EA9D0 /* MDCMenuViewController.swift in Sources */,
 				64F6D8831F915CA600AA4B24 /* MDCDebugSafeAreaInsetsView.swift in Sources */,
 				66D3389520730A3E00FFA1AB /* MDCThemePickerViewController.swift in Sources */,

--- a/components/Tabs2/BUILD
+++ b/components/Tabs2/BUILD
@@ -15,6 +15,7 @@
 
 load(
     "//:material_components_ios.bzl",
+    "mdc_examples_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
@@ -34,6 +35,14 @@ mdc_objc_library(
     name = "privateHeaders",
     hdrs = glob(["src/private/*.h"]),
     testonly = 1,
+)
+
+mdc_examples_objc_library(
+    name = "ObjcExamples",
+    deps = [
+        ":Tabs2",
+        "//components/schemes/Container",
+    ],
 )
 
 mdc_unit_test_objc_library(

--- a/components/Tabs2/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs2/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -45,7 +45,8 @@ static NSString *const kExampleTitle = @"TabBarView";
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 
   self.tabBar = [[MDCTabBarView alloc] init];
-  self.tabBar.bounds = CGRectMake(0, 0, 48, 48);
+  CGSize barIntrinsicContentSize = self.tabBar.intrinsicContentSize;
+  self.tabBar.bounds = CGRectMake(0, 0, 0, barIntrinsicContentSize.width);
   // TODO: Change this to theming (or at least .primaryColor) once we have content.
   self.tabBar.backgroundColor = self.containerScheme.colorScheme.primaryColorVariant;
   self.tabBar.translatesAutoresizingMaskIntoConstraints = NO;

--- a/components/Tabs2/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs2/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -1,0 +1,77 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import <MaterialComponents/MaterialContainerScheme.h>
+#import "MaterialTabs2.h"
+
+static NSString *const kExampleTitle = @"TabBarView";
+
+/**
+ Typical use example showing how to place an @c MDCTabBarView within another view.
+ */
+@interface MDCTabBarViewTypicalExampleViewController : UIViewController
+
+/** The tab bar for this example. */
+@property(nonatomic, strong) MDCTabBarView *tabBar;
+
+/** The container scheme injected into this example. */
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+
+@end
+
+@implementation MDCTabBarViewTypicalExampleViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.title = kExampleTitle;
+
+  if (!self.containerScheme) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+
+  self.tabBar = [[MDCTabBarView alloc] init];
+  self.tabBar.bounds = CGRectMake(0, 0, 48, 48);
+  // TODO: Change this to theming (or at least .primaryColor) once we have content.
+  self.tabBar.backgroundColor = self.containerScheme.colorScheme.primaryColorVariant;
+  self.tabBar.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.view addSubview:self.tabBar];
+
+  if (@available(iOS 11.0, *)) {
+    [self.view.layoutMarginsGuide.topAnchor constraintEqualToAnchor:self.tabBar.topAnchor].active =
+        YES;
+  } else {
+    [self.topLayoutGuide.bottomAnchor constraintEqualToAnchor:self.tabBar.topAnchor].active = YES;
+  }
+  [self.view.leftAnchor constraintEqualToAnchor:self.tabBar.leftAnchor].active = YES;
+  [self.view.rightAnchor constraintEqualToAnchor:self.tabBar.rightAnchor].active = YES;
+}
+
+@end
+
+#pragma mark - CatalogByConvention
+@implementation MDCTabBarViewTypicalExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Tab Bar", kExampleTitle ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
+}
+
+@end

--- a/components/Tabs2/src/MDCTabBarView.m
+++ b/components/Tabs2/src/MDCTabBarView.m
@@ -16,4 +16,12 @@
 
 @implementation MDCTabBarView
 
+- (CGSize)intrinsicContentSize {
+  return CGSizeMake(UIViewNoIntrinsicMetric, 48);
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+  return CGSizeMake(size.width, MAX(size.height, 48));
+}
+
 @end

--- a/components/Tabs2/src/MDCTabBarView.m
+++ b/components/Tabs2/src/MDCTabBarView.m
@@ -14,14 +14,17 @@
 
 #import "MDCTabBarView.h"
 
+/** Minimum (typical) height of a Material Tab bar. */
+static const CGFloat kMinHeight = 48;
+
 @implementation MDCTabBarView
 
 - (CGSize)intrinsicContentSize {
-  return CGSizeMake(UIViewNoIntrinsicMetric, 48);
+  return CGSizeMake(UIViewNoIntrinsicMetric, kMinHeight);
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
-  return CGSizeMake(size.width, MAX(size.height, 48));
+  return CGSizeMake(size.width, MAX(size.height, kMinHeight));
 }
 
 @end


### PR DESCRIPTION
Creates a basic example view controller for showing the TabBarView.

|iPhone SE (iOS 9.3)|iPhone XR (iOS 12.0|
|---|---|
|![Simulator Screen Shot - iPhone SE - 2019-06-20 at 14 04 37](https://user-images.githubusercontent.com/1753199/59873062-34e85000-9369-11e9-9f90-89d028bb7310.png)|![Simulator Screen Shot - iPhone XR - 2019-06-20 at 14 05 26](https://user-images.githubusercontent.com/1753199/59873069-37e34080-9369-11e9-905b-175d308a8d0d.png)|



Closes #7659 