### PR TITLE
[Tabs] Retain custom view in example.

### DIFF
--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -247,6 +247,15 @@ static NSString *const kExampleTitle = @"TabBarView";
                                  : NSNotFound;
   for (NSUInteger index = 0; index < self.tabBar.items.count; ++index) {
     UITabBarItem *originalItem = self.tabBar.items[index];
+    if ([originalItem isKindOfClass:[MDCTabBarItem class]]) {
+      MDCTabBarItem *originalCustomItem = (MDCTabBarItem *)originalItem;
+      MDCTabBarItem *newCustomItem = [[MDCTabBarItem alloc] initWithTitle:nil
+                                                                    image:nil
+                                                                      tag:originalItem.tag];
+      newCustomItem.mdc_customView = originalCustomItem.mdc_customView;
+      [newItems addObject:newCustomItem];
+      continue;
+    }
     UITabBarItem *newItem = [[UITabBarItem alloc] initWithTitle:nil image:nil tag:originalItem.tag];
     newItem.title = self.tabBarItemTitles[index % self.tabBarItemTitles.count];
     [newItems addObject:newItem];


### PR DESCRIPTION
When switching to title-only Tabs, the custom view was lost because the `UITabBarItem` was recreated incorrectly.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 7 - 2019-07-12 at 13 51 27](https://user-images.githubusercontent.com/1753199/61148259-5b069900-a4ac-11e9-9fb0-0cc42d619a7c.png)|![Simulator Screen Shot - iPhone 7 - 2019-07-12 at 13 52 48](https://user-images.githubusercontent.com/1753199/61148263-5d68f300-a4ac-11e9-9ae5-ce746dfa51ae.png)|

Part of #7896
Follow-up to #7897