### PR TITLE
[FlexibleHeader] Ensures the frame is correct under UIKit for Mac

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -141,6 +141,15 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
 - (void)didMoveToParentViewController:(UIViewController *)parent {
   [super didMoveToParentViewController:parent];
 
+#if TARGET_OS_UIKITFORMAC
+    // When running under UIKit for Mac, the window size may not match the value returned by
+    // `[UIScreen mainScreen].bounds` when `commonMDCFlexibleHeaderViewControllerInit` was
+    // called, so the width will be updated here to match the hosting view.
+    CGRect headerFrame = _headerView.frame;
+    headerFrame.size.width = CGRectGetWidth(_headerView.superview.bounds);
+    _headerView.frame = headerFrame;
+#endif
+
   // The header depends on the tracking scroll view to know how tall it should be.
   // If there is no tracking scroll view then we have to poke the header into sizing itself.
   if (!_headerView.trackingScrollView) {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -142,12 +142,12 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   [super didMoveToParentViewController:parent];
 
 #if TARGET_OS_UIKITFORMAC
-    // When running under UIKit for Mac, the window size may not match the value returned by
-    // `[UIScreen mainScreen].bounds` when `commonMDCFlexibleHeaderViewControllerInit` was
-    // called, so the width will be updated here to match the hosting view.
-    CGRect headerFrame = _headerView.frame;
-    headerFrame.size.width = CGRectGetWidth(_headerView.superview.bounds);
-    _headerView.frame = headerFrame;
+  // When running under UIKit for Mac, the window size may not match the value returned by
+  // `[UIScreen mainScreen].bounds` when `commonMDCFlexibleHeaderViewControllerInit` was
+  // called, so the width will be updated here to match the hosting view.
+  CGRect headerFrame = _headerView.frame;
+  headerFrame.size.width = CGRectGetWidth(_headerView.superview.bounds);
+  _headerView.frame = headerFrame;
 #endif
 
   // The header depends on the tracking scroll view to know how tall it should be.


### PR DESCRIPTION
When running under UIKit for Mac, the window size may not match the value returned by `[UIScreen mainScreen].bounds` when `commonMDCFlexibleHeaderViewControllerInit` was called, so the width is updated when the view controller is added to a parent view controller.

This change is wrapped with a `#if` test so that it will only affect UIKit for Mac. It should never be necessary on iOS devices and it's possible that there are existing users who modify the frame and do not expect it to be changed after initialisation. If this (presumably unlikely) regression is acceptable then the platform tests could be removed.

closes #7667

Video showing corrected behaviour: https://www.dropbox.com/s/xc6mxofzey1m78q/FlexibleBarGood.mov?dl=0