### PR TITLE
[FlexibleHeader] Add unit test for the shadow layer

### DIFF
--- a/MDCFlexibleHeaderShadowTests.swift
+++ b/MDCFlexibleHeaderShadowTests.swift
@@ -1,0 +1,32 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+import MaterialComponents.MaterialFlexibleHeader
+
+class MDCFlexibleHeaderShadowTests: XCTestCase {
+  var flexibleHeader: MDCFlexibleHeaderView!
+
+  func setUp() {
+    super.setUp()
+
+    flexibleHeader = MDCFlexibleHeaderView()
+  }
+
+  func tearDown() {
+    flexibleHeader = nil
+
+    super.tearDown()
+  }
+}

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1059,6 +1059,7 @@ Pod::Spec.new do |mdc|
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
       unit_tests.dependency "MaterialComponents/FlexibleHeader+ColorThemer"
+      unit_tests.dependency "MaterialComponents/ShadowLayer"
     end
   end
 

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -91,6 +91,7 @@ swift_library(
         ":CanAlwaysExpandToMaximumHeight",
         ":ColorThemer",
         ":FlexibleHeader",
+        "//components/ShadowLayer",
     ],
 )
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShadowTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShadowTests.swift
@@ -12,21 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import XCTest
 import UIKit
 import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialShadowLayer
 
 class MDCFlexibleHeaderShadowTests: XCTestCase {
   var flexibleHeader: MDCFlexibleHeaderView!
 
-  func setUp() {
+  override func setUp() {
     super.setUp()
 
     flexibleHeader = MDCFlexibleHeaderView()
   }
 
-  func tearDown() {
+  override func tearDown() {
     flexibleHeader = nil
 
     super.tearDown()
+  }
+
+  func testDefaultFlexibleHeaderShadow() {
+    // Then
+    XCTAssertNil(flexibleHeader.shadowLayer)
+  }
+
+  func testMaterialShadowLayer() {
+    // Given
+    let shadowLayer = MDCShadowLayer()
+
+    // When
+    flexibleHeader.shadowLayer = shadowLayer
+
+    // Then
+    XCTAssertEqual(flexibleHeader.shadowLayer, shadowLayer)
+  }
+
+  func testCALayerShadowLayer() {
+    // Given
+    let fakeShadowLayer = CALayer()
+
+    // When
+    flexibleHeader.shadowLayer = fakeShadowLayer
+
+    // Then
+    XCTAssertEqual(flexibleHeader.shadowLayer, fakeShadowLayer)
   }
 }


### PR DESCRIPTION
MDCFlexibleHeader currently doesn't have any tests related to the shadow layer.  This adds tests for that property. Since there are no general flexible header tests I added this within it's own file as all other test files seem specific to other tests.