### PR TITLE
[Tabs] Fix title-only example.

### DIFF
--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -241,11 +241,19 @@ static NSString *const kExampleTitle = @"TabBarView";
 }
 
 - (void)changeItemsToTextOnly {
+  NSMutableArray<UITabBarItem *> *newItems = [NSMutableArray array];
+  NSUInteger selectedIndex = self.tabBar.selectedItem
+                                 ? [self.tabBar.items indexOfObject:self.tabBar.selectedItem]
+                                 : NSNotFound;
   for (NSUInteger index = 0; index < self.tabBar.items.count; ++index) {
-    UITabBarItem *item = self.tabBar.items[index];
-    item.image = nil;
-    item.selectedImage = nil;
-    item.title = self.tabBarItemTitles[index % self.tabBarItemTitles.count];
+    UITabBarItem *originalItem = self.tabBar.items[index];
+    UITabBarItem *newItem = [[UITabBarItem alloc] initWithTitle:nil image:nil tag:originalItem.tag];
+    newItem.title = self.tabBarItemTitles[index % self.tabBarItemTitles.count];
+    [newItems addObject:newItem];
+  }
+  self.tabBar.items = newItems;
+  if (selectedIndex != NSNotFound) {
+    self.tabBar.selectedItem = self.tabBar.items[selectedIndex];
   }
 }
 


### PR DESCRIPTION
Once support for `selectedItem` was added, the example no longer correctly changed to title-only Tabs. This is because UITabBarItem seems to never allow setting `selectedItem` to `nil` once it has been read and returned anything other than `nil`.

Closes #7896