### PR TITLE
[Collections] Clear MDCCollectionViewStyler background image cache on traitCollectionDidChange

### DIFF
--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -195,8 +195,8 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 #pragma mark - <UICollectionViewDelegateFlowLayout>
 
 - (CGSize)collectionView:(UICollectionView *)collectionView
-                  layout:(UICollectionViewLayout *)collectionViewLayout
-  sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+                    layout:(UICollectionViewLayout *)collectionViewLayout
+    sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
   UICollectionViewLayoutAttributes *attr =
       [collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
   CGSize size = [self sizeWithAttribute:attr collectionView:collectionView];

--- a/components/Collections/src/MDCCollectionViewController.m
+++ b/components/Collections/src/MDCCollectionViewController.m
@@ -128,6 +128,12 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
   }
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  self.styler.shouldInvalidateLayout = YES;
+  [self.collectionView.collectionViewLayout invalidateLayout];
+}
+
 - (void)setCollectionView:(__kindof UICollectionView *)collectionView {
   [super setCollectionView:collectionView];
 
@@ -189,8 +195,8 @@ NSString *const MDCCollectionInfoBarKindFooter = @"MDCCollectionInfoBarKindFoote
 #pragma mark - <UICollectionViewDelegateFlowLayout>
 
 - (CGSize)collectionView:(UICollectionView *)collectionView
-                    layout:(UICollectionViewLayout *)collectionViewLayout
-    sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+                  layout:(UICollectionViewLayout *)collectionViewLayout
+  sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
   UICollectionViewLayoutAttributes *attr =
       [collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
   CGSize size = [self sizeWithAttribute:attr collectionView:collectionView];

--- a/components/Collections/src/private/MDCCollectionViewStyler.m
+++ b/components/Collections/src/private/MDCCollectionViewStyler.m
@@ -465,6 +465,13 @@ NS_INLINE CGRect RectShift(CGRect rect, CGFloat dx, CGFloat dy) {
   }
 }
 
+- (void)setShouldInvalidateLayout:(BOOL)shouldInvalidateLayout {
+  _shouldInvalidateLayout = shouldInvalidateLayout;
+  if (shouldInvalidateLayout) {
+    [_cellBackgroundCaches removeAllObjects];
+  }
+}
+
 - (void)invalidateLayoutForStyleChange {
   _shouldInvalidateLayout = YES;
 }


### PR DESCRIPTION


Because the `MDCCollectionViewStyler` draws caches background colors as images, we need to reset that cache when collection view's trait collection changes. 

More detail:
`MDCCollectionViewStylingDelegate` allows clients to provide cell background colors via the `- (UIColor *)collectionView:(UICollectionView *)collectionView cellBackgroundColorAtIndexPath:(NSIndexPath *)indexPath` function. When `MDCCollectionViewStyler` uses this function (in `backgroundImageForCellLayoutAttributes:`), it uses that color as a `CGContext` fill color and draws it as an image. If a user switches to/from Dark Mode, these images will not be updated, even if they were drawn with dynamic `UIColor`s. Thus, we need to reset the cache and redraw the images.

Related to #7855