### PR TITLE
[private] Adds a flow to get snapshot tests for iOS13

### DIFF
--- a/components/private/Snapshot/src/SnapshotTestCase/MDCSnapshotTestCase.h
+++ b/components/private/Snapshot/src/SnapshotTestCase/MDCSnapshotTestCase.h
@@ -27,11 +27,23 @@
 - (void)snapshotVerifyView:(UIView *)view;
 
 /**
+ * This will call FBSnapshotVerifyView for iOS13. Additionally,
+ * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
+ *
+ * Permits no changed pixels.
+ *
+ * @param view The view to use for snapshot comparison.
+ */
+- (void)snapshotVerifyViewForIOS13:(UIView *)view;
+
+/**
  * This will call FBSnapshotVerifyView but first check for supported iOS versions. Additionally,
  * this will use UIGraphicsImageRenderer to render the view correctly (including shadows).
  * @param view the view to use for snapshot comparison.
  * @param tolerancePercent the percentage (0.0 - 1.0) of pixels that can differ while still passing.
+ * @param supportIOS13 if to take the snapshot test on iOS13.
  */
-- (void)snapshotVerifyView:(UIView *)view tolerance:(CGFloat)tolerancePercent;
-
+- (void)snapshotVerifyView:(UIView *)view
+                 tolerance:(CGFloat)tolerancePercent
+              supportIOS13:(BOOL)supportIOS13;
 @end

--- a/components/private/Snapshot/src/SnapshotTestCase/MDCSnapshotTestCase.m
+++ b/components/private/Snapshot/src/SnapshotTestCase/MDCSnapshotTestCase.m
@@ -24,6 +24,8 @@
  */
 static NSString *const kiPhone7ModelA = @"iPhone9,1";
 static NSString *const kiPhone7ModelB = @"iPhone9,3";
+static NSString *const kiPhone8ModelA = @"iPhone10,1";
+static NSString *const kiPhone8ModelB = @"iPhone10,4";
 
 @implementation MDCSnapshotTestCase
 
@@ -33,11 +35,19 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
 }
 
 - (void)snapshotVerifyView:(UIView *)view {
-  [self snapshotVerifyView:view tolerance:0];
+  [self snapshotVerifyView:view tolerance:0 supportIOS13:NO];
 }
 
-- (void)snapshotVerifyView:(UIView *)view tolerance:(CGFloat)tolerancePercent {
-  if (![self isSupportedDevice]) {
+- (void)snapshotVerifyViewForIOS13:(UIView *)view {
+  [self snapshotVerifyView:view tolerance:0 supportIOS13:YES];
+}
+
+- (void)snapshotVerifyView:(UIView *)view
+                 tolerance:(CGFloat)tolerancePercent
+              supportIOS13:(BOOL)supportIOS13 {
+  if (!supportIOS13 && ![self isSupportedDevice]) {
+    return;
+  } else if (supportIOS13 && ![self isSupportedIOS13Device]) {
     return;
   }
 
@@ -78,6 +88,24 @@ static NSString *const kiPhone7ModelB = @"iPhone9,3";
   if (!([deviceName isEqualToString:kiPhone7ModelA] ||
         [deviceName isEqualToString:kiPhone7ModelB])) {
     NSLog(@"Unsupported device. Snapshot tests currently only run on iPhone 7");
+    return NO;
+  }
+
+  return YES;
+}
+
+- (BOOL)isSupportedIOS13Device {
+  if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion != 13 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.minorVersion != 0 ||
+      NSProcessInfo.processInfo.operatingSystemVersion.patchVersion != 0) {
+    NSLog(@"Unsupported device. Snapshot tests currently only run on iOS 13.0.0");
+    return NO;
+  }
+
+  NSString *deviceName = [self getDeviceName];
+  if (!([deviceName isEqualToString:kiPhone8ModelA] ||
+        [deviceName isEqualToString:kiPhone8ModelB])) {
+    NSLog(@"Unsupported device. Snapshot tests currently only run on iPhone 8");
     return NO;
   }
 


### PR DESCRIPTION
Adds a flow to get snapshot tests for iOS13.

Snapshot tests that want to be run on iOS13 can and should call `- (void)snapshotVerifyViewForIOS13:(UIView *)view`.

This flow makes it that we don't duplicate all our snapshot tests for another device, and allows only specific tests to run on iOS13.