### PR TITLE
[BottomSheet] Added test to avoid referencing UIWebView under UIKit for Mac

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -31,8 +31,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   if ([viewController.view isKindOfClass:[UIScrollView class]]) {
     scrollView = (UIScrollView *)viewController.view;
+#if !TARGET_OS_UIKITFORMAC
   } else if ([viewController.view isKindOfClass:[UIWebView class]]) {
     scrollView = ((UIWebView *)viewController.view).scrollView;
+#endif
   } else if ([viewController isKindOfClass:[UICollectionViewController class]]) {
     scrollView = ((UICollectionViewController *)viewController).collectionView;
   }


### PR DESCRIPTION
`MDCBottomSheetPresentationController.m` contains a reference to UIWebView. This prevents compilation under UIKit for Mac where that class does not exist.

closes #7677 
