### PR TITLE
[TextFields] Textfields dynamic color support

### DIFF
--- a/components/TextFields/src/MDCTextInputUnderlineView.m
+++ b/components/TextFields/src/MDCTextInputUnderlineView.m
@@ -74,6 +74,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
 - (void)layoutSubviews {
   [super layoutSubviews];
   [self updateUnderlinePath];
+  [self updateColor];
 }
 
 - (CGSize)intrinsicContentSize {

--- a/components/TextFields/src/MaterialTextFields.h
+++ b/components/TextFields/src/MaterialTextFields.h
@@ -18,6 +18,7 @@
 #import "MDCTextField.h"
 #import "MDCTextFieldPositioningDelegate.h"
 #import "MDCTextInput.h"
+#import "MDCTextInputBorderView.h"
 #import "MDCTextInputCharacterCounter.h"
 #import "MDCTextInputController.h"
 #import "MDCTextInputControllerFilled.h"


### PR DESCRIPTION
CGColor is not used very often in MDCTextFields. CGColors are set in two files: MDCTextInputBorderView and MDCTextInputUnderlineView.

In MDCTextInputBorderView, a layer's strokeColor and fillColor are assigned the CGColor versions of public UIColor properties on the view. This happens on every call to layoutSubviews. I didn't change anything.

MDCTextInputUnderlineView,  there are layers representing an underline and a disabledUnderline. Both have their strokeColor properties updated using public UIColor properties in a method called updateColor. This PR makes it so that that method gets called in every layoutSubviews.

Closes #7862.