### PR TITLE
[Buttons] add traitCollectionDidChangeBlock API.

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -329,8 +329,8 @@
  A block that is invoked when the MDCButton receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
-@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)(UITraitCollection *_Nullable previousTraitCollection);
-
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (UITraitCollection *_Nullable previousTraitCollection);
 
 #pragma mark - Deprecated
 

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -325,6 +325,13 @@
  */
 + (nonnull instancetype)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
 
+/**
+ A block that is invoked when the MDCButton receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)(UITraitCollection *_Nullable previousTraitCollection);
+
+
 #pragma mark - Deprecated
 
 /**

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -317,7 +317,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
 
-  [self updateTitleFont];
   if (self.traitCollectionDidChangeBlock) {
     self.traitCollectionDidChangeBlock(previousTraitCollection);
   }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -314,6 +314,15 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return superSize;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  [self updateTitleFont];
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(previousTraitCollection);
+  }
+}
+
 #pragma mark - UIResponder
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1327,7 +1327,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
                  UIAccessibilityTraitAllowsDirectInteraction | UIAccessibilityTraitButton);
 }
 
-#pragma mark -UITraitCollection
+#pragma mark - UITraitCollection
 
 - (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
   // Given

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1327,4 +1327,23 @@ static NSString *controlStateDescription(UIControlState controlState) {
                  UIAccessibilityTraitAllowsDirectInteraction | UIAccessibilityTraitButton);
 }
 
+#pragma mark -UITraitCollection
+
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCButton *button = [[MDCButton alloc] init];
+  XCTestExpectation *expectation =
+  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  button.traitCollectionDidChangeBlock = ^(UITraitCollection *_Nullable previousTraitCollection) {
+    [expectation fulfill];
+  };
+
+  // When
+  [button traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+
 @end

--- a/components/Buttons/tests/unit/ButtonsTests.m
+++ b/components/Buttons/tests/unit/ButtonsTests.m
@@ -1333,7 +1333,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // Given
   MDCButton *button = [[MDCButton alloc] init];
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
   button.traitCollectionDidChangeBlock = ^(UITraitCollection *_Nullable previousTraitCollection) {
     [expectation fulfill];
   };
@@ -1344,6 +1344,5 @@ static NSString *controlStateDescription(UIControlState controlState) {
   // Then
   [self waitForExpectations:@[ expectation ] timeout:1];
 }
-
 
 @end


### PR DESCRIPTION
Provides an API for clients to respond to `traitCollectionDidChange` without subclassing.

closes https://github.com/material-components/material-components-ios/issues/7854