### PR TITLE
[*] Remove RTL snapshot method overrides.

### DIFF
--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -81,18 +81,6 @@ static NSString *const kLongTitle5Arabic =
   //  self.recordMode = YES;
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UIImageView class]]) {
-        continue;
-      }
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
   UIView *snapshotView = [view mdc_addToBackgroundView];
   [self snapshotVerifyView:snapshotView];

--- a/components/ActivityIndicator/tests/snapshot/MDCActivityIndicatorSnapshotTests.m
+++ b/components/ActivityIndicator/tests/snapshot/MDCActivityIndicatorSnapshotTests.m
@@ -62,15 +62,6 @@
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 #pragma mark - Tests
 
 - (void)testDeterminateProgress000LTR {

--- a/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
+++ b/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
@@ -71,15 +71,6 @@
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 #pragma mark - Tests
 
 - (void)testFloatingButtonCenterLTR {

--- a/components/ButtonBar/tests/snapshot/MDCButtonBarSnapshotTests.m
+++ b/components/ButtonBar/tests/snapshot/MDCButtonBarSnapshotTests.m
@@ -100,15 +100,6 @@ static NSString *const kTrailingTitleArabic = @"كل.";
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeToRTLAndArabic {
   self.leadingTitleItem.title = kLeadingTitleArabic;
   self.middleTitleItem.title = kMiddleTitleArabic;

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
@@ -71,15 +71,6 @@ static NSString *const kActionLowUrdu = @"کم";
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeToRTL:(MDCAlertController *)alertController {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:alertController.view];

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
@@ -98,15 +98,6 @@ static NSString *const kMessageLongArabic =
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeToRTL:(MDCAlertController *)alertController {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:alertController.view];

--- a/components/Dialogs/tests/snapshot/MDCAlertController_ThemingSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertController_ThemingSnapshotTests.m
@@ -168,15 +168,6 @@ static NSString *const kMessageLongArabic =
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeToRTL:(MDCAlertController *)alertController {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:alertController.view];

--- a/components/NavigationBar/tests/snapshot/MDCNavigationBarSnapshotTests.m
+++ b/components/NavigationBar/tests/snapshot/MDCNavigationBarSnapshotTests.m
@@ -110,15 +110,6 @@ static NSString *const kItemTitleLong3Arabic = @"تحت أي قدما وإقام
   [super tearDown];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)setStringsToArabicShort {
   self.itemWithTitle1.title = kItemTitleShort1Arabic;
   self.itemWithTitle2.title = kItemTitleShort2Arabic;

--- a/components/PageControl/tests/snapshot/MDCPageControlSnapshotTests.m
+++ b/components/PageControl/tests/snapshot/MDCPageControlSnapshotTests.m
@@ -50,15 +50,6 @@
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 #pragma mark - Tests
 
 - (void)testPageControlDefault {

--- a/components/ProgressView/tests/snapshot/MDCProgressViewCornerRadiusSnapshotTests.m
+++ b/components/ProgressView/tests/snapshot/MDCProgressViewCornerRadiusSnapshotTests.m
@@ -44,13 +44,6 @@
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-  for (UIView *subview in view.subviews) {
-    [self changeViewToRTL:subview];
-  }
-}
-
 #pragma mark - Tests
 
 - (void)testProgress000LTR {

--- a/components/ProgressView/tests/snapshot/MDCProgressViewSnapshotTests.m
+++ b/components/ProgressView/tests/snapshot/MDCProgressViewSnapshotTests.m
@@ -47,15 +47,6 @@
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 #pragma mark - Tests
 
 - (void)testProgress000LTR {

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -73,15 +73,6 @@ static NSString *const kItemTitleLong2Arabic =
   [self snapshotVerifyView:snapshotView];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (MDCSnackbarMessageView *)snackbarMessageViewWithMessage:(MDCSnackbarMessage *)message {
   return [[MDCSnackbarMessageView alloc] initWithMessage:message
                                           dismissHandler:nil

--- a/components/Tabs/tests/snapshot/MDCTabBarExtendedAlignmentSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/MDCTabBarExtendedAlignmentSnapshotTests.m
@@ -109,18 +109,6 @@ static NSString *const kItemTitleLong3Arabic = @"تحت أي قدما وإقام
   [super tearDown];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UIImageView class]]) {
-        continue;
-      }
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeLayoutToRTL {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:self.tabBar];

--- a/components/Tabs/tests/snapshot/MDCTabBarSizeClassDelegateSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/MDCTabBarSizeClassDelegateSnapshotTests.m
@@ -100,18 +100,6 @@ static NSString *const kItemTitleShort3Arabic = @"وتم";
   [super tearDown];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UIImageView class]]) {
-        continue;
-      }
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeLayoutToRTL {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:self.tabBar];

--- a/components/Tabs/tests/snapshot/MDCTabBarSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/MDCTabBarSnapshotTests.m
@@ -104,18 +104,6 @@ static NSString *const kItemTitleLong3Arabic = @"تحت أي قدما وإقام
   [super tearDown];
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  if (@available(iOS 9.0, *)) {
-    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UIImageView class]]) {
-        continue;
-      }
-      [self changeViewToRTL:subview];
-    }
-  }
-}
-
 - (void)changeLayoutToRTL {
   if (@available(iOS 9.0, *)) {
     [self changeViewToRTL:self.tabBar];

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
@@ -242,16 +242,6 @@ static NSString *const kItemTitleLong3Arabic = @"تحت أي قدما وإقام
   }
 }
 
-- (void)changeViewToRTL:(UIView *)view {
-  for (UIView *subview in view.subviews) {
-    if ([view isKindOfClass:[UIImageView class]]) {
-      continue;
-    }
-    [self changeViewToRTL:subview];
-  }
-  view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-}
-
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
   // Needed so that the stack view can be constrained correctly and then allow any "scrolling" to
   // take place for the selected item to be visible.


### PR DESCRIPTION
With #7986, most snapshot tests began overriding a method that had nearly the
same behavior.
