### PR TITLE
[AppBar] Provide app bar parameter for traitCollectionDidChange block.

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -41,7 +41,8 @@
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-    (UITraitCollection *_Nullable previousTraitCollection);
+    (MDCAppBarViewController *_Nonnull appBarController,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -256,7 +256,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   [super traitCollectionDidChange:previousTraitCollection];
 
   if (self.traitCollectionDidChangeBlock) {
-    self.traitCollectionDidChangeBlock(previousTraitCollection);
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
   }
 }
 

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -28,7 +28,8 @@
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
   appBarController.traitCollectionDidChangeBlock =
-      ^(UITraitCollection *_Nullable previousTraitCollection) {
+      ^(MDCAppBarViewController *_Nonnull appBarViewController,
+        UITraitCollection *_Nullable previousTraitCollection) {
         [expectation fulfill];
       };
 
@@ -39,15 +40,18 @@
   [self waitForExpectations:@[ expectation ] timeout:1];
 }
 
-- (void)testTraitCollectionDidChangeBlockCalledWithExpectedPreviousTraitCollection {
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
+  __block MDCAppBarViewController *passedAppBarViewController;
   appBarController.traitCollectionDidChangeBlock =
-      ^(UITraitCollection *_Nullable previousTraitCollection) {
+      ^(MDCAppBarViewController *_Nonnull appBarViewController,
+        UITraitCollection *_Nullable previousTraitCollection) {
         passedTraitCollection = previousTraitCollection;
+        passedAppBarViewController = appBarViewController;
         [expectation fulfill];
       };
 
@@ -58,6 +62,7 @@
   // Then
   [self waitForExpectations:@[ expectation ] timeout:1];
   XCTAssertEqual(passedTraitCollection, testCollection);
+  XCTAssertEqual(passedAppBarViewController, appBarController);
 }
 
 @end


### PR DESCRIPTION
Because `MDCAppBarViewController` is often injected into other view controllers, setting these blocks on the injector (*e.g.*, `MDCAppBarNavigationController`) means that the eventual app bar view controller object isn't actually available when the block is written. Instead of assuming access to the object receiving a trait collection change, the block can receive that object directly as a parameter.

Part of #7849
Follow-up to #7851