### PR TITLE
[Elevation] Add property mdc_overrideElevation property

### DIFF
--- a/components/Elevation/src/MDCElevation.h
+++ b/components/Elevation/src/MDCElevation.h
@@ -33,6 +33,6 @@
  This can be used in cases where there is elevation behind an object that is not part of the
  view hierarchy, like a @c UIPresentationController.
 */
-@property (nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
+@property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
 
 @end

--- a/components/Elevation/src/MDCElevation.h
+++ b/components/Elevation/src/MDCElevation.h
@@ -25,4 +25,14 @@
  */
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
 
+@optional
+
+/**
+ When available, used by @c MaterialElevationResponding instead of @c mdc_baseElevation.
+
+ This can be used in cases where there is elevation behind an object that is not part of the
+ view hierarchy, like a @c UIPresentationController.
+*/
+@property (nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
+
 @end


### PR DESCRIPTION
Add an optional property for clients to override their elevation if they are using a UIPresentationController or another object that may not be in the view hierarchy but in the UIWindow.

Part of #7964