### PR TITLE
[Chips] Add traitCollectionDidChangeBlock

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -335,4 +335,11 @@
 - (void)setTitleColor:(nullable UIColor *)titleColor
              forState:(UIControlState)state UI_APPEARANCE_SELECTOR;
 
+/**
+ A block that is invoked when the MDCChipView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCChipView *_Nonnull activityIndicator, UITraitCollection *_Nullable previousTraitCollection);
+
 @end

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -236,6 +236,13 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
                                                 object:nil];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (void)setShapeGenerator:(id<MDCShapeGenerating>)shapeGenerator {
   if (shapeGenerator) {
     self.layer.cornerRadius = 0;

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -448,4 +448,28 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertTrue(chipView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCChipView *passedChipView;
+  chipView.traitCollectionDidChangeBlock =
+      ^(MDCChipView *_Nonnull blockChipView, UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+        passedTraitCollection = previousTraitCollection;
+        passedChipView = blockChipView;
+      };
+  UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [chipView traitCollectionDidChange:testTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testTraitCollection);
+  XCTAssertEqual(passedChipView, chipView);
+}
+
 @end


### PR DESCRIPTION
Adds traitCollectionDidChangeBlock to `MDCChipView`, called when the chip view's trait collection is changed.

Closes #7952 