### PR TITLE
[Tabs] Allow setting selected item without animation.

### DIFF
--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -111,7 +111,7 @@ Pod::Spec.new do |mdc|
       "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}",
       "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     ]
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/Ripple"
 
     extension.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -93,7 +93,9 @@ mdc_extension_objc_library(
 
 mdc_extension_objc_library(
     name = "TabBarView",
-    deps = ["//components/Ripple"],
+    deps = [
+        "//components/Ripple",
+    ],
 )
 
 mdc_examples_objc_library(

--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -27,6 +27,9 @@ __attribute__((objc_subclassing_restricted)) @interface MDCTabBarView : UIScroll
 /** The currently-selected item in the Tab bar. */
 @property(nullable, nonatomic, strong) UITabBarItem *selectedItem;
 
+/** Set the selected item with or without animation. */
+- (void)setSelectedItem:(nullable UITabBarItem *)selectedItem animated:(BOOL)animated;
+
 /** The color of the Tab bar's background. */
 @property(nullable, nonatomic, copy) UIColor *barTintColor;
 

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -16,6 +16,8 @@
 #import "MDCTabBarViewDelegate.h"
 #import "private/MDCTabBarViewItemView.h"
 
+#import <CoreGraphics/CoreGraphics.h>
+
 // KVO contexts
 static char *const kKVOContextMDCTabBarView = "kKVOContextMDCTabBarView";
 
@@ -136,6 +138,10 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 }
 
 - (void)setSelectedItem:(UITabBarItem *)selectedItem {
+  [self setSelectedItem:selectedItem animated:YES];
+}
+
+- (void)setSelectedItem:(UITabBarItem *)selectedItem animated:(BOOL)animated {
   if (self.selectedItem == selectedItem) {
     return;
   }
@@ -171,7 +177,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   CGRect itemFrameInScrollViewBounds =
       [self convertRect:self.containerView.arrangedSubviews[itemIndex].frame
                fromView:self.containerView];
-  [self scrollRectToVisible:itemFrameInScrollViewBounds animated:YES];
+  [self scrollRectToVisible:itemFrameInScrollViewBounds animated:animated];
 }
 
 - (void)updateImageTintColorForAllViews {
@@ -424,7 +430,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 
 - (void)scrollUntilSelectedItemIsVisibleWithoutAnimation {
   NSUInteger index = [self.items indexOfObject:self.selectedItem];
-  if (index == NSNotFound || index > self.containerView.arrangedSubviews.count) {
+  if (index == NSNotFound || index >= self.containerView.arrangedSubviews.count) {
     return;
   }
 

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
@@ -97,7 +97,7 @@ static const CGFloat kMaxItemWidth = 360;
 
   // When
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -111,7 +111,7 @@ static const CGFloat kMaxItemWidth = 360;
 
   // When
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -126,7 +126,7 @@ static const CGFloat kMaxItemWidth = 360;
 
   // When
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -141,7 +141,7 @@ static const CGFloat kMaxItemWidth = 360;
 
   // When
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -157,10 +157,10 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
-  self.tabBarView.selectedItem = item1;
+  [self.tabBarView setSelectedItem:item1 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -179,7 +179,7 @@ static const CGFloat kMaxItemWidth = 360;
   self.tabBarView.items = @[ item1, item2, item3, item4, item5, item6 ];
 
   // When
-  self.tabBarView.selectedItem = item5;
+  [self.tabBarView setSelectedItem:item5 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];
@@ -194,7 +194,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   item2.title = @"2";
@@ -210,7 +210,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   item1.image = self.typicalIcon2;
@@ -226,7 +226,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   item2.image = self.typicalIcon2;
@@ -242,7 +242,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   item1.selectedImage = self.typicalIcon2;
@@ -258,7 +258,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon1 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon1 tag:5];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   item2.selectedImage = self.typicalIcon2;
@@ -394,7 +394,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   [self.tabBarView setTitleColor:UIColor.brownColor forState:UIControlStateSelected];
@@ -411,7 +411,8 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
+  ;
 
   // When
   [self.tabBarView setTitleColor:UIColor.purpleColor forState:UIControlStateNormal];
@@ -427,7 +428,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   [self.tabBarView setTitleColor:nil forState:UIControlStateNormal];
@@ -444,7 +445,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   [self.tabBarView setImageTintColor:UIColor.brownColor forState:UIControlStateSelected];
@@ -461,7 +462,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   [self.tabBarView setImageTintColor:UIColor.purpleColor forState:UIControlStateNormal];
@@ -478,7 +479,7 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
 
   // When
   [self.tabBarView setImageTintColor:nil forState:UIControlStateNormal];
@@ -495,14 +496,14 @@ static const CGFloat kMaxItemWidth = 360;
   UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:self.typicalIcon2 tag:2];
   UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:self.typicalIcon3 tag:3];
   self.tabBarView.items = @[ item1, item2, item3 ];
-  self.tabBarView.selectedItem = item2;
+  [self.tabBarView setSelectedItem:item2 animated:NO];
   [self.tabBarView setTitleColor:UIColor.purpleColor forState:UIControlStateNormal];
   [self.tabBarView setImageTintColor:UIColor.redColor forState:UIControlStateNormal];
   [self.tabBarView setTitleColor:UIColor.brownColor forState:UIControlStateSelected];
   [self.tabBarView setImageTintColor:UIColor.blueColor forState:UIControlStateSelected];
 
   // When
-  self.tabBarView.selectedItem = item3;
+  [self.tabBarView setSelectedItem:item3 animated:NO];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.tabBarView];


### PR DESCRIPTION
The property setter will automatically animate setting the selected item. For
some use cases, like tests or configuring a view for the first time, it's
useful to set the selected item without animation.

Part of #7744
