### PR TITLE
[Tabs] Fixes layout for changing font sizes.

### DIFF
--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -126,6 +126,7 @@ static NSString *const kExampleTitle = @"TabBarView";
                         forState:UIControlStateSelected];
   [self.tabBar setTitleFont:self.containerScheme.typographyScheme.button
                    forState:UIControlStateNormal];
+  [self.tabBar setTitleFont:[UIFont systemFontOfSize:16] forState:UIControlStateSelected];
   self.tabBar.selectedItem = item4;
   self.tabBar.translatesAutoresizingMaskIntoConstraints = NO;
   [self.view addSubview:self.tabBar];

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -305,6 +305,8 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     } else {
       tabBarViewItemView.titleLabel.font = [self titleFontForState:UIControlStateNormal];
     }
+    [itemView invalidateIntrinsicContentSize];
+    [itemView setNeedsLayout];
   }
 }
 


### PR DESCRIPTION
When different font sizes for different states are used, the item view may end up with a different layout or even a different intrinsic content size.

## Dragons Example

|Before|After|
|---|---|
|![tab-font-change-broken](https://user-images.githubusercontent.com/1753199/60480015-f2baea80-9c55-11e9-9b72-c7523d96bf31.gif)|![tab-font-change-fixed](https://user-images.githubusercontent.com/1753199/60480019-f64e7180-9c55-11e9-867f-3eb890d28fc0.gif)|



Follow-up to #7757