### PR TITLE
[FlexibleHeader] use MDCEdgeInsetsEqualToEdgeInsets to compare insets

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -32,6 +32,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/private/Application",
+        "//components/private/Math",
         "//components/private/UIMetrics",
         "@material_text_accessibility_ios//:MDFTextAccessibility",
     ],

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -16,6 +16,7 @@
 
 #import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "MaterialApplication.h"
+#import "MaterialMath.h"
 #import "MaterialUIMetrics.h"
 #import "private/MDCFlexibleHeaderMinMaxHeight.h"
 #import "private/MDCFlexibleHeaderTopSafeArea.h"
@@ -643,7 +644,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   insets.top += topInsetAdjustment;
   info.injectedTopContentInset = desiredTopInset;
   info.hasInjectedTopContentInset = YES;
-  if (!UIEdgeInsetsEqualToEdgeInsets(scrollView.contentInset, insets)) {
+  if (!MDCEdgeInsetsEqualToEdgeInsets(scrollView.contentInset, insets)) {
     scrollView.contentInset = insets;
   }
 


### PR DESCRIPTION
closes #7752.

This PR ensures that FlexibleHeader compares the insets by the Epsilon tolerance.