### PR TITLE
[Tabs] Fixes the scrollable content size.

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -473,6 +473,9 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
           constraintEqualToAnchor:self.containerView.trailingAnchor],
       [self.safeAreaLayoutGuide.bottomAnchor
           constraintEqualToAnchor:self.containerView.bottomAnchor],
+      [self.contentLayoutGuide.widthAnchor constraintEqualToAnchor:self.containerView.widthAnchor],
+      [self.contentLayoutGuide.heightAnchor
+          constraintEqualToAnchor:self.containerView.heightAnchor],
     ];
     self.scrollableLayoutConstraints = @[
       [self.contentLayoutGuide.topAnchor constraintEqualToAnchor:self.containerView.topAnchor],


### PR DESCRIPTION
The constraints left the scrollable content size ambiguous in the Justified layout style. Constraining it to the height and width of the content results in no ambiguous layout.

Follow-up to #7753
