### PR TITLE
[ProgressView] Provide unique names for methods.

### DIFF
--- a/components/ProgressView/src/Theming/MDCProgressView+MaterialTheming.m
+++ b/components/ProgressView/src/Theming/MDCProgressView+MaterialTheming.m
@@ -25,11 +25,11 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = (CGFloat)0.3;
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
   self.trackTintColor =
-      [[self class] defaultTrackTintColorForProgressTintColor:colorScheme.primaryColor];
+      [[self class] mdcThemingDefaultTrackTintColorForProgressTintColor:colorScheme.primaryColor];
   self.progressTintColor = colorScheme.primaryColor;
 }
 
-+ (UIColor *)defaultTrackTintColorForProgressTintColor:(UIColor *)progressTintColor {
++ (UIColor *)mdcThemingDefaultTrackTintColorForProgressTintColor:(UIColor *)progressTintColor {
   CGFloat hue, saturation, brightness, alpha;
   if ([progressTintColor getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha]) {
     CGFloat newSaturation = MIN(saturation * MDCProgressViewTrackColorDesaturation, 1);

--- a/components/ProgressView/tests/unit/Theming/ProgressViewMaterialThemingTests.m
+++ b/components/ProgressView/tests/unit/Theming/ProgressViewMaterialThemingTests.m
@@ -60,7 +60,8 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = (CGFloat)0.3;
   // Test Colors
   XCTAssertEqualObjects(
       self.progressView.trackTintColor,
-      [self defaultTrackTintColorForProgressTintColor:scheme.colorScheme.primaryColor]);
+      [self
+          mdcThemingTestDefaultTrackTintColorForProgressTintColor:scheme.colorScheme.primaryColor]);
   XCTAssertEqualObjects(self.progressView.progressTintColor, scheme.colorScheme.primaryColor);
 }
 
@@ -75,11 +76,12 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = (CGFloat)0.3;
   // Test Colors
   XCTAssertEqualObjects(
       self.progressView.trackTintColor,
-      [self defaultTrackTintColorForProgressTintColor:scheme.colorScheme.primaryColor]);
+      [self
+          mdcThemingTestDefaultTrackTintColorForProgressTintColor:scheme.colorScheme.primaryColor]);
   XCTAssertEqualObjects(self.progressView.progressTintColor, scheme.colorScheme.primaryColor);
 }
 
-- (UIColor *)defaultTrackTintColorForProgressTintColor:(UIColor *)progressTintColor {
+- (UIColor *)mdcThemingTestDefaultTrackTintColorForProgressTintColor:(UIColor *)progressTintColor {
   CGFloat hue, saturation, brightness, alpha;
   if ([progressTintColor getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha]) {
     CGFloat newSaturation = MIN(saturation * MDCProgressViewTrackColorDesaturation, 1);


### PR DESCRIPTION
ProgressView, its Theming Extension, and its tests all declared the same
method. This can introduce linker or compiler problems. Unique names are
provided based on their contexts.

Follow-up to #7791