### PR TITLE
[TabBarView] Add accessibility label

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -228,7 +228,10 @@ static NSString *const kAccessibilityLabelKeyPath = @"accessibilityLabel";
            forKeyPath:kTitleKeyPath
               options:NSKeyValueObservingOptionNew
               context:kKVOContextMDCTabBarView];
-    [item addObserver:self forKeyPath:kAccessibilityLabelKeyPath options:NSKeyValueObservingOptionNew context:kKVOContextMDCTabBarView];
+    [item addObserver:self
+           forKeyPath:kAccessibilityLabelKeyPath
+              options:NSKeyValueObservingOptionNew
+              context:kKVOContextMDCTabBarView];
   }
 }
 
@@ -236,7 +239,9 @@ static NSString *const kAccessibilityLabelKeyPath = @"accessibilityLabel";
   for (UITabBarItem *item in self.items) {
     [item removeObserver:self forKeyPath:kImageKeyPath context:kKVOContextMDCTabBarView];
     [item removeObserver:self forKeyPath:kTitleKeyPath context:kKVOContextMDCTabBarView];
-    [item removeObserver:self forKeyPath:kAccessibilityLabelKeyPath context:kKVOContextMDCTabBarView];
+    [item removeObserver:self
+              forKeyPath:kAccessibilityLabelKeyPath
+                 context:kKVOContextMDCTabBarView];
   }
 }
 

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -23,6 +23,7 @@ static const CGFloat kMinHeight = 48;
 
 static NSString *const kImageKeyPath = @"image";
 static NSString *const kTitleKeyPath = @"title";
+static NSString *const kAccessibilityLabelKeyPath = @"accessibilityLabel";
 
 @interface MDCTabBarView ()
 
@@ -92,6 +93,7 @@ static NSString *const kTitleKeyPath = @"title";
     MDCTabBarViewItemView *itemView = [[MDCTabBarViewItemView alloc] init];
     itemView.translatesAutoresizingMaskIntoConstraints = NO;
     itemView.titleLabel.text = item.title;
+    itemView.accessibilityLabel = item.accessibilityLabel;
     itemView.titleLabel.textColor = [self titleColorForState:UIControlStateNormal];
     itemView.iconImageView.image = item.image;
     [itemView setContentCompressionResistancePriority:UILayoutPriorityRequired
@@ -226,6 +228,7 @@ static NSString *const kTitleKeyPath = @"title";
            forKeyPath:kTitleKeyPath
               options:NSKeyValueObservingOptionNew
               context:kKVOContextMDCTabBarView];
+    [item addObserver:self forKeyPath:kAccessibilityLabelKeyPath options:NSKeyValueObservingOptionNew context:kKVOContextMDCTabBarView];
   }
 }
 
@@ -233,6 +236,7 @@ static NSString *const kTitleKeyPath = @"title";
   for (UITabBarItem *item in self.items) {
     [item removeObserver:self forKeyPath:kImageKeyPath context:kKVOContextMDCTabBarView];
     [item removeObserver:self forKeyPath:kTitleKeyPath context:kKVOContextMDCTabBarView];
+    [item removeObserver:self forKeyPath:kAccessibilityLabelKeyPath context:kKVOContextMDCTabBarView];
   }
 }
 
@@ -259,6 +263,8 @@ static NSString *const kTitleKeyPath = @"title";
       tabBarItemView.iconImageView.image = change[NSKeyValueChangeNewKey];
     } else if ([keyPath isEqualToString:kTitleKeyPath]) {
       tabBarItemView.titleLabel.text = change[NSKeyValueChangeNewKey];
+    } else if ([keyPath isEqualToString:kAccessibilityLabelKeyPath]) {
+      tabBarItemView.accessibilityLabel = change[NSKeyValueChangeNewKey];
     }
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -35,7 +35,9 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
 
 @end
 
-@implementation MDCTabBarViewItemView
+@implementation MDCTabBarViewItemView {
+  NSString *_accessibilityLabel;
+}
 
 #pragma mark - Init
 
@@ -130,6 +132,16 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
   CGFloat height = (CGFloat)ceil(iconSize.height + labelSize.height + verticalPadding);
   height = MAX(minHeight, height);
   return CGSizeMake(width, height);
+}
+
+#pragma mark - Accessibility
+
+- (NSString *)accessibilityLabel {
+  return _accessibilityLabel ?: self.titleLabel.text;
+}
+
+- (void)setAccessibilityLabel:(NSString *)accessibilityLabel {
+  _accessibilityLabel = accessibilityLabel;
 }
 
 @end

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -35,9 +35,7 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
 
 @end
 
-@implementation MDCTabBarViewItemView {
-  NSString *_accessibilityLabel;
-}
+@implementation MDCTabBarViewItemView 
 
 #pragma mark - Init
 
@@ -137,11 +135,7 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
 #pragma mark - Accessibility
 
 - (NSString *)accessibilityLabel {
-  return _accessibilityLabel ?: self.titleLabel.text;
-}
-
-- (void)setAccessibilityLabel:(NSString *)accessibilityLabel {
-  _accessibilityLabel = accessibilityLabel;
+  return [super accessibilityLabel] ?: self.titleLabel.text;
 }
 
 @end

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -35,7 +35,7 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
 
 @end
 
-@implementation MDCTabBarViewItemView 
+@implementation MDCTabBarViewItemView
 
 #pragma mark - Init
 
@@ -132,7 +132,7 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
   return CGSizeMake(width, height);
 }
 
-#pragma mark - Accessibility
+#pragma mark - UIAccessibility
 
 - (NSString *)accessibilityLabel {
   return [super accessibilityLabel] ?: self.titleLabel.text;


### PR DESCRIPTION
This adds the `accessibilityLabel` to MDCTabBarView, this falls back to the titleLabel.text if the accessibility label isn't set. This has been tested on a device.

## Testing
Steps to reproduce
1. Update the [example](https://github.com/material-components/material-components-ios/blob/develop/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m) to have a custom `accessibilityLabel` for one of the tabBarItems
```objc
item1.accessibilityLabel = @"Hello world";
```
2. Select the item with Voiceover on
3. Navigate to the other items with titles but no custom value.
