### PR TITLE
[Catalog] Make the catalog use a dynamic color scheme

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -49,16 +49,10 @@ final class AppTheme {
 func DefaultContainerScheme() -> MDCContainerScheme {
   let containerScheme = MDCContainerScheme()
 
-  let colorScheme = MDCSemanticColorScheme()
-  colorScheme.primaryColor =  UIColor(red: CGFloat(0x21) / 255.0,
-                                      green: CGFloat(0x21) / 255.0,
-                                      blue: CGFloat(0x21) / 255.0,
-                                      alpha: 1)
-  colorScheme.primaryColorVariant = .init(white: 0.7, alpha: 1)
-  colorScheme.secondaryColor = UIColor(red: CGFloat(0x00) / 255.0,
-                                       green: CGFloat(0xE6) / 255.0,
-                                       blue: CGFloat(0x76) / 255.0,
-                                       alpha: 1)
+  let colorScheme = MDCSemanticColorScheme(defaults: .material201907)
+  colorScheme.primaryColor =  primaryColor()
+  colorScheme.primaryColorVariant = primaryColorVariant()
+  colorScheme.secondaryColor = secondaryColor()
   containerScheme.colorScheme = colorScheme
 
   let typographyScheme = MDCTypographyScheme()
@@ -71,4 +65,64 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   containerScheme.shapeScheme = shapeScheme
 
   return containerScheme
+}
+
+private func primaryColor() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return UIColor(
+          red: CGFloat(0xde) / 255.0,
+          green: CGFloat(0xde) / 255.0,
+          blue: CGFloat(0xde) / 255.0,
+          alpha: 1)
+      }
+      return UIColor(
+        red: CGFloat(0x21) / 255.0,
+        green: CGFloat(0x21) / 255.0,
+        blue: CGFloat(0x21) / 255.0,
+        alpha: 1)
+    }
+  }
+  return UIColor(
+    red: CGFloat(0x21) / 255.0,
+    green: CGFloat(0x21) / 255.0,
+    blue: CGFloat(0x21) / 255.0,
+    alpha: 1)
+}
+
+private func primaryColorVariant() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return .init(white: 0.3, alpha: 1)
+      }
+      return .init(white: 0.7, alpha: 1)
+    }
+  }
+  return .init(white: 0.7, alpha: 1)
+}
+
+private func secondaryColor() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return UIColor(
+          red: CGFloat(0xFF) / 255.0,
+          green: CGFloat(0x19) / 255.0,
+          blue: CGFloat(0x89) / 255.0,
+          alpha: 1)
+      }
+      return  UIColor(
+        red: CGFloat(0x00) / 255.0,
+        green: CGFloat(0xE6) / 255.0,
+        blue: CGFloat(0x76) / 255.0,
+        alpha: 1)
+    }
+  }
+  return UIColor(
+    red: CGFloat(0x00) / 255.0,
+    green: CGFloat(0xE6) / 255.0,
+    blue: CGFloat(0x76) / 255.0,
+    alpha: 1)
 }

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -50,9 +50,6 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   let containerScheme = MDCContainerScheme()
 
   let colorScheme = MDCSemanticColorScheme(defaults: .material201907)
-  colorScheme.primaryColor =  primaryColor()
-  colorScheme.primaryColorVariant = primaryColorVariant()
-  colorScheme.secondaryColor = secondaryColor()
   containerScheme.colorScheme = colorScheme
 
   let typographyScheme = MDCTypographyScheme()
@@ -65,64 +62,4 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   containerScheme.shapeScheme = shapeScheme
 
   return containerScheme
-}
-
-private func primaryColor() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return UIColor(
-          red: CGFloat(0xde) / 255.0,
-          green: CGFloat(0xde) / 255.0,
-          blue: CGFloat(0xde) / 255.0,
-          alpha: 1)
-      }
-      return UIColor(
-        red: CGFloat(0x21) / 255.0,
-        green: CGFloat(0x21) / 255.0,
-        blue: CGFloat(0x21) / 255.0,
-        alpha: 1)
-    })
-  }
-  return UIColor(
-    red: CGFloat(0x21) / 255.0,
-    green: CGFloat(0x21) / 255.0,
-    blue: CGFloat(0x21) / 255.0,
-    alpha: 1)
-}
-
-private func primaryColorVariant() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return .init(white: 0.3, alpha: 1)
-      }
-      return .init(white: 0.7, alpha: 1)
-    })
-  }
-  return .init(white: 0.7, alpha: 1)
-}
-
-private func secondaryColor() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return UIColor(
-          red: CGFloat(0xFF) / 255.0,
-          green: CGFloat(0x19) / 255.0,
-          blue: CGFloat(0x89) / 255.0,
-          alpha: 1)
-      }
-      return  UIColor(
-        red: CGFloat(0x00) / 255.0,
-        green: CGFloat(0xE6) / 255.0,
-        blue: CGFloat(0x76) / 255.0,
-        alpha: 1)
-    })
-  }
-  return UIColor(
-    red: CGFloat(0x00) / 255.0,
-    green: CGFloat(0xE6) / 255.0,
-    blue: CGFloat(0x76) / 255.0,
-    alpha: 1)
 }

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -69,7 +69,7 @@ func DefaultContainerScheme() -> MDCContainerScheme {
 
 private func primaryColor() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return UIColor(
           red: CGFloat(0xde) / 255.0,
@@ -82,7 +82,7 @@ private func primaryColor() -> UIColor {
         green: CGFloat(0x21) / 255.0,
         blue: CGFloat(0x21) / 255.0,
         alpha: 1)
-    }
+    })
   }
   return UIColor(
     red: CGFloat(0x21) / 255.0,
@@ -93,19 +93,19 @@ private func primaryColor() -> UIColor {
 
 private func primaryColorVariant() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return .init(white: 0.3, alpha: 1)
       }
       return .init(white: 0.7, alpha: 1)
-    }
+    })
   }
   return .init(white: 0.7, alpha: 1)
 }
 
 private func secondaryColor() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return UIColor(
           red: CGFloat(0xFF) / 255.0,
@@ -118,7 +118,7 @@ private func secondaryColor() -> UIColor {
         green: CGFloat(0xE6) / 255.0,
         blue: CGFloat(0x76) / 255.0,
         alpha: 1)
-    }
+    })
   }
   return UIColor(
     red: CGFloat(0x00) / 255.0,


### PR DESCRIPTION
This updates the catalog to use the dynamic color scheme `.material201907`.

| Before | After |
| --- | --- |
|![cat-before](https://user-images.githubusercontent.com/7131294/61297556-56363380-a791-11e9-9d95-991ea0bafe17.gif)|![cat-material](https://user-images.githubusercontent.com/7131294/61304656-61439080-a79e-11e9-9eae-91b2347ba275.gif)|

