### PR TITLE
[*] Drop iOS 9 guards for Swift.

### DIFF
--- a/components/Cards/examples/EditReorderCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderCollectionViewController.swift
@@ -64,17 +64,15 @@ class EditReorderCollectionViewController: UIViewController,
     collectionView.allowsMultipleSelection = true
     view.addSubview(collectionView)
 
-    if #available(iOS 9.0, *) {
-      navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
-                                                          style: .plain,
-                                                          target: self,
-                                                          action: #selector(toggleModes))
+    navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
+                                                        style: .plain,
+                                                        target: self,
+                                                        action: #selector(toggleModes))
 
-      let longPressGesture = UILongPressGestureRecognizer(target: self,
-                                                          action: #selector(reorderCards(gesture:)))
-      longPressGesture.cancelsTouchesInView = false
-      collectionView.addGestureRecognizer(longPressGesture)
-    }
+    let longPressGesture = UILongPressGestureRecognizer(target: self,
+                                                        action: #selector(reorderCards(gesture:)))
+    longPressGesture.cancelsTouchesInView = false
+    collectionView.addGestureRecognizer(longPressGesture)
 
     // randomly select images to display 30 items
     let count = UInt32(images.count)

--- a/components/Cards/examples/EditReorderShapedCollectionViewController.swift
+++ b/components/Cards/examples/EditReorderShapedCollectionViewController.swift
@@ -81,12 +81,10 @@ class EditReorderShapedCollectionViewController: UIViewController,
                                                         target: self,
                                                         action: #selector(toggleModes))
 
-    if #available(iOS 9.0, *) {
-      longPressGesture = UILongPressGestureRecognizer(target: self,
-                                                      action: #selector(handleReordering(gesture:)))
-      longPressGesture.cancelsTouchesInView = false
-      collectionView.addGestureRecognizer(longPressGesture)
-    }
+    longPressGesture = UILongPressGestureRecognizer(target: self,
+                                                    action: #selector(handleReordering(gesture:)))
+    longPressGesture.cancelsTouchesInView = false
+    collectionView.addGestureRecognizer(longPressGesture)
 
     for i in 0..<20 {
       dataSource.append((i, false))

--- a/components/Ripple/examples/CardCellsWithRippleExample.swift
+++ b/components/Ripple/examples/CardCellsWithRippleExample.swift
@@ -64,17 +64,15 @@ class CardCellsWithRippleExample: UIViewController,
     collectionView.allowsMultipleSelection = true
     view.addSubview(collectionView)
 
-    if #available(iOS 9.0, *) {
-      navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
-                                                          style: .plain,
-                                                          target: self,
-                                                          action: #selector(toggleModes))
+    navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reorder",
+                                                        style: .plain,
+                                                        target: self,
+                                                        action: #selector(toggleModes))
 
-      let longPressGesture = UILongPressGestureRecognizer(target: self,
-                                                          action: #selector(reorderCards(gesture:)))
-      longPressGesture.cancelsTouchesInView = false
-      collectionView.addGestureRecognizer(longPressGesture)
-    }
+    let longPressGesture = UILongPressGestureRecognizer(target: self,
+                                                        action: #selector(reorderCards(gesture:)))
+    longPressGesture.cancelsTouchesInView = false
+    collectionView.addGestureRecognizer(longPressGesture)
 
     if #available(iOS 11, *) {
       let guide = view.safeAreaLayoutGuide

--- a/components/TextFields/examples/TextFieldKitchenSinkExample.swift
+++ b/components/TextFields/examples/TextFieldKitchenSinkExample.swift
@@ -202,27 +202,10 @@ final class TextFieldKitchenSinkSwiftExample: UIViewController {
     baselineTestLabel.font = textFieldFloatingCharMax.font
     self.scrollView.addSubview(baselineTestLabel)
 
-    if #available(iOS 9.0, *) {
-      baselineTestLabel.trailingAnchor.constraint(equalTo: textFieldFloatingCharMax.trailingAnchor,
-                                                 constant: 0).isActive = true
+    baselineTestLabel.trailingAnchor.constraint(equalTo: textFieldFloatingCharMax.trailingAnchor,
+                                               constant: 0).isActive = true
 
-      baselineTestLabel.firstBaselineAnchor.constraint(equalTo: textFieldFloatingCharMax.firstBaselineAnchor).isActive = true
-    } else {
-      NSLayoutConstraint(item: baselineTestLabel,
-                         attribute: .trailing,
-                         relatedBy: .equal,
-                         toItem: textFieldFloatingCharMax,
-                         attribute: .trailing,
-                         multiplier: 1,
-                         constant: 0).isActive = true
-      NSLayoutConstraint(item: baselineTestLabel,
-                         attribute: .lastBaseline,
-                         relatedBy: .equal,
-                         toItem: textFieldFloatingCharMax,
-                         attribute: .lastBaseline,
-                         multiplier: 1,
-                         constant: 0).isActive = true
-    }
+    baselineTestLabel.firstBaselineAnchor.constraint(equalTo: textFieldFloatingCharMax.firstBaselineAnchor).isActive = true
 
     return [textFieldControllerFloating, textFieldControllerFloatingCharMax]
   }

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -141,20 +141,18 @@ class TextFieldTests: XCTestCase {
     XCTAssertTrue(textField.subviews.contains(leftView))
     XCTAssertTrue(textField.subviews.contains(rightView))
 
-    if #available(iOS 9.0, *) {
-      if UIView.userInterfaceLayoutDirection(for: .unspecified) == .leftToRight {
-        XCTAssertEqual(textField.leadingView, leftView)
-        XCTAssertEqual(textField.leadingView, textField.leftView)
+    if UIView.userInterfaceLayoutDirection(for: .unspecified) == .leftToRight {
+      XCTAssertEqual(textField.leadingView, leftView)
+      XCTAssertEqual(textField.leadingView, textField.leftView)
 
-        XCTAssertEqual(textField.trailingView, rightView)
-        XCTAssertEqual(textField.trailingView, textField.rightView)
-      } else {
-        XCTAssertEqual(textField.leadingView, rightView)
-        XCTAssertEqual(textField.leadingView, textField.rightView)
+      XCTAssertEqual(textField.trailingView, rightView)
+      XCTAssertEqual(textField.trailingView, textField.rightView)
+    } else {
+      XCTAssertEqual(textField.leadingView, rightView)
+      XCTAssertEqual(textField.leadingView, textField.rightView)
 
-        XCTAssertEqual(textField.trailingView, leftView)
-        XCTAssertEqual(textField.trailingView, textField.leftView)
-      }
+      XCTAssertEqual(textField.trailingView, leftView)
+      XCTAssertEqual(textField.trailingView, textField.leftView)
     }
   }
 

--- a/components/private/Dragons/examples/ZShadow.swift
+++ b/components/private/Dragons/examples/ZShadow.swift
@@ -63,18 +63,10 @@ class ZShadowViewController: UIViewController {
                                                        options: [],
                                                        metrics: nil,
                                                        views: ["view": contentView]));
-    if #available(iOS 9.0, *) {
-      greenBannerLeadingConstraintCollapsed = contentView.greenBanner.trailingAnchor.constraint(equalTo: contentView.greenTappable.trailingAnchor)
-    } else {
-      greenBannerLeadingConstraintCollapsed = NSLayoutConstraint(item: contentView.greenBanner, attribute: .right, relatedBy: .equal, toItem: contentView.greenTappable, attribute: .right, multiplier: 1, constant: 0)
-    }
+    greenBannerLeadingConstraintCollapsed = contentView.greenBanner.trailingAnchor.constraint(equalTo: contentView.greenTappable.trailingAnchor)
     greenBannerLeadingConstraintCollapsed.isActive = false
     
-    if #available(iOS 9.0, *) {
-      blueBannerLeadingConstraintCollapsed = contentView.blueBanner.trailingAnchor.constraint(equalTo: contentView.blueTappable.trailingAnchor)
-    } else {
-      blueBannerLeadingConstraintCollapsed = NSLayoutConstraint(item: contentView.blueBanner, attribute: .right, relatedBy: .equal, toItem: contentView.blueTappable, attribute: .right, multiplier: 1, constant: 0)
-    }
+    blueBannerLeadingConstraintCollapsed = contentView.blueBanner.trailingAnchor.constraint(equalTo: contentView.blueTappable.trailingAnchor)
     blueBannerLeadingConstraintCollapsed.isActive = false
     
     let tap = UITapGestureRecognizer(target: self, action: #selector(squaresTapped))


### PR DESCRIPTION
Drops some iOS 9 checks in Swift code.

Part of #2651
