### PR TITLE
[Catalog] Update the catalog to support dark mode

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -49,16 +49,10 @@ final class AppTheme {
 func DefaultContainerScheme() -> MDCContainerScheme {
   let containerScheme = MDCContainerScheme()
 
-  let colorScheme = MDCSemanticColorScheme()
-  colorScheme.primaryColor =  UIColor(red: CGFloat(0x21) / 255.0,
-                                      green: CGFloat(0x21) / 255.0,
-                                      blue: CGFloat(0x21) / 255.0,
-                                      alpha: 1)
-  colorScheme.primaryColorVariant = .init(white: 0.7, alpha: 1)
-  colorScheme.secondaryColor = UIColor(red: CGFloat(0x00) / 255.0,
-                                       green: CGFloat(0xE6) / 255.0,
-                                       blue: CGFloat(0x76) / 255.0,
-                                       alpha: 1)
+  let colorScheme = MDCSemanticColorScheme(defaults: .material201907)
+  colorScheme.primaryColor =  primaryColor()
+  colorScheme.primaryColorVariant = primaryColorVariant()
+  colorScheme.secondaryColor = secondaryColor()
   containerScheme.colorScheme = colorScheme
 
   let typographyScheme = MDCTypographyScheme()
@@ -71,4 +65,64 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   containerScheme.shapeScheme = shapeScheme
 
   return containerScheme
+}
+
+private func primaryColor() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return UIColor(
+          red: CGFloat(0xde) / 255.0,
+          green: CGFloat(0xde) / 255.0,
+          blue: CGFloat(0xde) / 255.0,
+          alpha: 1)
+      }
+      return UIColor(
+        red: CGFloat(0x21) / 255.0,
+        green: CGFloat(0x21) / 255.0,
+        blue: CGFloat(0x21) / 255.0,
+        alpha: 1)
+    }
+  }
+  return UIColor(
+    red: CGFloat(0x21) / 255.0,
+    green: CGFloat(0x21) / 255.0,
+    blue: CGFloat(0x21) / 255.0,
+    alpha: 1)
+}
+
+private func primaryColorVariant() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return .init(white: 0.3, alpha: 1)
+      }
+      return .init(white: 0.7, alpha: 1)
+    }
+  }
+  return .init(white: 0.7, alpha: 1)
+}
+
+private func secondaryColor() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor { (trait) -> UIColor in
+      if (trait.userInterfaceStyle == .dark) {
+        return UIColor(
+          red: CGFloat(0xFF) / 255.0,
+          green: CGFloat(0x19) / 255.0,
+          blue: CGFloat(0x89) / 255.0,
+          alpha: 1)
+      }
+      return  UIColor(
+        red: CGFloat(0x00) / 255.0,
+        green: CGFloat(0xE6) / 255.0,
+        blue: CGFloat(0x76) / 255.0,
+        alpha: 1)
+    }
+  }
+  return UIColor(
+    red: CGFloat(0x00) / 255.0,
+    green: CGFloat(0xE6) / 255.0,
+    blue: CGFloat(0x76) / 255.0,
+    alpha: 1)
 }

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -50,9 +50,6 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   let containerScheme = MDCContainerScheme()
 
   let colorScheme = MDCSemanticColorScheme(defaults: .material201907)
-  colorScheme.primaryColor =  primaryColor()
-  colorScheme.primaryColorVariant = primaryColorVariant()
-  colorScheme.secondaryColor = secondaryColor()
   containerScheme.colorScheme = colorScheme
 
   let typographyScheme = MDCTypographyScheme()
