### PR TITLE
[Tabs] Include public headers in umbrella header.

### DIFF
--- a/components/Tabs/src/TabBarView/MaterialTabs+TabBarView.h
+++ b/components/Tabs/src/TabBarView/MaterialTabs+TabBarView.h
@@ -16,4 +16,8 @@
 #import "MDCTabBarItemCustomViewing.h"
 #import "MDCTabBarView.h"
 #import "MDCTabBarViewDelegate.h"
+#import "MDCTabBarViewIndicatorAttributes.h"
+#import "MDCTabBarViewIndicatorContext.h"
 #import "MDCTabBarViewIndicatorSupporting.h"
+#import "MDCTabBarViewIndicatorTemplate.h"
+#import "MDCTabBarViewUnderlineIndicatorTemplate.h"


### PR DESCRIPTION
The umbrella header should include all public headers. Clients are likely to use all public headers at any given time and should not rely on individual file names for imports.

Closes #7780