### PR TITLE
[BottomAppBar] Add traitCollectionDidChange block

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -129,4 +129,12 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 - (void)setFloatingButtonPosition:(MDCBottomAppBarFloatingButtonPosition)floatingButtonPosition
                          animated:(BOOL)animated;
 
+/**
+ A block that is invoked when the @c MDCBottomAppBarView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCBottomAppBarView *_Nonnull bottomAppBar,
+UITraitCollection *_Nullable previousTraitCollection);
+
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -134,7 +134,7 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCBottomAppBarView *_Nonnull bottomAppBar,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCBottomAppBarView *_Nonnull bottomAppBar,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -423,4 +423,14 @@ static const int kMDCButtonAnimationDuration = 200;
   return [UIColor colorWithCGColor:_bottomBarLayer.shadowColor];
 }
 
+#pragma mark TraitCollection
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -159,4 +159,43 @@
   }
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  bottomAppBar.traitCollectionDidChangeBlock =
+    ^(MDCBottomAppBarView * _Nonnull bottomAppBarView, UITraitCollection * _Nullable previousTraitCollection) {
+    [expectation fulfill];
+  };
+
+  // When
+  [bottomAppBar traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCBottomAppBarView *passedBottomAppBar;
+  bottomAppBar.traitCollectionDidChangeBlock =
+  ^(MDCBottomAppBarView * _Nonnull bottomAppBarView, UITraitCollection * _Nullable previousTraitCollection) {
+    [expectation fulfill];
+    passedTraitCollection = previousTraitCollection;
+    passedBottomAppBar = bottomAppBarView;
+  };
+  UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [bottomAppBar traitCollectionDidChange:testTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testTraitCollection);
+  XCTAssertEqual(passedBottomAppBar, bottomAppBar);
+}
+
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -162,11 +162,13 @@
 - (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
   // Given
   MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
-  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
   bottomAppBar.traitCollectionDidChangeBlock =
-    ^(MDCBottomAppBarView * _Nonnull bottomAppBarView, UITraitCollection * _Nullable previousTraitCollection) {
-    [expectation fulfill];
-  };
+      ^(MDCBottomAppBarView *_Nonnull bottomAppBarView,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
 
   // When
   [bottomAppBar traitCollectionDidChange:nil];
@@ -178,15 +180,17 @@
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
-  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
   __block MDCBottomAppBarView *passedBottomAppBar;
   bottomAppBar.traitCollectionDidChangeBlock =
-  ^(MDCBottomAppBarView * _Nonnull bottomAppBarView, UITraitCollection * _Nullable previousTraitCollection) {
-    [expectation fulfill];
-    passedTraitCollection = previousTraitCollection;
-    passedBottomAppBar = bottomAppBarView;
-  };
+      ^(MDCBottomAppBarView *_Nonnull bottomAppBarView,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+        passedTraitCollection = previousTraitCollection;
+        passedBottomAppBar = bottomAppBarView;
+      };
   UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When


### PR DESCRIPTION
The bottom app bar needs an API so clients can hook-in to trait collection changes. This additionally passes the bottom app bar as a parameter so clients can modify the bottom app bar within the block.

Closes #7927 