### PR TITLE
[Ripple] Fix active ripple color not having a persistent storage issue.

### DIFF
--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -62,18 +62,16 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
 @property(nonatomic, strong, nonnull) UIColor *rippleColor;
 
 /**
+ The ripple color of the currently active ripple.
+ */
+@property(nonatomic, strong, nonnull) UIColor *activeRippleColor;
+
+/**
  The maximum radius the ripple can expand to.
 
  @note This property is ignored if @c rippleStyle is set to @c MDCRippleStyleBounded.
  */
 @property(nonatomic, assign) CGFloat maximumRadius;
-
-/**
- Sets the ripple color of the currently active ripple.
-
- @param rippleColor The color to set the active ripple to.
- */
-- (void)setActiveRippleColor:(nullable UIColor *)rippleColor;
 
 /**
  Cancels all the existing ripples.

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -60,6 +60,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 
   _rippleColor = [[UIColor alloc] initWithWhite:0 alpha:kRippleDefaultAlpha];
+  _activeRippleColor = _rippleColor;
 
   _rippleStyle = MDCRippleStyleBounded;
   self.layer.masksToBounds = YES;

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -73,7 +73,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [super layoutSubviews];
 
   [self updateRippleStyle];
-  self.activeRippleLayer.fillColor = self.rippleColor.CGColor;
+  self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
 }
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -188,11 +188,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [self.activeRippleLayer fadeOutRippleAnimated:animated completion:completion];
 }
 
-- (void)setActiveRippleColor:(UIColor *)rippleColor {
-  _activeRippleColor = rippleColor;
-  self.activeRippleLayer.fillColor = rippleColor.CGColor;
-}
-
 #pragma mark - MDCRippleLayerDelegate
 
 - (void)rippleLayerTouchDownAnimationDidBegin:(MDCRippleLayer *)rippleLayer {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -38,6 +38,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 @implementation MDCRippleView
 
+@synthesize activeRippleColor = _activeRippleColor;
+
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
@@ -154,6 +156,11 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
     return _activeRippleColor;
   }
   return self.rippleColor;
+}
+
+- (void)setActiveRippleColor:(UIColor *)rippleColor {
+  _activeRippleColor = rippleColor;
+  self.activeRippleLayer.fillColor = rippleColor.CGColor;
 }
 
 - (void)beginRippleTouchDownAtPoint:(CGPoint)point

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -77,6 +77,14 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
 }
 
+- (void)setActiveRippleColor:(UIColor *)rippleColor {
+  if (rippleColor == nil) {
+    return;
+  }
+  _activeRippleColor = rippleColor;
+  self.activeRippleLayer.fillColor = rippleColor.CGColor;
+}
+
 - (void)layoutSublayersOfLayer:(CALayer *)layer {
   [super layoutSublayersOfLayer:layer];
   for (CALayer *sublayer in self.layer.sublayers) {
@@ -158,13 +166,13 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     [self.traitCollection performAsCurrentTraitCollection:^{
-      rippleLayer.fillColor = self.rippleColor.CGColor;
+      rippleLayer.fillColor = self.activeRippleColor.CGColor;
     }];
   } else {
-    rippleLayer.fillColor = self.rippleColor.CGColor;
+    rippleLayer.fillColor = self.activeRippleColor.CGColor;
   }
 #else
-  rippleLayer.fillColor = self.rippleColor.CGColor;
+  rippleLayer.fillColor = self.activeRippleColor.CGColor;
 #endif
   rippleLayer.frame = self.bounds;
   if (self.rippleStyle == MDCRippleStyleUnbounded) {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -188,13 +188,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [self.activeRippleLayer fadeOutRippleAnimated:animated completion:completion];
 }
 
-- (void)setActiveRippleColor:(UIColor *)rippleColor {
-  if (rippleColor == nil) {
-    return;
-  }
-  self.activeRippleLayer.fillColor = rippleColor.CGColor;
-}
-
 #pragma mark - MDCRippleLayerDelegate
 
 - (void)rippleLayerTouchDownAnimationDidBegin:(MDCRippleLayer *)rippleLayer {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -188,6 +188,11 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [self.activeRippleLayer fadeOutRippleAnimated:animated completion:completion];
 }
 
+- (void)setActiveRippleColor:(UIColor *)rippleColor {
+  _activeRippleColor = rippleColor;
+  self.activeRippleLayer.fillColor = rippleColor.CGColor;
+}
+
 #pragma mark - MDCRippleLayerDelegate
 
 - (void)rippleLayerTouchDownAnimationDidBegin:(MDCRippleLayer *)rippleLayer {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -60,7 +60,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 
   _rippleColor = [[UIColor alloc] initWithWhite:0 alpha:kRippleDefaultAlpha];
-  _activeRippleColor = _rippleColor;
 
   _rippleStyle = MDCRippleStyleBounded;
   self.layer.masksToBounds = YES;
@@ -75,14 +74,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
   [self updateRippleStyle];
   self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
-}
-
-- (void)setActiveRippleColor:(UIColor *)rippleColor {
-  if (rippleColor == nil) {
-    return;
-  }
-  _activeRippleColor = rippleColor;
-  self.activeRippleLayer.fillColor = rippleColor.CGColor;
 }
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer {
@@ -156,6 +147,13 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
     return nil;
   }
   return _activeRippleLayer;
+}
+
+- (UIColor *)activeRippleColor {
+  if (_activeRippleColor) {
+    return _activeRippleColor;
+  }
+  return self.rippleColor;
 }
 
 - (void)beginRippleTouchDownAtPoint:(CGPoint)point

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -144,15 +144,13 @@ static UIColor *RippleSelectedColor(void) {
   _selected = selected;
   // Go into the selected state visually.
   if (selected) {
+    [self updateActiveRippleColor];
     if (!self.activeRippleLayer) {
       // If we go into the selected state but a ripple layer doesn't exist yet, it means we went
       // into this state without initially creating the ripple overlay by going through the
       // highlighted state. This usually occurs when cells are reused and the selected state is
       // manually set to show the cell's existing state.
-      [self updateRippleColor];
       [self beginRippleTouchDownAtPoint:_lastTouch animated:NO completion:nil];
-    } else {
-      [self updateActiveRippleColor];
     }
   } else {
     // If we are no longer selecting, we cancel all the ripples.
@@ -169,7 +167,7 @@ static UIColor *RippleSelectedColor(void) {
   // Go into the highlighted state visually.
   if (rippleHighlighted && !_tapWentInsideOfBounds) {
     // If ripple becomes highlighted we initiate a ripple with animation.
-    [self updateRippleColor];
+    [self updateActiveRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
     if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
@@ -188,13 +186,11 @@ static UIColor *RippleSelectedColor(void) {
   _dragged = dragged;
   // Go into the dragged state visually.
   if (dragged) {
+    [self updateActiveRippleColor];
     if (!self.activeRippleLayer) {
       // If we go into the dragged state manually, without coming from the highlighted state,
       // We present the ripple overlay instantly without animation.
-      [self updateRippleColor];
       [self beginRippleTouchDownAtPoint:_lastTouch animated:NO completion:nil];
-    } else {
-      [self updateActiveRippleColor];
     }
   } else {
     // If we are no longer dragging, we cancel all the ripples.

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -94,7 +94,7 @@ static UIColor *RippleSelectedColor(void) {
 
 - (void)updateActiveRippleColor {
   UIColor *rippleColor = [self rippleColorForState:self.state];
-  [self setActiveRippleColor:rippleColor];
+  self.activeRippleColor = rippleColor;
 }
 
 - (void)setRippleColor:(UIColor *)rippleColor forState:(MDCRippleState)state {

--- a/components/Ripple/src/MDCStatefulRippleView.m
+++ b/components/Ripple/src/MDCStatefulRippleView.m
@@ -144,13 +144,15 @@ static UIColor *RippleSelectedColor(void) {
   _selected = selected;
   // Go into the selected state visually.
   if (selected) {
-    [self updateActiveRippleColor];
     if (!self.activeRippleLayer) {
       // If we go into the selected state but a ripple layer doesn't exist yet, it means we went
       // into this state without initially creating the ripple overlay by going through the
       // highlighted state. This usually occurs when cells are reused and the selected state is
       // manually set to show the cell's existing state.
+      [self updateRippleColor];
       [self beginRippleTouchDownAtPoint:_lastTouch animated:NO completion:nil];
+    } else {
+      [self updateActiveRippleColor];
     }
   } else {
     // If we are no longer selecting, we cancel all the ripples.
@@ -167,7 +169,7 @@ static UIColor *RippleSelectedColor(void) {
   // Go into the highlighted state visually.
   if (rippleHighlighted && !_tapWentInsideOfBounds) {
     // If ripple becomes highlighted we initiate a ripple with animation.
-    [self updateActiveRippleColor];
+    [self updateRippleColor];
     [self beginRippleTouchDownAtPoint:_lastTouch animated:_didReceiveTouch completion:nil];
   } else if (!rippleHighlighted) {
     if (!self.allowsSelection && !self.dragged && !_tapWentOutsideOfBounds) {
@@ -186,11 +188,13 @@ static UIColor *RippleSelectedColor(void) {
   _dragged = dragged;
   // Go into the dragged state visually.
   if (dragged) {
-    [self updateActiveRippleColor];
     if (!self.activeRippleLayer) {
       // If we go into the dragged state manually, without coming from the highlighted state,
       // We present the ripple overlay instantly without animation.
+      [self updateRippleColor];
       [self beginRippleTouchDownAtPoint:_lastTouch animated:NO completion:nil];
+    } else {
+      [self updateActiveRippleColor];
     }
   } else {
     // If we are no longer dragging, we cancel all the ripples.

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -145,7 +145,7 @@
 
   // When
   [rippleView beginRippleTouchDownAtPoint:CGPointMake(0, 0) animated:YES completion:nil];
-  [rippleView setActiveRippleColor:[UIColor blueColor]];
+  rippleView.activeRippleColor = [UIColor blueColor];
 
   // Then
   XCTAssertTrue(

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
@@ -549,7 +549,7 @@ static NSString *const kLongTitleArabic =
   // Given
   self.itemView.titleLabel.textColor = UIColor.yellowColor;
   self.itemView.iconImageView.tintColor = UIColor.magentaColor;
-  self.itemView.rippleTouchController.rippleView.activeRippleColor = UIColor.blueColor;
+  self.itemView.rippleTouchController.rippleView.activeRippleColor  = UIColor.blueColor;
   [self.itemView sizeToFit];
 
   // When

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
@@ -549,7 +549,7 @@ static NSString *const kLongTitleArabic =
   // Given
   self.itemView.titleLabel.textColor = UIColor.yellowColor;
   self.itemView.iconImageView.tintColor = UIColor.magentaColor;
-  self.itemView.rippleTouchController.rippleView.rippleColor  = UIColor.blueColor;
+  self.itemView.rippleTouchController.rippleView.rippleColor = UIColor.blueColor;
   [self.itemView sizeToFit];
 
   // When

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
@@ -549,7 +549,7 @@ static NSString *const kLongTitleArabic =
   // Given
   self.itemView.titleLabel.textColor = UIColor.yellowColor;
   self.itemView.iconImageView.tintColor = UIColor.magentaColor;
-  self.itemView.rippleTouchController.rippleView.activeRippleColor  = UIColor.blueColor;
+  self.itemView.rippleTouchController.rippleView.rippleColor  = UIColor.blueColor;
   [self.itemView sizeToFit];
 
   // When

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewItemViewSnapshotTests.m
@@ -549,7 +549,7 @@ static NSString *const kLongTitleArabic =
   // Given
   self.itemView.titleLabel.textColor = UIColor.yellowColor;
   self.itemView.iconImageView.tintColor = UIColor.magentaColor;
-  self.itemView.rippleTouchController.rippleView.rippleColor = UIColor.blueColor;
+  self.itemView.rippleTouchController.rippleView.activeRippleColor = UIColor.blueColor;
   [self.itemView sizeToFit];
 
   // When


### PR DESCRIPTION
rippleColor was overwriting the color value of activeRippleLayer because there was no way to store the real active ripple color.

There was a view logic dependency that activeRippleColor's value was initialized from rippleColor if there is no value set. The added getter persists that for consistence.