### PR TITLE
[BottomNavigation] Add `traitCollectionDidChangeBlock` API.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -199,6 +199,14 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarAlignment) {
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
 /**
+A block that is invoked when the @c MDCBottomNavigationBar receives a call to @c
+traitCollectionDidChange:. The block is called after the call to the superclass.
+*/
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCBottomNavigationBar *_Nonnull bottomNavigationBar,
+     UITraitCollection *_Nullable previousTraitCollection);
+
+/**
  Returns the navigation bar subview associated with the specific item.
 
  @param item A UITabBarItem

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -479,6 +479,14 @@ static NSString *const kOfAnnouncement = @"of";
   return nil;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark - Touch handlers
 
 - (void)didTouchUpInsideButton:(UIButton *)button {

--- a/components/BottomNavigation/tests/unit/BottomNavigationTests.m
+++ b/components/BottomNavigation/tests/unit/BottomNavigationTests.m
@@ -511,4 +511,30 @@
   XCTAssertNil(result);
 }
 
+#pragma mark - traitCollectionDidChangeBlock
+
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  __block MDCBottomNavigationBar *passedBottomNavigationBar = nil;
+  __block UITraitCollection *passedTraitCollection = nil;
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Called traitCollectionDidChangeBlock"];
+  UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:77];
+  void (^block)(MDCBottomNavigationBar *_Nonnull, UITraitCollection *_Nullable) = ^void(
+      MDCBottomNavigationBar *bottomNavigationBar, UITraitCollection *previousTraitCollection) {
+    passedBottomNavigationBar = bottomNavigationBar;
+    passedTraitCollection = previousTraitCollection;
+    [expectation fulfill];
+  };
+  self.bottomNavBar.traitCollectionDidChangeBlock = block;
+
+  // When
+  [self.bottomNavBar traitCollectionDidChange:testTraitCollection];
+  [self waitForExpectations:@[ expectation ] timeout:1];
+
+  // Then
+  XCTAssertEqual(passedBottomNavigationBar, self.bottomNavBar);
+  XCTAssertEqual(passedTraitCollection, testTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Provides a new API to allow a block of code to be executed when the Bottom
Navigation bar receives a `-traitCollectionDidChange:` call.

Closes #7892