### PR TITLE
[Dialogs] Add traitCollectionDidChangeBlock to MDCAlertController

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -178,6 +178,14 @@
  */
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
+/**
+ A block that is invoked when the MDCAlertController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCAlertController *_Nullable alertController,
+     UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 typedef NS_ENUM(NSInteger, MDCActionEmphasis) {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -124,6 +124,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   return self;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 /* Disable setter. Always use internal transition controller */
 - (void)setTransitioningDelegate:
     (__unused id<UIViewControllerTransitioningDelegate>)transitioningDelegate {

--- a/components/Dialogs/src/MDCDialogPresentationController.h
+++ b/components/Dialogs/src/MDCDialogPresentationController.h
@@ -131,4 +131,12 @@
  */
 - (CGRect)frameOfPresentedViewInContainerView;
 
+/**
+ A block that is invoked when the MDCDialogPresentationController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCDialogPresentationController *_Nullable presentationController,
+     UITraitCollection *_Nullable previousTraitCollection);
+
 @end

--- a/components/Dialogs/src/MDCDialogPresentationController.m
+++ b/components/Dialogs/src/MDCDialogPresentationController.m
@@ -115,6 +115,13 @@ static UIEdgeInsets MDCDialogEdgeInsets = {24, 20, 24, 20};
   [self unregisterKeyboardNotifications];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (CGRect)frameOfPresentedViewInContainerView {
   CGRect containerBounds = CGRectStandardize(self.containerView.bounds);
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -418,15 +418,16 @@
   // Given
   MDCAlertController *alertController = [[MDCAlertController alloc] init];
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
   __block MDCAlertController *passedAlertController;
   alertController.traitCollectionDidChangeBlock =
-  ^(MDCAlertController *_Nonnull blockAlertController, UITraitCollection *_Nullable previousTraitCollection) {
-    [expectation fulfill];
-    passedTraitCollection = previousTraitCollection;
-    passedAlertController = blockAlertController;
-  };
+      ^(MDCAlertController *_Nonnull blockAlertController,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+        passedTraitCollection = previousTraitCollection;
+        passedAlertController = blockAlertController;
+      };
   UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -414,4 +414,28 @@
                  fakeButtonFont);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCAlertController *alertController = [[MDCAlertController alloc] init];
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCAlertController *passedAlertController;
+  alertController.traitCollectionDidChangeBlock =
+  ^(MDCAlertController *_Nonnull blockAlertController, UITraitCollection *_Nullable previousTraitCollection) {
+    [expectation fulfill];
+    passedTraitCollection = previousTraitCollection;
+    passedAlertController = blockAlertController;
+  };
+  UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [alertController traitCollectionDidChange:testTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testTraitCollection);
+  XCTAssertEqual(passedAlertController, alertController);
+}
+
 @end

--- a/components/Dialogs/tests/unit/MDCDialogPresentationControllerUnitTests.swift
+++ b/components/Dialogs/tests/unit/MDCDialogPresentationControllerUnitTests.swift
@@ -24,11 +24,11 @@ class MDCDialogPresentationControllerTests: XCTestCase {
                                         presenting: UIViewController())
     let expectation = XCTestExpectation(description: "traitCollectionDidChange")
     var passedTraitCollection: UITraitCollection!
-    var passedAlertController: MDCDialogPresentationController!
+    var passedPresentationController: MDCDialogPresentationController!
     presentationController.traitCollectionDidChangeBlock = {
-      blockAlertController, previousTraitCollection in
+      blockPresentationController, previousTraitCollection in
       passedTraitCollection = previousTraitCollection
-      passedAlertController = blockAlertController
+      passedPresentationController = blockPresentationController
           expectation.fulfill()
     }
     let traitCollection = UITraitCollection(displayScale: 7)
@@ -39,6 +39,6 @@ class MDCDialogPresentationControllerTests: XCTestCase {
     // Then
     wait(for: [expectation], timeout: 1)
     XCTAssertEqual(passedTraitCollection, traitCollection)
-    XCTAssertEqual(passedAlertController, presentationController)
+    XCTAssertEqual(passedPresentationController, presentationController)
   }
 }

--- a/components/Dialogs/tests/unit/MDCDialogPresentationControllerUnitTests.swift
+++ b/components/Dialogs/tests/unit/MDCDialogPresentationControllerUnitTests.swift
@@ -1,0 +1,44 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+import MaterialComponents.MaterialDialogs
+
+class MDCDialogPresentationControllerTests: XCTestCase {
+  func testTraitCollectionDidChangeCalledWithCorrectParameters() {
+    // Given
+    let presentationController =
+        MDCDialogPresentationController(presentedViewController: UIViewController(),
+                                        presenting: UIViewController())
+    let expectation = XCTestExpectation(description: "traitCollectionDidChange")
+    var passedTraitCollection: UITraitCollection!
+    var passedAlertController: MDCDialogPresentationController!
+    presentationController.traitCollectionDidChangeBlock = {
+      blockAlertController, previousTraitCollection in
+      passedTraitCollection = previousTraitCollection
+      passedAlertController = blockAlertController
+          expectation.fulfill()
+    }
+    let traitCollection = UITraitCollection(displayScale: 7)
+
+    // When
+    presentationController.traitCollectionDidChange(traitCollection)
+
+    // Then
+    wait(for: [expectation], timeout: 1)
+    XCTAssertEqual(passedTraitCollection, traitCollection)
+    XCTAssertEqual(passedAlertController, presentationController)
+  }
+}


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCAlertController, called when its trait collection changes.

Closes #7951