### PR TITLE
[Tabs] Item views should translate their autoresizing mask into constraints

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -164,7 +164,6 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
       mdcItemView.iconImageView.image = item.image;
       itemView = mdcItemView;
     }
-    itemView.translatesAutoresizingMaskIntoConstraints = NO;
     UITapGestureRecognizer *tapGesture =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapItemView:)];
     [itemView addGestureRecognizer:tapGesture];


### PR DESCRIPTION
Set `translatesAutoresizingMaskIntoConstraints = YES` on the itemView since otherwise it will not transfer its frame information as auto layout constraints which make its subviews not working with the auto layout.
