### PR TITLE
[ProgressView] Add Indeterminate Progress View State

### DIFF
--- a/components/ProgressView/src/MDCProgressView.h
+++ b/components/ProgressView/src/MDCProgressView.h
@@ -24,6 +24,15 @@ typedef NS_ENUM(NSInteger, MDCProgressViewBackwardAnimationMode) {
   MDCProgressViewBackwardAnimationModeAnimate
 };
 
+/** The mode the progress bar is in. */
+typedef NS_ENUM(NSInteger, MDCProgressViewMode) {
+  /** Display the progress in a determinate way. */
+  MDCProgressViewModeDeterminate,
+
+  /** Display the progress in an indeterminate way. */
+  MDCProgressViewModeIndeterminate
+};
+
 /**
  A Material linear determinate progress view.
 
@@ -67,6 +76,21 @@ IB_DESIGNABLE
 @property(nonatomic, assign) float progress;
 
 /**
+ If the progress view shows a constant loading animation (MDCProgressViewModeIndeterminate) or is
+ based on the progress property (MDCProgressViewModeDeterminate).
+
+ The default value is MDCProgressViewModeDeterminate.
+ */
+@property(nonatomic, assign) MDCProgressViewMode mode;
+
+/**
+ If the progress view is animating. Used when the isIndeterminate property is true.
+
+ The default value is false.
+ */
+@property(nonatomic, assign, getter=isAnimating) BOOL animating;
+
+/**
  The backward progress animation mode.
 
  When animating progress which is lower than the current progress value, this mode
@@ -97,10 +121,52 @@ IB_DESIGNABLE
        completion:(void (^__nullable)(BOOL finished))completion;
 
 /**
+ Changes the Determinate state, optionally animating the change.
+
+ @param mode The mode to change the progress view to.
+ @param animated Whether the change should be animated.
+ @param completion The completion block executed at the end of the animation.
+ */
+- (void)setMode:(MDCProgressViewMode)mode
+       animated:(BOOL)animated
+     completion:(void (^__nullable)(BOOL finished))completion;
+
+/**
+ Start the progress bar's indeterminate animation.
+ */
+- (void)startAnimating;
+
+/**
+ Stop the progress bar's indeterminate animation.
+ */
+- (void)stopAnimating;
+
+/**
  A block that is invoked when the @c MDCProgressView receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCProgressView *_Nonnull progressView, UITraitCollection *_Nullable previousTraitCollection);
+
+/**
+ Changes the Determinate state, optionally animating the change.
+
+ @param mode The mode to change the progress view to.
+ @param animated Whether the change should be animated.
+ @param completion The completion block executed at the end of the animation.
+ */
+- (void)setMode:(MDCProgressViewMode)mode
+       animated:(BOOL)animated
+     completion:(void (^__nullable)(BOOL finished))completion;
+
+/**
+ Start the progress bar's indeterminate animation.
+ */
+- (void)startAnimating;
+
+/**
+ Stop the progress bar's indeterminate animation.
+ */
+- (void)stopAnimating;
 
 @end

--- a/components/ProgressView/src/MDCProgressView.h
+++ b/components/ProgressView/src/MDCProgressView.h
@@ -148,25 +148,4 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCProgressView *_Nonnull progressView, UITraitCollection *_Nullable previousTraitCollection);
 
-/**
- Changes the Determinate state, optionally animating the change.
-
- @param mode The mode to change the progress view to.
- @param animated Whether the change should be animated.
- @param completion The completion block executed at the end of the animation.
- */
-- (void)setMode:(MDCProgressViewMode)mode
-       animated:(BOOL)animated
-     completion:(void (^__nullable)(BOOL finished))completion;
-
-/**
- Start the progress bar's indeterminate animation.
- */
-- (void)startAnimating;
-
-/**
- Stop the progress bar's indeterminate animation.
- */
-- (void)stopAnimating;
-
 @end

--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -29,14 +29,21 @@ static const CGFloat MDCProgressViewTrackColorDesaturation = (CGFloat)0.3;
 
 static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
 
+static const NSTimeInterval kAnimationDuration = 1.8;
+
+static const CGFloat MDCProgressViewBarWidthPercentage + (CGFloat)0.52;
+
 @interface MDCProgressView ()
 @property(nonatomic, strong) UIView *progressView;
 @property(nonatomic, strong) UIView *trackView;
+@property(nonatomic, strong) UIView *transitionView;
 @property(nonatomic) BOOL animatingHide;
 // A UIProgressView to return the same format for the accessibility value. For example, when
 // progress is 0.497, it reports "fifty per cent".
 @property(nonatomic, readonly) UIProgressView *accessibilityProgressView;
