### PR TITLE
[Slider] Haptics For Slider

### DIFF
--- a/components/Slider/examples/SliderCollectionViewController.m
+++ b/components/Slider/examples/SliderCollectionViewController.m
@@ -39,6 +39,7 @@ static CGFloat const kSliderVerticalMargin = 12;
 @property(nonatomic, assign) BOOL discreteValueLabel;
 @property(nonatomic, assign) BOOL hollowCircle;
 @property(nonatomic, assign) BOOL enabled;
+@property(nonatomic, assign) BOOL hapticsEnabled;
 
 - (void)didChangeMDCSliderValue:(MDCSlider *)slider;
 
@@ -60,6 +61,7 @@ static CGFloat const kSliderVerticalMargin = 12;
     _discreteValueLabel = YES;
     _hollowCircle = YES;
     _enabled = YES;
+    _hapticsEnabled = YES;
   }
 
   return self;
@@ -106,6 +108,7 @@ static CGFloat const kSliderVerticalMargin = 12;
   _slider.shouldDisplayDiscreteValueLabel = model.discreteValueLabel;
   _slider.thumbHollowAtStart = model.hollowCircle;
   _slider.enabled = model.enabled;
+  _slider.hapticsEnabled = model.hapticsEnabled;
 
   // Don't apply a `nil` color, use the default
   if (model.sliderColor) {
@@ -261,6 +264,12 @@ static CGFloat const kSliderVerticalMargin = 12;
     model.labelString = @"Anchored slider";
     model.anchorValue = (CGFloat)0.5;
     model.value = (CGFloat)0.7;
+    [_sliders addObject:model];
+
+    model = [[MDCSliderModel alloc] init];
+    model.labelString = @"Haptics Disabled Slider";
+    model.value = (CGFloat)0.66;
+    model.hapticsEnabled = NO;
     [_sliders addObject:model];
 
     model = [[MDCSliderModel alloc] init];

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -45,6 +45,7 @@ IB_DESIGNABLE
 /** The delegate for the slider. */
 @property(nullable, nonatomic, weak) id<MDCSliderDelegate> delegate;
 
+
 /**
  Sets the color of the thumb for the specified state.
 
@@ -334,6 +335,14 @@ IB_DESIGNABLE
  @note Has no effect if @c statefulAPIEnabled is @c YES.
  */
 @property(nonatomic, strong, null_resettable) UIColor *trackBackgroundColor UI_APPEARANCE_SELECTOR;
+
+/** When @c YES, haptics are enabled. The haptics casue a light impact reaction when the slider
+ reaches the minimum or maximum value.
+
+ Defaults to @c YES in iOS 10 or later, @c NO otherwise
+ */
+@property(nonatomic, assign) BOOL hapticsEnabled;
+
 
 @end
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -45,7 +45,6 @@ IB_DESIGNABLE
 /** The delegate for the slider. */
 @property(nullable, nonatomic, weak) id<MDCSliderDelegate> delegate;
 
-
 /**
  Sets the color of the thumb for the specified state.
 
@@ -342,7 +341,6 @@ IB_DESIGNABLE
  Defaults to @c YES in iOS 10 or later, @c NO otherwise
  */
 @property(nonatomic, assign) BOOL hapticsEnabled;
-
 
 @end
 

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -31,9 +31,9 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   return MDCPalette.bluePalette.tint500;
 }
 
-API_AVAILABLE(ios(10.0))
 @interface MDCSlider () <MDCThumbTrackDelegate>
