### PR TITLE
[Tabs] Fix segmented control position.

### DIFF
--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -194,7 +194,13 @@ static NSString *const kExampleTitle = @"TabBarView";
         .active = YES;
   } else {
     [self.view.centerXAnchor constraintEqualToAnchor:segmentedControl.centerXAnchor].active = YES;
-    [self.view.centerYAnchor constraintEqualToAnchor:segmentedControl.centerYAnchor].active = YES;
+    NSLayoutConstraint *centerYConstraint =
+        [self.view.centerYAnchor constraintEqualToAnchor:segmentedControl.centerYAnchor];
+    centerYConstraint.priority = UILayoutPriorityDefaultLow;
+    centerYConstraint.active = YES;
+    [self.tabBar.bottomAnchor constraintLessThanOrEqualToAnchor:segmentedControl.topAnchor
+                                                       constant:-16]
+        .active = YES;
     [self.view.leadingAnchor constraintLessThanOrEqualToAnchor:segmentedControl.leadingAnchor]
         .active = YES;
     [self.view.trailingAnchor constraintGreaterThanOrEqualToAnchor:segmentedControl.trailingAnchor]


### PR DESCRIPTION
On smaller devices, the constraints of the segmented control caused it to overlap the tab bar slightly.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone SE - 2019-07-11 at 23 52 17](https://user-images.githubusercontent.com/1753199/61101216-f1987300-a436-11e9-93c0-6dbce2274a25.png)|![Simulator Screen Shot - iPhone SE - 2019-07-11 at 23 49 14](https://user-images.githubusercontent.com/1753199/61101138-c01fa780-a436-11e9-8940-6117f1613673.png)|


Closes #7813
