### PR TITLE
[ActionSheet] Add traitCollectionDidChange block

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -116,8 +116,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCActionSheetController *_Nonnull actionSheet,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCActionSheetController *_Nonnull actionSheet,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 /**
  Indicates whether the button should automatically update its font when the device’s

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -112,6 +112,14 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
 @property(nonatomic, nullable, copy) NSString *message;
 
 /**
+ A block that is invoked when the @c MDCActionSheetController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCActionSheetController *_Nonnull actionSheet,
+UITraitCollection *_Nullable previousTraitCollection);
+
+/**
  Indicates whether the button should automatically update its font when the device’s
  UIContentSizeCategory is changed.
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -331,6 +331,14 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   return self.header.message;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (void)setTitleFont:(UIFont *)titleFont {
   self.header.titleFont = titleFont;
 }

--- a/components/ActionSheet/tests/unit/ActionSheetTest.swift
+++ b/components/ActionSheet/tests/unit/ActionSheetTest.swift
@@ -108,4 +108,39 @@ class ActionSheetTest: XCTestCase {
     XCTAssertEqual(actionSheet.view.backgroundColor, actionSheet.backgroundColor)
     XCTAssertEqual(actionSheet.view.backgroundColor, newBackgroundColor)
   }
+
+  func testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges() {
+    // Given
+    let expectation = XCTestExpectation(description: "traitCollectionDidChange")
+    actionSheet.traitCollectionDidChangeBlock = { (_, _) in
+      expectation.fulfill()
+    }
+
+    // When
+    actionSheet.traitCollectionDidChange(nil)
+
+    // Then
+    self.wait(for: [expectation], timeout: 1)
+  }
+
+  func testTraitCollectionDidChangeBlockCalledWithExpectedParameters() {
+    // Given
+    let expectation = XCTestExpectation(description: "traitCollectionDidChange")
+    var passedTraitCollection: UITraitCollection? = nil
+    var passedActionSheet: MDCActionSheetController? = nil
+    actionSheet.traitCollectionDidChangeBlock = { (action, traitCollection) in
+      passedTraitCollection = traitCollection
+      passedActionSheet = action
+      expectation.fulfill()
+    }
+    let fakeTraitCollection = UITraitCollection(displayScale: 77)
+
+    // When
+    actionSheet.traitCollectionDidChange(fakeTraitCollection)
+
+    // Then
+    self.wait(for: [expectation], timeout: 1)
+    XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+    XCTAssertEqual(passedActionSheet, actionSheet);
+  }
 }


### PR DESCRIPTION
The action sheet needs an API so clients can hook-in to trait collection changes. This additionally passes the action sheet as a parameter so clients can modify the action sheet within the block.