-@property(nonnull, nonatomic, strong)   UIImpactFeedbackGenerator *feedbackGenerator API_AVAILABLE(ios(10.0));
+@property(nonnull, nonatomic, strong)
+    UIImpactFeedbackGenerator *feedbackGenerator API_AVAILABLE(ios(10.0));
 @end
 
 @implementation MDCSlider {
@@ -107,11 +107,11 @@ API_AVAILABLE(ios(10.0))
   _backgroundTickColorsForState[@(UIControlStateNormal)] = UIColor.blackColor;
   [self addSubview:_thumbTrack];
 
-  if (@available(iOS 10.0, *)){
+  if (@available(iOS 10.0, *)) {
     _hapticsEnabled = YES;
-    self.feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
-  }
-  else {
+    self.feedbackGenerator =
+        [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+  } else {
     _hapticsEnabled = NO;
   }
 }
@@ -325,11 +325,9 @@ API_AVAILABLE(ios(10.0))
 }
 
 - (void)setHapticsEnabled:(BOOL)hapticsEnabled {
-
-  if(@available(iOS 10.0, *)){
+  if (@available(iOS 10.0, *)) {
     _hapticsEnabled = hapticsEnabled;
-  }
-  else {
+  } else {
     _hapticsEnabled = NO;
   }
 }
@@ -545,15 +543,18 @@ API_AVAILABLE(ios(10.0))
 - (void)thumbTrackValueChanged:(__unused MDCThumbTrack *)thumbTrack {
   [self sendActionsForControlEvents:UIControlEventValueChanged];
   UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.accessibilityValue);
-  if (@available(iOS 10.0, *)){
-    if (self.hapticsEnabled && (_thumbTrack.value == _thumbTrack.minimumValue || _thumbTrack.value == _thumbTrack.maximumValue)){
-      [self.feedbackGenerator prepare];
+  if (@available(iOS 10.0, *)) {
+    if (self.hapticsEnabled && (_thumbTrack.value == _thumbTrack.minimumValue ||
+                                _thumbTrack.value == _thumbTrack.maximumValue)) {
       [self.feedbackGenerator impactOccurred];
     }
   }
 }
 
 - (void)thumbTrackTouchDown:(__unused MDCThumbTrack *)thumbTrack {
+  if (@available(iOS 10.0, *)) {
+    [self.feedbackGenerator prepare];
+  }
   [self sendActionsForControlEvents:UIControlEventTouchDown];
 }
 
@@ -590,7 +591,6 @@ API_AVAILABLE(ios(10.0))
 
 - (void)setDisabledColor:(UIColor *)disabledColor {
   if (self.isStatefulAPIEnabled) {
-
     return;
   }
   _thumbTrack.trackDisabledColor = disabledColor ?: [[self class] defaultDisabledColor];

--- a/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.h
+++ b/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.h
@@ -1,0 +1,26 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(ios(10.0))
+@interface MockUIImpactFeedbackGenerator : UIImpactFeedbackGenerator
+
+@property(nonatomic) BOOL impactHasOccurred;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.m
+++ b/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.m
@@ -1,0 +1,32 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MockUIImpactFeedbackGenerator.h"
+
+@implementation MockUIImpactFeedbackGenerator
+
+- (instancetype)init {
+  self = [super init];
+  if (self){
+    _impactHasOccurred = NO;
+  }
+  return self;
+}
+
+- (void)impactOccurred{
+  _impactHasOccurred = YES;
+}
+
+
+@end

--- a/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.m
+++ b/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.m
@@ -18,15 +18,14 @@
 
 - (instancetype)init {
   self = [super init];
-  if (self){
+  if (self) {
     _impactHasOccurred = NO;
   }
   return self;
 }
 
-- (void)impactOccurred{
+- (void)impactOccurred {
   _impactHasOccurred = YES;
 }
-
 
 @end

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -27,7 +27,8 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (NSString *)thumbTrack:(MDCThumbTrack *)thumbTrack stringForValue:(CGFloat)value;
 - (void)thumbTrackValueChanged:(__unused MDCThumbTrack *)thumbTrack;
-@property(nonnull, nonatomic, strong)   UIImpactFeedbackGenerator *feedbackGenerator API_AVAILABLE(ios(10.0));
+@property(nonnull, nonatomic, strong)
+    UIImpactFeedbackGenerator *feedbackGenerator API_AVAILABLE(ios(10.0));
 @end
 
 @interface SliderTests : XCTestCase
@@ -37,7 +38,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 @property(nonatomic, nullable) UIColor *defaultGray;
 @end
 
-@implementation SliderTests{
+@implementation SliderTests {
   MockUIImpactFeedbackGenerator *_mockFeedbackGenerator API_AVAILABLE(ios(10.0));
 }
 
@@ -1109,6 +1110,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
 - (void)testDefaultHapticsEnabledValue {
   if (@available(iOS 10.0, *)) {
+    // Then
     XCTAssertTrue(self.slider.hapticsEnabled);
   } else {
     XCTAssertFalse(self.slider.hapticsEnabled);
@@ -1116,58 +1118,60 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 }
 
 - (void)testEnabledHapticFeedback {
-  //Given
+  // Given
   self.slider.minimumValue = 0;
-  self.slider.maximumValue = 10;
+  self.slider.maximumValue = 5;
   self.slider.hapticsEnabled = YES;
 
-
   if (@available(iOS 10.0, *)) {
-    for (NSUInteger i = 0; i < 11; ++i) {
-        self.slider.value = i;
-        _mockFeedbackGenerator = [[MockUIImpactFeedbackGenerator alloc] init];
-        self.slider.feedbackGenerator = _mockFeedbackGenerator;
+    _mockFeedbackGenerator = [[MockUIImpactFeedbackGenerator alloc] init];
+    self.slider.feedbackGenerator = _mockFeedbackGenerator;
+    for (NSUInteger i = 0; i < 6; ++i) {
+      self.slider.value = i;
 
-        //When
-        [self.slider thumbTrackValueChanged:self.slider.thumbTrack];
+      // When
+      [self.slider thumbTrackValueChanged:self.slider.thumbTrack];
 
-        //Then
-      if (i == 0 || i == 10){
+      // Then
+      if (i == 0 || i == 5) {
         XCTAssertTrue(_mockFeedbackGenerator.impactHasOccurred);
-      } else{
+      } else {
         XCTAssertFalse(_mockFeedbackGenerator.impactHasOccurred);
       }
+      _mockFeedbackGenerator.impactHasOccurred = nil;
     }
   }
 }
 
 - (void)testNotEnabledHapticFeedbackAtMax {
-  //Given
+  // Given
   self.slider.minimumValue = 0;
-  self.slider.maximumValue = 10;
+  self.slider.maximumValue = 5;
   self.slider.hapticsEnabled = NO;
 
   if (@available(iOS 10.0, *)) {
-    for (NSUInteger i = 0; i < 11; ++i) {
+    _mockFeedbackGenerator = [[MockUIImpactFeedbackGenerator alloc] init];
+    self.slider.feedbackGenerator = _mockFeedbackGenerator;
+    for (NSUInteger i = 0; i < 6; ++i) {
       self.slider.value = i;
-      _mockFeedbackGenerator = [[MockUIImpactFeedbackGenerator alloc] init];
-      self.slider.feedbackGenerator = _mockFeedbackGenerator;
 
-      //When
+      // When
       [self.slider thumbTrackValueChanged:self.slider.thumbTrack];
 
-      //Then
+      // Then
       XCTAssertFalse(_mockFeedbackGenerator.impactHasOccurred);
+
+      _mockFeedbackGenerator.impactHasOccurred = nil;
     }
   }
 }
 
 - (void)testDefaultHapticsEnabledValues {
-  NSOperatingSystemVersion iOS10Version = {10,0,0};
+  NSOperatingSystemVersion iOS10Version = {10, 0, 0};
   if ([NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:iOS10Version]) {
     XCTAssertTrue(self.slider.hapticsEnabled);
-  } else{
-     XCTAssertFalse(self.slider.hapticsEnabled);
+  } else {
+    XCTAssertFalse(self.slider.hapticsEnabled);
   }
 }
 

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -1166,15 +1166,6 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   }
 }
 
-- (void)testDefaultHapticsEnabledValues {
-  NSOperatingSystemVersion iOS10Version = {10, 0, 0};
-  if ([NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:iOS10Version]) {
-    XCTAssertTrue(self.slider.hapticsEnabled);
-  } else {
-    XCTAssertFalse(self.slider.hapticsEnabled);
-  }
-}
-
 #pragma mark Private test helpers
 
 - (CGFloat)randomNumber {

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -1143,7 +1143,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   }
 }
 
-- (void)testNotEnabledHapticFeedbackAtMax {
+- (void)testNotEnabledHapticFeedback {
   // Given
   self.slider.minimumValue = 0;
   self.slider.maximumValue = 5;

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -1138,7 +1138,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
       } else {
         XCTAssertFalse(_mockFeedbackGenerator.impactHasOccurred);
       }
-      _mockFeedbackGenerator.impactHasOccurred = nil;
+      _mockFeedbackGenerator.impactHasOccurred = NO;
     }
   }
 }
@@ -1161,7 +1161,7 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
       // Then
       XCTAssertFalse(_mockFeedbackGenerator.impactHasOccurred);
 
-      _mockFeedbackGenerator.impactHasOccurred = nil;
+      _mockFeedbackGenerator.impactHasOccurred = NO;
     }
   }
 }


### PR DESCRIPTION
This adds haptics for sliders. The haptics for sliders are opt-out and cause a light vibration when the slider reaches the min or max value. These decisions were made to match apples implementation of haptics for sliders.