### PR TITLE
[ThumbTrack] Use @synthesize for touchController to avoid warning

### DIFF
--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -178,6 +178,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
 
 @synthesize thumbEnabledColor = _thumbEnabledColor;
 @synthesize trackOnColor = _trackOnColor;
+@synthesize touchController = _touchController;
 
 // TODO(iangordon): ThumbView is not respecting the bounds of ThumbTrack
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -1294,10 +1295,6 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
 
 - (MDCNumericValueLabel *)numericValueLabel {
   return _valueLabel;
-}
-
-- (MDCInkTouchController *)touchController {
-  return _touchController;
 }
 
 - (MDCDiscreteDotView *)discreteDotView {


### PR DESCRIPTION
As touchController is a property defined in a class extension, it
is auto-synthesized (if enabled when compiling the file) because
there are no setters in the class @implementation.

However, since there is a setter in a category, two setters are
generated, thus causing the following linker warning:

  ld: warning: instance method 'touchController' in category from MDCThumbTrack.o overrides method from class in MDCThumbTrack.o

Instead remove the custom setter and uses @synthesize to ensure
that only one implementation of the setter exists.

Closes #7669.