### PR TITLE
[Snackbar] Make MDCSnackbarMessage convenience class methods allocate the proper instance type

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -35,13 +35,13 @@ static BOOL _usesLegacySnackbar = NO;
 @dynamic text;
 
 + (instancetype)messageWithText:(NSString *)text {
-  MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
+  MDCSnackbarMessage *message = [[[self class] alloc] init];
   message.text = text;
   return message;
 }
 
 + (instancetype)messageWithAttributedText:(NSAttributedString *)attributedText {
-  MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
+  MDCSnackbarMessage *message = [[[self class] alloc] init];
   message.attributedText = attributedText;
   return message;
 }


### PR DESCRIPTION
If `MDCSnackbarMessage` is subclassed these convenience methods do not create the proper instance type as they use `MDCSnackbarMessage` directly. In Swift these convenience methods get converted into initializers which makes things even more confusing (`MyCustomSnackbarMessage(text: "Test")` returns a `MDCSnackbarMessage` instead of the custom type). This PR ensures that the correct type is created with these methods.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
