### PR TITLE
[ActivityIndicator] Add traitCollectionDidChange block

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -138,6 +138,14 @@ IB_DESIGNABLE
  */
 - (void)stopAnimatingWithTransition:(nonnull MDCActivityIndicatorTransition *)stopTransition;
 
+/**
+ A block that is invoked when the @c MDCActivityIndicator receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCActivityIndicator *_Nonnull activityIndicator,
+     UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 /**

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -1016,6 +1016,14 @@ static const CGFloat kSingleCycleRotation =
   return UIAccessibilityTraitUpdatesFrequently;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 @end
 
 @implementation MDCActivityIndicatorTransition

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -167,6 +167,49 @@ static CGFloat randomNumber() {
   XCTAssertFalse(indicator.animating);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
+  // Given
+  MDCActivityIndicator *activityIndicator = [[MDCActivityIndicator alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  activityIndicator.traitCollectionDidChangeBlock =
+      ^(MDCActivityIndicator *_Nonnull indicator,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
+
+  // When
+  [activityIndicator traitCollectionDidChange:nil];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCActivityIndicator *activityIndicator = [[MDCActivityIndicator alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCActivityIndicator *passedActivityIndicator;
+  activityIndicator.traitCollectionDidChangeBlock =
+      ^(MDCActivityIndicator *_Nonnull indicator,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+        passedTraitCollection = previousTraitCollection;
+        passedActivityIndicator = indicator;
+      };
+  UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [activityIndicator traitCollectionDidChange:testTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testTraitCollection);
+  XCTAssertEqual(passedActivityIndicator, activityIndicator);
+}
+
 #pragma mark - Helpers
 
 - (void)verifySettingProgressOnIndicator:(MDCActivityIndicator *)indicator animated:(BOOL)animated {

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -167,24 +167,6 @@ static CGFloat randomNumber() {
   XCTAssertFalse(indicator.animating);
 }
 
-- (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
-  // Given
-  MDCActivityIndicator *activityIndicator = [[MDCActivityIndicator alloc] init];
-  XCTestExpectation *expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
-  activityIndicator.traitCollectionDidChangeBlock =
-      ^(MDCActivityIndicator *_Nonnull indicator,
-        UITraitCollection *_Nullable previousTraitCollection) {
-        [expectation fulfill];
-      };
-
-  // When
-  [activityIndicator traitCollectionDidChange:nil];
-
-  // Then
-  [self waitForExpectations:@[ expectation ] timeout:1];
-}
-
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   MDCActivityIndicator *activityIndicator = [[MDCActivityIndicator alloc] init];


### PR DESCRIPTION
The activity indicator needs an API so clients can hook-in to trait collection changes. This additionally passes the activity indicator as a parameter so clients can modify the activity indicator within the block.

Closes #7928 