### PR TITLE
[Tabs] Vertically hug content in sizeThatFits:

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -556,7 +556,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 
 - (CGSize)sizeThatFits:(CGSize)size {
   CGSize intrinsicSize = self.intrinsicContentSize;
-  return CGSizeMake(MAX(intrinsicSize.width, size.width), MAX(intrinsicSize.height, size.height));
+  return CGSizeMake(MAX(intrinsicSize.width, size.width), intrinsicSize.height);
 }
 
 #pragma mark - Helpers

--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -653,7 +653,7 @@ static UIImage *fakeImage(CGSize size) {
   XCTAssertEqualWithAccuracy(size.height, kMinHeight, 0.001);
 }
 
-- (void)testSizeThatFitsDoesntShrinkToFitContent {
+- (void)testSizeThatFitsShrinksToFitContentVerticallyButNotHorizontally {
   // Given
   self.tabBarView.items = @[ self.itemA ];
   CGSize intrinsicSize = self.tabBarView.intrinsicContentSize;
@@ -664,7 +664,7 @@ static UIImage *fakeImage(CGSize size) {
 
   // Then
   XCTAssertEqualWithAccuracy(size.width, biggerSize.width, 0.001);
-  XCTAssertEqualWithAccuracy(size.height, biggerSize.height, 0.001);
+  XCTAssertEqualWithAccuracy(size.height, intrinsicSize.height, 0.001);
 }
 
 @end


### PR DESCRIPTION
To ensure that TabBarView works correctly with the Flexible Header, it should
"hug" its content vertically when interrogated for a fit size. The previous
behavior may have resulted in a tab bar that was too tall (or too short).

Closes #7769