### PR TITLE
Fix memory leak in -[MDCRectangleShapeGenerator pathForSize:] by returning an autoreleased CGPathRef

### DIFF
--- a/components/Shapes/src/MDCRectangleShapeGenerator.m
+++ b/components/Shapes/src/MDCRectangleShapeGenerator.m
@@ -195,7 +195,7 @@ typedef enum : NSUInteger {
 
   CGPathCloseSubpath(path);
 
-  return path;
+  return CFAutorelease(path);
 }
 
 - (CGFloat)angleOfCorner:(MDCShapeCornerPosition)cornerPosition forViewSize:(CGSize)size {


### PR DESCRIPTION
Fixes #7912 