### PR TITLE
[AppBar] Add `traitCollectionDidChangeBlock` to AppBarViewController.

### DIFF
--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -145,6 +145,7 @@ mdc_unit_test_swift_library(
 mdc_unit_test_suite(
     name = "unit_tests",
     deps = [
+        ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
 )

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -36,6 +36,13 @@
  */
 @property(nonatomic, strong, nonnull) MDCHeaderStackView *headerStackView;
 
+/**
+ A block that is invoked when the AppBarViewController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 #pragma mark - To be deprecated

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -70,6 +70,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   self.headerStackView.topBar = self.navigationBar;
 }
 
+#pragma mark - Properties
+
 - (MDCHeaderStackView *)headerStackView {
   // Removed call to loadView here as we should never be calling it manually.
   // It previously replaced loadViewIfNeeded call that is only iOS 9.0+ to
@@ -145,6 +147,17 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   return backBarButtonItem;
 }
 
+- (void)setInferTopSafeAreaInsetFromViewController:(BOOL)inferTopSafeAreaInsetFromViewController {
+  [super setInferTopSafeAreaInsetFromViewController:inferTopSafeAreaInsetFromViewController];
+
+  if (inferTopSafeAreaInsetFromViewController) {
+    self.topLayoutGuideAdjustmentEnabled = YES;
+  }
+
+  _verticalConstraint.active = !self.inferTopSafeAreaInsetFromViewController;
+  _topSafeAreaConstraint.active = self.inferTopSafeAreaInsetFromViewController;
+}
+
 #pragma mark - Resource bundle
 
 + (NSBundle *)bundle {
@@ -165,6 +178,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
   return [resourcePath stringByAppendingPathComponent:bundleName];
 }
+
+#pragma mark - UIViewController Overrides
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -208,17 +223,6 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
       .active = YES;
 }
 
-- (void)setInferTopSafeAreaInsetFromViewController:(BOOL)inferTopSafeAreaInsetFromViewController {
-  [super setInferTopSafeAreaInsetFromViewController:inferTopSafeAreaInsetFromViewController];
-
-  if (inferTopSafeAreaInsetFromViewController) {
-    self.topLayoutGuideAdjustmentEnabled = YES;
-  }
-
-  _verticalConstraint.active = !self.inferTopSafeAreaInsetFromViewController;
-  _topSafeAreaConstraint.active = self.inferTopSafeAreaInsetFromViewController;
-}
-
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
@@ -247,6 +251,16 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   frame.size.width = CGRectGetWidth(parent.view.bounds);
   self.view.frame = frame;
 }
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(previousTraitCollection);
+  }
+}
+
+#pragma mark - UIAccessibility
 
 - (BOOL)accessibilityPerformEscape {
   [self dismissSelf];

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -1,0 +1,63 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCAppBarViewController.h"
+
+@interface MDCAppBarViewControllerTests : XCTestCase
+
+@end
+
+@implementation MDCAppBarViewControllerTests
+
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  appBarController.traitCollectionDidChangeBlock =
+      ^(UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
+
+  // When
+  [appBarController traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedPreviousTraitCollection {
+  // Given
+  MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  appBarController.traitCollectionDidChangeBlock =
+      ^(UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        [expectation fulfill];
+      };
+
+  // When
+  UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];
+  [appBarController traitCollectionDidChange:testCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testCollection);
+}
+
+@end


### PR DESCRIPTION
The MDCAppBarViewController needs an API so clients can hook-in to trait collection changes.

Part of #7849
