### PR TITLE
[Tabs] Add tests for `sizeToFit`.

### DIFF
--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -705,6 +705,39 @@ static UIImage *fakeImage(CGSize size) {
   XCTAssertEqualWithAccuracy(size.height, intrinsicSize.height, 0.001);
 }
 
+- (void)testSizeToFitResizesToFitContentFromInitiallySmallBounds {
+  // Given
+  self.tabBarView.items = @[ self.itemA ];
+  self.tabBarView.bounds = CGRectZero;
+
+  // When
+  [self.tabBarView sizeToFit];
+
+  // Then
+  CGSize fitSize =
+      CGSizeMake(CGRectGetWidth(self.tabBarView.bounds), CGRectGetHeight(self.tabBarView.bounds));
+  CGSize intrinsicContentSize = self.tabBarView.intrinsicContentSize;
+  XCTAssertEqualWithAccuracy(fitSize.width, intrinsicContentSize.width, 0.001);
+  XCTAssertEqualWithAccuracy(fitSize.height, intrinsicContentSize.height, 0.001);
+}
+
+- (void)testSizeToFitResizesToHugContentVerticallyButRetainsWiderBounds {
+  // Given
+  self.tabBarView.items = @[ self.itemA ];
+  CGSize tooLargeSize = CGSizeMake(100000, 200000);
+  self.tabBarView.bounds = CGRectMake(0, 0, tooLargeSize.width, tooLargeSize.height);
+
+  // When
+  [self.tabBarView sizeToFit];
+
+  // Then
+  CGSize fitSize =
+      CGSizeMake(CGRectGetWidth(self.tabBarView.bounds), CGRectGetHeight(self.tabBarView.bounds));
+  CGSize intrinsicContentSize = self.tabBarView.intrinsicContentSize;
+  XCTAssertEqualWithAccuracy(fitSize.width, tooLargeSize.width, 0.001);
+  XCTAssertEqualWithAccuracy(fitSize.height, intrinsicContentSize.height, 0.001);
+}
+
 #pragma mark - Custom Views
 
 - (void)testCustomViewSetSelectedAnimatedCalledForSelectedWithImplicitAnimation {


### PR DESCRIPTION
Adds tests to explicitly verify the behavior of `sizeToFit` to ensure that the tab bar can resize itself to fit its content in the expected behavior.
