### PR TITLE
[NavigationBar] Add traitCollectionDidChange block.

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -303,6 +303,14 @@ IB_DESIGNABLE
  */
 @property(nonatomic) MDCNavigationBarTitleAlignment titleAlignment;
 
+/**
+ A block that is invoked when the NavigationBar receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCNavigationBar *_Nonnull navigationBar,
+UITraitCollection *_Nullable previousTraitCollection);
+
 #pragma mark Observing UINavigationItem instances
 
 /**

--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -307,9 +307,8 @@ IB_DESIGNABLE
  A block that is invoked when the NavigationBar receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
-@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCNavigationBar *_Nonnull navigationBar,
-UITraitCollection *_Nullable previousTraitCollection);
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)(
+    MDCNavigationBar *_Nonnull navigationBar, UITraitCollection *_Nullable previousTraitCollection);
 
 #pragma mark Observing UINavigationItem instances
 

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -437,6 +437,16 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   }
 }
 
+#pragma mark TraitCollection
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark Layout
 
 - (CGRect)mdc_frameAlignedVertically:(CGRect)frame

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -545,4 +545,47 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   XCTAssertEqualObjects([self.navBar trailingButtonBar].tintColor, UIColor.cyanColor);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCNavigationBar *navigationBar = [[MDCNavigationBar alloc] init];
+  XCTestExpectation *expectation =
+  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  navigationBar.traitCollectionDidChangeBlock =
+  ^(MDCNavigationBar *_Nonnull navBar,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    [expectation fulfill];
+  };
+
+  // When
+  [navigationBar traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters{
+  // Given
+  MDCNavigationBar *navigationBar = [[MDCNavigationBar alloc] init];
+  XCTestExpectation *expectation =
+  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCNavigationBar *passedNavigationBar;
+  navigationBar.traitCollectionDidChangeBlock =
+  ^(MDCNavigationBar *_Nonnull navBar,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedNavigationBar = navBar;
+    [expectation fulfill];
+  };
+
+  // When
+  UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];
+  [navigationBar traitCollectionDidChange:testCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testCollection);
+  XCTAssertEqual(passedNavigationBar, navigationBar);
+}
+
 @end

--- a/components/NavigationBar/tests/unit/NavigationBarTests.m
+++ b/components/NavigationBar/tests/unit/NavigationBarTests.m
@@ -549,12 +549,11 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   // Given
   MDCNavigationBar *navigationBar = [[MDCNavigationBar alloc] init];
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
   navigationBar.traitCollectionDidChangeBlock =
-  ^(MDCNavigationBar *_Nonnull navBar,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    [expectation fulfill];
-  };
+      ^(MDCNavigationBar *_Nonnull navBar, UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
 
   // When
   [navigationBar traitCollectionDidChange:nil];
@@ -563,20 +562,19 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   [self waitForExpectations:@[ expectation ] timeout:1];
 }
 
-- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters{
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   MDCNavigationBar *navigationBar = [[MDCNavigationBar alloc] init];
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Called traitCollectionDidChange"];
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
   __block MDCNavigationBar *passedNavigationBar;
   navigationBar.traitCollectionDidChangeBlock =
-  ^(MDCNavigationBar *_Nonnull navBar,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedNavigationBar = navBar;
-    [expectation fulfill];
-  };
+      ^(MDCNavigationBar *_Nonnull navBar, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedNavigationBar = navBar;
+        [expectation fulfill];
+      };
 
   // When
   UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];


### PR DESCRIPTION
The navigation bar needs an API so clients can hook-in to trait collection changes. This additionally passes the navigation bar as a parameter so clients can modify the flexible header within the block. 

Closes #7919 