### PR TITLE
[Tabs] Make itemView conform to the selection indicator protocol.

### DIFF
--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.h
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.h
@@ -14,10 +14,12 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MDCTabBarViewIndicatorSupporting.h"
+
 #import <MaterialComponents/MaterialRipple.h>
 
 /** A basic view that displays a title and image for a tab bar item within MDCTabBarView. */
-@interface MDCTabBarViewItemView : UIView
+@interface MDCTabBarViewItemView : UIView <MDCTabBarViewIndicatorSupporting>
 
 /** The image view to display the icon. */
 @property(nonatomic, strong) UIImageView *iconImageView;

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -85,6 +85,10 @@ static const UIEdgeInsets kEdgeInsets = {.top = 12, .right = 16, .bottom = 12, .
   }
 }
 
+- (CGRect)contentFrame {
+  return self.contentView.frame;
+}
+
 #pragma mark - UIView
 
 - (void)layoutSubviews {


### PR DESCRIPTION
Preparing the item view to conform to the selection indicator protocol so the indicator can be rendered correctly around it.

Part of #7744