+@property(nonatomic) CFTimeInterval indeterminateAnimationStartTime;
 
+@property(nonatomic) CFTimeInterval indeterminateAnimationStartTime;
 @end
 
 @implementation MDCProgressView
@@ -63,13 +70,23 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
   self.clipsToBounds = YES;
   self.isAccessibilityElement = YES;
 
+  _mode = MDCProgressViewModeDeterminate;
+  _animating = NO;
+
   _backwardProgressAnimationMode = MDCProgressViewBackwardAnimationModeReset;
 
   _trackView = [[UIView alloc] initWithFrame:self.frame];
   _trackView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   [self addSubview:_trackView];
 
-  _progressView = [[UIView alloc] initWithFrame:CGRectZero];
+  _transitionView =
+      [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, CGRectGetHeight(self.bounds))];
+  _transitionView.backgroundColor = MDCProgressViewDefaultTintColor();
+  [self addSubview:_transitionView];
+
+  float barWidth = [self indeterminateLoadingBarWidth];
+  CGRect progressBarFrame = CGRectMake(-barWidth, 0, barWidth, CGRectGetHeight(self.bounds));
+  _progressView = [[UIView alloc] initWithFrame:progressBarFrame];
   [self addSubview:_progressView];
 
   _progressView.backgroundColor = MDCProgressViewDefaultTintColor();
@@ -90,6 +107,11 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
     [self updateProgressView];
     [self updateTrackView];
   }
+
+  if (_mode == MDCProgressViewModeIndeterminate && _animating) {
+    [self stopAnimating];
+    [self startAnimating];
+  }
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
@@ -109,10 +131,100 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
     progressTintColor = MDCProgressViewDefaultTintColor();
   }
   self.progressView.backgroundColor = progressTintColor;
