### PR TITLE
[FlexibleHeader] Add traitCollectionDidChangeBlock

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -375,6 +375,12 @@ IB_DESIGNABLE
 /** The delegate for this header view. */
 @property(nonatomic, weak, nullable) id<MDCFlexibleHeaderViewDelegate> delegate;
 
+/**
+ A block that is invoked when the FlexibleHeaderView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -379,7 +379,9 @@ IB_DESIGNABLE
  A block that is invoked when the FlexibleHeaderView receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
-@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,UITraitCollection *_Nullable previousTraitCollection);
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1259,6 +1259,16 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [self fhv_updateLayout];
 }
 
+#pragma mark TraitCollection
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark KVO
 
 - (void)observeValueForKeyPath:(NSString *)keyPath

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
@@ -26,12 +26,12 @@
   // Given
   MDCFlexibleHeaderView *flexibleHeader = [[MDCFlexibleHeaderView alloc] init];
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
   flexibleHeader.traitCollectionDidChangeBlock =
-  ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    [expectation fulfill];
-  };
+      ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
 
   // When
   [flexibleHeader traitCollectionDidChange:nil];
@@ -44,16 +44,16 @@
   // Given
   MDCFlexibleHeaderView *flexibleHeader = [[MDCFlexibleHeaderView alloc] init];
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
   __block MDCFlexibleHeaderView *passedFlexibleHeader;
   flexibleHeader.traitCollectionDidChangeBlock =
-  ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedFlexibleHeader = flexibleHeaderView;
-    [expectation fulfill];
-  };
+      ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedFlexibleHeader = flexibleHeaderView;
+        [expectation fulfill];
+      };
 
   // When
   UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
@@ -31,6 +31,7 @@
       ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
         UITraitCollection *_Nullable previousTraitCollection) {
         [expectation fulfill];
+        flexibleHeaderView.traitCollectionDidChangeBlock = nil;
       };
 
   // When
@@ -53,6 +54,7 @@
         passedTraitCollection = previousTraitCollection;
         passedFlexibleHeader = flexibleHeaderView;
         [expectation fulfill];
+        flexibleHeaderView.traitCollectionDidChangeBlock = nil;
       };
 
   // When

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
@@ -31,7 +31,6 @@
       ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
         UITraitCollection *_Nullable previousTraitCollection) {
         [expectation fulfill];
-        flexibleHeaderView.traitCollectionDidChangeBlock = nil;
       };
 
   // When
@@ -54,7 +53,6 @@
         passedTraitCollection = previousTraitCollection;
         passedFlexibleHeader = flexibleHeaderView;
         [expectation fulfill];
-        flexibleHeaderView.traitCollectionDidChangeBlock = nil;
       };
 
   // When

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderTraitColletionDidChangeTests.m
@@ -1,0 +1,68 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialFlexibleHeader.h"
+
+@interface FlexibleHeaderTraitCollectionDidChangeTests : XCTestCase
+
+@end
+
+@implementation FlexibleHeaderTraitCollectionDidChangeTests
+
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCFlexibleHeaderView *flexibleHeader = [[MDCFlexibleHeaderView alloc] init];
+  XCTestExpectation *expectation =
+  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  flexibleHeader.traitCollectionDidChangeBlock =
+  ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    [expectation fulfill];
+  };
+
+  // When
+  [flexibleHeader traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCFlexibleHeaderView *flexibleHeader = [[MDCFlexibleHeaderView alloc] init];
+  XCTestExpectation *expectation =
+  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCFlexibleHeaderView *passedFlexibleHeader;
+  flexibleHeader.traitCollectionDidChangeBlock =
+  ^(MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedFlexibleHeader = flexibleHeaderView;
+    [expectation fulfill];
+  };
+
+  // When
+  UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];
+  [flexibleHeader traitCollectionDidChange:testCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testCollection);
+  XCTAssertEqual(passedFlexibleHeader, flexibleHeader);
+}
+
+@end


### PR DESCRIPTION
The Flexible needs an API so clients can hook-in to trait collection changes. This additionally passes the flexibleHeader as a parameter so clients can modify the flexible header within the block.