### PR TITLE
[TabBarView] Add accessibility hint and identifier

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -251,7 +251,9 @@ static NSString *const kAccessibilityIdentifierKeyPath = @"accessibilityIdentifi
   for (UITabBarItem *item in self.items) {
     [item removeObserver:self forKeyPath:kImageKeyPath context:kKVOContextMDCTabBarView];
     [item removeObserver:self forKeyPath:kTitleKeyPath context:kKVOContextMDCTabBarView];
-    [item removeObserver:self forKeyPath:kAccessibilityLabelKeyPath context:kKVOContextMDCTabBarView];
+    [item removeObserver:self
+              forKeyPath:kAccessibilityLabelKeyPath
+                 context:kKVOContextMDCTabBarView];
     [item removeObserver:self
               forKeyPath:kAccessibilityHintKeyPath
                  context:kKVOContextMDCTabBarView];

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -23,6 +23,8 @@ static const CGFloat kMinHeight = 48;
 
 static NSString *const kImageKeyPath = @"image";
 static NSString *const kTitleKeyPath = @"title";
+static NSString *const kAccessibilityHintKeyPath = @"accessibilityHint";
+static NSString *const kAccessibilityIdentifierKeyPath = @"accessibilityIdentifier";
 
 @interface MDCTabBarView ()
 
@@ -92,6 +94,8 @@ static NSString *const kTitleKeyPath = @"title";
     MDCTabBarViewItemView *itemView = [[MDCTabBarViewItemView alloc] init];
     itemView.translatesAutoresizingMaskIntoConstraints = NO;
     itemView.titleLabel.text = item.title;
+    itemView.accessibilityHint = item.accessibilityHint;
+    itemView.accessibilityIdentifier = item.accessibilityIdentifier;
     itemView.titleLabel.textColor = [self titleColorForState:UIControlStateNormal];
     itemView.iconImageView.image = item.image;
     [itemView setContentCompressionResistancePriority:UILayoutPriorityRequired
@@ -226,6 +230,14 @@ static NSString *const kTitleKeyPath = @"title";
            forKeyPath:kTitleKeyPath
               options:NSKeyValueObservingOptionNew
               context:kKVOContextMDCTabBarView];
+    [item addObserver:self
+           forKeyPath:kAccessibilityHintKeyPath
+              options:NSKeyValueObservingOptionNew
+              context:kKVOContextMDCTabBarView];
+    [item addObserver:self
+           forKeyPath:kAccessibilityIdentifierKeyPath
+              options:NSKeyValueObservingOptionNew
+              context:kKVOContextMDCTabBarView];
   }
 }
 
@@ -233,6 +245,12 @@ static NSString *const kTitleKeyPath = @"title";
   for (UITabBarItem *item in self.items) {
     [item removeObserver:self forKeyPath:kImageKeyPath context:kKVOContextMDCTabBarView];
     [item removeObserver:self forKeyPath:kTitleKeyPath context:kKVOContextMDCTabBarView];
+    [item removeObserver:self
+              forKeyPath:kAccessibilityHintKeyPath
+                 context:kKVOContextMDCTabBarView];
+    [item removeObserver:self
+              forKeyPath:kAccessibilityIdentifierKeyPath
+                 context:kKVOContextMDCTabBarView];
   }
 }
 
@@ -259,6 +277,10 @@ static NSString *const kTitleKeyPath = @"title";
       tabBarItemView.iconImageView.image = change[NSKeyValueChangeNewKey];
     } else if ([keyPath isEqualToString:kTitleKeyPath]) {
       tabBarItemView.titleLabel.text = change[NSKeyValueChangeNewKey];
+    } else if ([keyPath isEqualToString:kAccessibilityHintKeyPath]) {
+      tabBarItemView.accessibilityHint = change[NSKeyValueChangeNewKey];
+    } else if ([keyPath isEqualToString:kAccessibilityIdentifierKeyPath]) {
+      tabBarItemView.accessibilityIdentifier = change[NSKeyValueChangeNewKey];
     }
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -132,14 +132,4 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
   return CGSizeMake(width, height);
 }
 
-#pragma mark - UIAccessibility
-
-- (NSString *)accessibilityHint {
-  return [super accessibilityLabel];
-}
-
-- (NSString *)accessibilityIdentifier {
-  return [super accessibilityIdentifier];
-}
-
 @end

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -132,4 +132,14 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
   return CGSizeMake(width, height);
 }
 
+#pragma mark - UIAccessibility
+
+- (NSString *)accessibilityHint {
+  return [super accessibilityLabel];
+}
+
+- (NSString *)accessibilityIdentifier {
+  return [super accessibilityIdentifier];
+}
+
 @end


### PR DESCRIPTION
This adds the `accessibilityHint` and `accessibilityIdentifer` to MDCTabBarView. This has been tested on a device and simulator.

## Testing

### `accessibilityHint`
Steps to reproduce
1. Update the [example](https://github.com/material-components/material-components-ios/blob/develop/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m) to have a custom `accessibilityHint` for one of the tabBarItems
```objc
item1.accessibilityHint = @"Hello world";
```
2. Launch on a device
3. Select the item with Voiceover on
4. Navigate to the other items with titles but no custom value.

### `accessibilityHint`
Steps to reproduce
1. Update the [example](https://github.com/material-components/material-components-ios/blob/develop/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m) to have a custom `accessibilityIdentifier` for one of the tabBarItems
```objc
item1.accessibilityIdentifier = @"Goodbye";
```
2. Launch MDCDragons on a simulator
3. Open up the accessibility inspector to make sure the value is set correctly