### PR TITLE
[FlexibleHeader] Add traitCollectionDidChangeBlock

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.h
@@ -75,7 +75,7 @@
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCFlexibleHeaderContainerViewController *_Nonnull flexibleHeaderContainer,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCFlexibleHeaderContainerViewController *_Nonnull flexibleHeaderContainer,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.h
@@ -70,4 +70,12 @@
  */
 @property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;
 
+/**
+ A block that is invoked when the @c MDCFlexibleHeaderContainerViewController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCFlexibleHeaderContainerViewController *_Nonnull flexibleHeaderContainer,
+UITraitCollection *_Nullable previousTraitCollection);
+
 @end

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderContainerViewController.m
@@ -73,6 +73,16 @@
   return _headerViewController.preferredStatusBarStyle;
 }
 
+#pragma mark TraitCollection
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark - Public
 
 - (void)setContentViewController:(UIViewController *)contentViewController {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderContainerViewControllerTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderContainerViewControllerTests.swift
@@ -1,0 +1,55 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+
+class FlexibleHeaderContainerViewControllerTests: XCTestCase {
+  func testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges() {
+    // Given
+    let flexibleHeader = MDCFlexibleHeaderContainerViewController()
+    let expectation = XCTestExpectation(description: "traitCollectionDidChange")
+    flexibleHeader.traitCollectionDidChangeBlock = { (_, _) in
+      expectation.fulfill()
+    }
+
+    // When
+    flexibleHeader.traitCollectionDidChange(nil)
+
+    // Then
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func testTraitCollectionDidChangeBlockCalledWithExpectedParameters() {
+  // Given
+  let flexibleHeader = MDCFlexibleHeaderContainerViewController()
+  let expectation = XCTestExpectation(description: "traitCollectionDidChange")
+  var passedTraitCollection: UITraitCollection? = nil
+  var passedFlexibleHeader: MDCFlexibleHeaderContainerViewController? = nil
+  flexibleHeader.traitCollectionDidChangeBlock = { (flexibleHeader, traitCollection) in
+    passedTraitCollection = traitCollection
+    passedFlexibleHeader = flexibleHeader
+    expectation.fulfill()
+  }
+  let fakeTraitCollection = UITraitCollection(displayScale: 77)
+
+  // When
+  flexibleHeader.traitCollectionDidChange(fakeTraitCollection)
+
+  // Then
+  self.wait(for: [expectation], timeout: 1)
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+  XCTAssertEqual(passedFlexibleHeader, flexibleHeader);
+  }
+}


### PR DESCRIPTION
The Flexible needs an API so clients can hook-in to trait collection changes. This additionally passes the flexibleHeader as a parameter so clients can modify the flexible header within the block.

Closes #7849 