### PR TITLE
[Tabs] Add `accessibilityElementForItem:` API.

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -101,4 +101,15 @@ __attribute__((objc_subclassing_restricted)) @interface MDCTabBarView : UIScroll
  */
 - (nullable UIFont *)titleFontForState:(UIControlState)state;
 
+/**
+ Returns the @c UIAccessibility element associated with the provided item.
+
+ @note The returned object is not guaranteed to be of type @c UIAccessibilityElement. It is
+       guaranteed to be the same object UIAccessibility systems identify as representing @c item.
+
+ @param item A tab bar item in the receivers @c items array.
+ @return The @c UIAccessibility element associated with @c item if one exists, else @c nil.
+ */
+- (nullable id)accessibilityElementForItem:(nonnull UITabBarItem *)item;
+
 @end

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -378,6 +378,16 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   }
 }
 
+#pragma mark - Custom APIs
+
+- (id)accessibilityElementForItem:(UITabBarItem *)item {
+  NSUInteger itemIndex = [self.items indexOfObject:item];
+  if (itemIndex == NSNotFound || itemIndex >= self.itemViews.count) {
+    return nil;
+  }
+  return self.itemViews[itemIndex];
+}
+
 #pragma mark - Key-Value Observing (KVO)
 
 - (void)addObserversToTabBarItems {

--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -840,4 +840,46 @@ static UIImage *fakeImage(CGSize size) {
   XCTAssertNoThrow([self.tabBarView layoutIfNeeded]);
 }
 
+#pragma mark - Custom APIs
+
+- (void)testAccessibilityElementForItemNotInItemsArrayReturnsNil {
+  // Given
+  self.tabBarView.items = @[ self.itemA ];
+
+  // When
+  UIAccessibilityElement *element = [self.tabBarView accessibilityElementForItem:self.itemB];
+
+  // Then
+  XCTAssertNil(element);
+}
+
+- (void)testAccessibilityElementForEmptyItemsArrayReturnsNil {
+  // Given
+  self.tabBarView.items = @[];
+
+  // When
+  UIAccessibilityElement *element = [self.tabBarView accessibilityElementForItem:self.itemB];
+
+  // Then
+  XCTAssertNil(element);
+}
+
+- (void)testAccessibilityElementForItemInItemsArrayReturnsItemViewWithMatchingTitleAndImage {
+  // Given
+  self.itemB.image = fakeImage(CGSizeMake(24, 24));
+  self.tabBarView.items = @[ self.itemA, self.itemB, self.itemC ];
+
+  // When
+  UIAccessibilityElement *element = [self.tabBarView accessibilityElementForItem:self.itemB];
+
+  // Then
+  XCTAssertTrue([element isKindOfClass:[MDCTabBarViewItemView class]], @"(%@) is not of class (%@)",
+                element, NSStringFromClass([MDCTabBarViewItemView class]));
+  if ([element isKindOfClass:[MDCTabBarViewItemView class]]) {
+    MDCTabBarViewItemView *itemView = (MDCTabBarViewItemView *)element;
+    XCTAssertEqualObjects(itemView.titleLabel.text, self.itemB.title);
+    XCTAssertEqualObjects(itemView.iconImageView.image, self.itemB.image);
+  }
+}
+
 @end


### PR DESCRIPTION
This API is used by multiple internal clients so that they can target the
accessibility element for notifications.

Closes #7797