+  self.transitionView.backgroundColor = progressTintColor;
 }
 
 - (UIColor *)trackTintColor {
   return self.trackView.backgroundColor;
+}
+
+- (void)setMode:(MDCProgressViewMode)mode {
+  if (_mode == mode) {
+    return;
+  }
+  _mode = mode;
+
+  // If the progress bar was animating in indeterminate mode before, restart the animation.
+  if (_animating && _mode == MDCProgressViewModeIndeterminate) {
+    [self.progressView.layer removeAllAnimations];
+    _animating = false;
+    [self startAnimating];
+  }
+}
+
+- (void)setMode:(MDCProgressViewMode)mode
+       animated:(BOOL)animated
+     completion:(void (^__nullable)(BOOL finished))completion {
+  if (_mode == mode) {
+    if(completion) {
+      completion(YES);
+    }
+    return;
+  }
+  _mode = mode;
+
+  if (!animated) {
+    if (_mode == MDCProgressViewModeIndeterminate) {
+      self.progressView.frame = CGRectMake(0, 0, 0, CGRectGetHeight(self.bounds));
+    }
+    // Update the transition without an animation.
+    [self updateProgressView];
+    if(completion) {
+      completion(YES);
+    }
+  }
+
+  // Change from indeterminate to determinate.
+  if (_mode == MDCProgressViewModeDeterminate) {
+    // If the indeterminate view wasn't animating, just animate the determinate bar in.
+    if (!_animating) {
+      [self setProgress:_progress animated:animated completion:completion];
+      if(completion) {
+        completion(YES);
+      }
+      return;
+    }
+
+    // Transition from the indeterminate to the determinate bar.
+    CFTimeInterval stopTime = [self.progressView.layer convertTime:CACurrentMediaTime()
+                                                         fromLayer:nil];
+    CFTimeInterval timeDiff = stopTime - _indeterminateAnimationStartTime;
+
+    CGFloat percentage = timeDiff / kAnimationDuration - floor(timeDiff / kAnimationDuration);
+    CGFloat xPosition =
+    (CGRectGetWidth(self.bounds) + [self indeterminateLoadingBarWidth]) * percentage -
+    [self indeterminateLoadingBarWidth];
+
+    [self.progressView.layer removeAllAnimations];
+    CGRect progressBarStartFrame =
+    CGRectMake(xPosition, 0, [self indeterminateLoadingBarWidth], CGRectGetHeight(self.bounds));
+    self.progressView.frame = progressBarStartFrame;
+
+    [UIView animateWithDuration:[[self class] animationDuration]
+                          delay:0
+                        options:[[self class] animationOptions]
+                     animations:^{
+                       [self updateProgressView];
+                     }
+                     completion:completion];
+  } else {
+    // Change from determinate to indeterminate.
+    CGRect zeroFrame = CGRectMake(0, 0, 0, CGRectGetHeight(self.bounds));
+    // Animate the transition from progress to indeterminate.
+    CGRect transitionViewFrame =
+    CGRectMake(0, 0, CGRectGetWidth(self.bounds) * _progress, CGRectGetHeight(self.bounds));
+    self.transitionView.frame = transitionViewFrame;
+    [self layoutIfNeeded];
+
+    [UIView animateWithDuration:[[self class] animationDuration]
+                          delay:0
+                        options:[[self class] animationOptions]
+                     animations:^{
+                       self.transitionView.frame = zeroFrame;
+                     }
+                     completion:completion];
+
+  }
 }
 
 - (void)setTrackTintColor:(UIColor *)trackTintColor {
@@ -147,6 +259,15 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
 - (void)setProgress:(float)progress
            animated:(BOOL)animated
          completion:(void (^__nullable)(BOOL finished))userCompletion {
+  // Indeterminate mode ignores the progress.
+  if (_mode == MDCProgressViewModeIndeterminate) {
+    self.progress = progress;
+    if(userCompletion) {
+      userCompletion(NO);
+    }
+    return;
+  }
+
   if (progress < self.progress &&
       self.backwardProgressAnimationMode == MDCProgressViewBackwardAnimationModeReset) {
     self.progress = 0;
@@ -269,6 +390,16 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
   return self.accessibilityProgressView.accessibilityLabel;
 }
 
+- (void)startAnimating {
+  [self startAnimatingBar];
+  _animating = YES;
+}
+
+- (void)stopAnimating {
+  _animating = NO;
+  [self.progressView.layer removeAllAnimations];
+}
+
 #pragma mark Private
 
 + (NSTimeInterval)animationDuration {
@@ -291,6 +422,9 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
 }
 
 - (void)updateProgressView {
+  if (_mode == MDCProgressViewModeIndeterminate) {
+    return;
+  }
   // Update progressView with the current progress value.
   CGFloat progressWidth = MDCCeil(self.progress * CGRectGetWidth(self.bounds));
   CGRect progressFrame = CGRectMake(0, 0, progressWidth, CGRectGetHeight(self.bounds));
@@ -303,6 +437,33 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
 - (void)updateTrackView {
   const CGSize size = self.bounds.size;
   self.trackView.frame = self.hidden ? CGRectMake(0.0, size.height, size.width, 0.0) : self.bounds;
+}
+
+- (void)startAnimatingBar {
+  // If the bar isn't indeterminate or the bar is already animating, don't add the animation again.
+  if (_mode == MDCProgressViewModeDeterminate || _animating) {
+    return;
+  }
+
+  float barWidth = [self indeterminateLoadingBarWidth];
+  CGRect progressBarStartFrame = CGRectMake(-barWidth, 0, barWidth, CGRectGetHeight(self.bounds));
+  self.progressView.frame = progressBarStartFrame;
+
+  CGPoint progressBarEndPoint =
+      CGPointMake(self.progressView.layer.position.x + CGRectGetWidth(self.bounds) + barWidth,
+                  CGRectGetHeight(self.bounds) / 2);
+  CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"position"];
+  animation.fromValue = [NSValue valueWithCGPoint:self.progressView.layer.position];
+  animation.toValue = [NSValue valueWithCGPoint:progressBarEndPoint];
+  animation.duration = kAnimationDuration;
+  animation.repeatCount = HUGE_VALF;
+  [self.progressView.layer addAnimation:animation forKey:@"position"];
+  _indeterminateAnimationStartTime = [self.progressView.layer convertTime:CACurrentMediaTime()
+                                                                fromLayer:nil];
+}
+
+- (float)indeterminateLoadingBarWidth {
+  return CGRectGetWidth(self.bounds) * MDCProgressViewBarWidthPercentage;
 }
 
 @end

--- a/components/ProgressView/tests/unit/ProgressViewTests.m
+++ b/components/ProgressView/tests/unit/ProgressViewTests.m
@@ -66,6 +66,14 @@
   XCTAssertEqual(_progressView.progress, 1);
 }
 
+- (void)testIndeterminateProgressView {
+  _progressView.mode = MDCProgressViewModeIndeterminate;
+  [_progressView startAnimating];
+  XCTAssertTrue(_progressView.isAnimating);
+  [_progressView stopAnimating];
+  XCTAssertFalse(_progressView.isAnimating);
+}
+
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   XCTestExpectation *expectation =


### PR DESCRIPTION
Add an indeterminate state to the progress view.

This resolves issue: https://github.com/material-components/material-components-ios/issues/7664

```closes #7664```