@@ -65,64 +62,4 @@ func DefaultContainerScheme() -> MDCContainerScheme {
   containerScheme.shapeScheme = shapeScheme
 
   return containerScheme
-}
-
-private func primaryColor() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return UIColor(
-          red: CGFloat(0xde) / 255.0,
-          green: CGFloat(0xde) / 255.0,
-          blue: CGFloat(0xde) / 255.0,
-          alpha: 1)
-      }
-      return UIColor(
-        red: CGFloat(0x21) / 255.0,
-        green: CGFloat(0x21) / 255.0,
-        blue: CGFloat(0x21) / 255.0,
-        alpha: 1)
-    })
-  }
-  return UIColor(
-    red: CGFloat(0x21) / 255.0,
-    green: CGFloat(0x21) / 255.0,
-    blue: CGFloat(0x21) / 255.0,
-    alpha: 1)
-}
-
-private func primaryColorVariant() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return .init(white: 0.3, alpha: 1)
-      }
-      return .init(white: 0.7, alpha: 1)
-    })
-  }
-  return .init(white: 0.7, alpha: 1)
-}
-
-private func secondaryColor() -> UIColor {
-  if #available(iOS 13.0, *) {
-    return UIColor(dynamicProvider: { (trait) -> UIColor in
-      if (trait.userInterfaceStyle == .dark) {
-        return UIColor(
-          red: CGFloat(0xFF) / 255.0,
-          green: CGFloat(0x19) / 255.0,
-          blue: CGFloat(0x89) / 255.0,
-          alpha: 1)
-      }
-      return  UIColor(
-        red: CGFloat(0x00) / 255.0,
-        green: CGFloat(0xE6) / 255.0,
-        blue: CGFloat(0x76) / 255.0,
-        alpha: 1)
-    })
-  }
-  return UIColor(
-    red: CGFloat(0x00) / 255.0,
-    green: CGFloat(0xE6) / 255.0,
-    blue: CGFloat(0x76) / 255.0,
-    alpha: 1)
 }

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -69,7 +69,7 @@ func DefaultContainerScheme() -> MDCContainerScheme {
 
 private func primaryColor() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return UIColor(
           red: CGFloat(0xde) / 255.0,
@@ -82,7 +82,7 @@ private func primaryColor() -> UIColor {
         green: CGFloat(0x21) / 255.0,
         blue: CGFloat(0x21) / 255.0,
         alpha: 1)
-    }
+    })
   }
   return UIColor(
     red: CGFloat(0x21) / 255.0,
@@ -93,19 +93,19 @@ private func primaryColor() -> UIColor {
 
 private func primaryColorVariant() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return .init(white: 0.3, alpha: 1)
       }
       return .init(white: 0.7, alpha: 1)
-    }
+    })
   }
   return .init(white: 0.7, alpha: 1)
 }
 
 private func secondaryColor() -> UIColor {
   if #available(iOS 13.0, *) {
-    return UIColor { (trait) -> UIColor in
+    return UIColor(dynamicProvider: { (trait) -> UIColor in
       if (trait.userInterfaceStyle == .dark) {
         return UIColor(
           red: CGFloat(0xFF) / 255.0,
@@ -118,7 +118,7 @@ private func secondaryColor() -> UIColor {
         green: CGFloat(0xE6) / 255.0,
         blue: CGFloat(0x76) / 255.0,
         alpha: 1)
-    }
+    })
   }
   return UIColor(
     red: CGFloat(0x00) / 255.0,

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -104,7 +104,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
 
     collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
-    collectionView?.backgroundColor = UIColor(white: 0.9, alpha: 1)
+    collectionView?.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
 
     MDCIcons.ic_arrow_backUseNewStyle(true)
 
@@ -341,7 +341,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
     let cell =
         collectionView.dequeueReusableCell(withReuseIdentifier: "MDCCatalogCollectionViewCell",
                                            for: indexPath)
-    cell.backgroundColor = UIColor.white
+    cell.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
 
     let componentName = node.children[indexPath.row].title
     if let catalogCell = cell as? MDCCatalogCollectionViewCell {

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -63,9 +63,14 @@ class MDCCatalogTileView: UIView {
     guard !bounds.isEmpty else {
       return
     }
-    imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
+    //imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
     imageView.image = getImage(componentNameString)
     imageView.frame = bounds
+  }
+
+  override func draw(_ rect: CGRect) {
+    super.draw(rect)
+    imageCache.removeAllObjects()
   }
 
   func getImage(_ key: String) -> UIImage {
@@ -146,22 +151,14 @@ class MDCCatalogTileView: UIView {
       newImage = MDCDrawImage(bounds, { MDCCatalogDrawMiscTile($0, $1) }, colorScheme)
     }
 
-    let styledImage = style(image: newImage)
-    imageCache.setObject(styledImage, forKey: componentNameString as AnyObject)
-    return styledImage
+    guard let unwrappedImage = newImage else {
+      let emptyImage = UIImage()
+      imageCache.setObject(emptyImage, forKey: componentNameString as AnyObject)
+      return emptyImage
+    }
+
+    imageCache.setObject(unwrappedImage, forKey: componentNameString as AnyObject)
+    return unwrappedImage
   }
   // swiftlint:enable function_body_length
-}
-
-/// Styles the image to support both light and dark mode.
-///
-/// - Note: If given `nil` will return a empty image styles correctly.
-/// - Parameter image: The image to be styled.
-private func style(image: UIImage?) -> UIImage {
-  let primaryColor = AppTheme.globalTheme.colorScheme.primaryColor
-  guard let unwrappedImage = image else {
-    let emptyImage = UIImage()
-    return emptyImage.withTintColor(primaryColor)
-  }
-  return unwrappedImage.withTintColor(primaryColor)
 }

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -63,7 +63,6 @@ class MDCCatalogTileView: UIView {
     guard !bounds.isEmpty else {
       return
     }
-    //imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
     imageView.image = getImage(componentNameString)
     imageView.frame = bounds
   }

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -29,7 +29,7 @@ class MDCCatalogTileView: UIView {
     }
   }
   private lazy var imageView = UIImageView()
-  let imageCache = NSCache<AnyObject, UIImage>()
+  private let imageCache = NSCache<AnyObject, UIImage>()
 
   deinit {
     NotificationCenter.default.removeObserver(self,
@@ -63,7 +63,6 @@ class MDCCatalogTileView: UIView {
     guard !bounds.isEmpty else {
       return
     }
-    imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
     imageView.image = getImage(componentNameString)
     imageView.frame = bounds
   }

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -63,6 +63,7 @@ class MDCCatalogTileView: UIView {
     guard !bounds.isEmpty else {
       return
     }
+    imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
     imageView.image = getImage(componentNameString)
     imageView.frame = bounds
   }

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -29,7 +29,7 @@ class MDCCatalogTileView: UIView {
     }
   }
   private lazy var imageView = UIImageView()
-  private let imageCache = NSCache<AnyObject, UIImage>()
+  let imageCache = NSCache<AnyObject, UIImage>()
 
   deinit {
     NotificationCenter.default.removeObserver(self,
@@ -56,7 +56,6 @@ class MDCCatalogTileView: UIView {
 
   @objc func themeDidChange(notification: NSNotification) {
     imageCache.removeAllObjects()
-    setNeedsLayout()
   }
 
   override func layoutSubviews() {
@@ -147,14 +146,22 @@ class MDCCatalogTileView: UIView {
       newImage = MDCDrawImage(bounds, { MDCCatalogDrawMiscTile($0, $1) }, colorScheme)
     }
 
-    guard let unwrappedImage = newImage else {
-      let emptyImage = UIImage()
-      imageCache.setObject(emptyImage, forKey: componentNameString as AnyObject)
-      return emptyImage
-    }
-
-    imageCache.setObject(unwrappedImage, forKey: componentNameString as AnyObject)
-    return unwrappedImage
+    let styledImage = style(image: newImage)
+    imageCache.setObject(styledImage, forKey: componentNameString as AnyObject)
+    return styledImage
   }
   // swiftlint:enable function_body_length
+}
+
+/// Styles the image to support both light and dark mode.
+///
+/// - Note: If given `nil` will return a empty image styles correctly.
+/// - Parameter image: The image to be styled.
+private func style(image: UIImage?) -> UIImage {
+  let primaryColor = AppTheme.globalTheme.colorScheme.primaryColor
+  guard let unwrappedImage = image else {
+    let emptyImage = UIImage()
+    return emptyImage.withTintColor(primaryColor)
+  }
+  return unwrappedImage.withTintColor(primaryColor)
 }

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -56,6 +56,7 @@ class MDCCatalogTileView: UIView {
 
   @objc func themeDidChange(notification: NSNotification) {
     imageCache.removeAllObjects()
+    setNeedsLayout()
   }
 
   override func layoutSubviews() {
@@ -63,6 +64,7 @@ class MDCCatalogTileView: UIView {
     guard !bounds.isEmpty else {
       return
     }
+    imageView.tintColor = AppTheme.globalTheme.colorScheme.primaryColor
     imageView.image = getImage(componentNameString)
     imageView.frame = bounds
   }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -534,7 +534,7 @@ extension MDCNodeListViewController {
       cell!.accessibilityIdentifier = "Cell" + cell!.textLabel!.text!
       cell!.accessoryType = .disclosureIndicator
     }
-
+    cell?.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
     return cell!
   }
 

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -211,7 +211,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
     mainSectionHeader = MainSectionHeader()
     additionalExamplesSectionHeader = createAdditionalExamplesSectionHeader()
-    self.tableView.backgroundColor = UIColor.white
+    self.tableView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
     self.tableView.separatorStyle = .none
     self.tableView.sectionHeaderHeight = UITableView.automaticDimension
 
@@ -284,7 +284,7 @@ extension MDCNodeListViewController {
 
   func createAdditionalExamplesSectionHeader() -> UIView {
     let sectionView = UIView()
-    sectionView.backgroundColor = UIColor.white
+    sectionView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
     let lineDivider = UIView()
     lineDivider.backgroundColor = UIColor(white: 0.85, alpha: 1)
     lineDivider.translatesAutoresizingMaskIntoConstraints = false
@@ -390,7 +390,7 @@ extension MDCNodeListViewController {
 
   func MainSectionHeader() -> UIView {
     let sectionView = UIView()
-    sectionView.backgroundColor = UIColor.white
+    sectionView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
 
     let sectionTitleLabel = UILabel()
     sectionTitleLabel.font = MDCTypography.body2Font()


### PR DESCRIPTION
This change updates the MDCCatalog to support dark mode for the collectionView and tableView within the main screen and the component screens.

| Before | After | 
| --- | --- |
|![cat-material](https://user-images.githubusercontent.com/7131294/61305357-88e72880-a79f-11e9-82f2-78bab20760cd.gif)|![cat-material-dark](https://user-images.githubusercontent.com/7131294/61305393-98667180-a79f-11e9-8d5c-f528c7f64e95.gif)|





Part of b/137100737
Stacked on #7934 