### PR TITLE
[Math] Add MDCEdgeInsetsEqualToEdgeInsets to compare two UIEdgeInsets.

### DIFF
--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -244,7 +244,6 @@ static inline CGPoint MDCRoundCenterWithBoundsAndScale(CGPoint center,
   return CGPointMake(origin.x + halfWidth, origin.y + halfHeight);
 }
 
-
 /// Compare two edge insets using MDCCGFloatEqual.
 /// @param insets1 An edge inset to compare with insets2
 /// @param insets2 An edge inset to compare with insets1

--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -14,6 +14,7 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import <math.h>
 
 static inline CGFloat MDCSin(CGFloat value) {
@@ -241,4 +242,16 @@ static inline CGPoint MDCRoundCenterWithBoundsAndScale(CGPoint center,
   CGPoint origin = CGPointMake(center.x - halfWidth, center.y - halfHeight);
   origin = MDCPointRoundWithScale(origin, scale);
   return CGPointMake(origin.x + halfWidth, origin.y + halfHeight);
+}
+
+
+/// Compare two edge insets using MDCCGFloatEqual.
+/// @param insets1 An edge inset to compare with insets2
+/// @param insets2 An edge inset to compare with insets1
+static inline BOOL MDCEdgeInsetsEqualToEdgeInsets(UIEdgeInsets insets1, UIEdgeInsets insets2) {
+  BOOL topEqual = MDCCGFloatEqual(insets1.top, insets2.top);
+  BOOL leftEqual = MDCCGFloatEqual(insets1.left, insets2.left);
+  BOOL bottomEqual = MDCCGFloatEqual(insets1.bottom, insets2.bottom);
+  BOOL rightEqual = MDCCGFloatEqual(insets1.right, insets2.right);
+  return topEqual && leftEqual && bottomEqual && rightEqual;
 }

--- a/components/private/Math/tests/unit/MDCMathTests.m
+++ b/components/private/Math/tests/unit/MDCMathTests.m
@@ -287,4 +287,38 @@
       CGPointZero, MDCRoundCenterWithBoundsAndScale(CGPointMake(1, 2), CGRectNull, 1)));
 }
 
+- (void)testUIEdgeInsetsEqualToEdgeInsets {
+  // Given
+  CGFloat epsilon = 0;
+#if CGFLOAT_IS_DOUBLE
+  epsilon = DBL_EPSILON;
+#else
+  epsilon = FLT_EPSILON;
+#endif
+
+  // When
+  UIEdgeInsets insets1 = UIEdgeInsetsMake(1, 1, 1, 1);
+  UIEdgeInsets insets2 = UIEdgeInsetsMake(1 + epsilon, 1 + epsilon, 1 + epsilon, 1 + epsilon);
+
+  // Then
+  XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(insets1, insets2));
+}
+
+- (void)testMDCEdgeInsetsEqualToEdgeInsets {
+  // Given
+  CGFloat epsilon = 0;
+#if CGFLOAT_IS_DOUBLE
+  epsilon = DBL_EPSILON;
+#else
+  epsilon = FLT_EPSILON;
+#endif
+
+  // When
+  UIEdgeInsets insets1 = UIEdgeInsetsMake(1, 1, 1, 1);
+  UIEdgeInsets insets2 = UIEdgeInsetsMake(1 + epsilon, 1 + epsilon, 1 + epsilon, 1 + epsilon);
+
+  // Then
+  XCTAssertTrue(MDCEdgeInsetsEqualToEdgeInsets(insets1, insets2));
+}
+
 @end


### PR DESCRIPTION
Created to prepare for a fix for https://github.com/material-components/material-components-ios/issues/7752.

`UIEdgeInsetsEqualToEdgeInsets` directly compares `CGFloat` number within two . The `MDCEdgeInsetsEqualToEdgeInsets` added in this PR compares UIEdgeInsets using `MDCCGFloatEqual` to take epsilon into consideration. 