### PR TITLE
[Cards] Add traitCollectionDidChange block to MDCCard

### DIFF
--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -141,6 +141,14 @@
  */
 - (nullable UIColor *)shadowColorForState:(UIControlState)state UI_APPEARANCE_SELECTOR;
 
+/**
+ A block that is invoked when the @c MDCCard receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCCard *_Nonnull card,
+UITraitCollection *_Nullable previousTraitCollection);
+
 /*
  The shape generator used to define the card's shape.
  When set, layer properties such as cornerRadius and other layer properties are nullified/zeroed.

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -146,8 +146,7 @@
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCCard *_Nonnull card,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCCard *_Nonnull card, UITraitCollection *_Nullable previousTraitCollection);
 
 /*
  The shape generator used to define the card's shape.

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -112,6 +112,14 @@ static const BOOL MDCCardIsInteractableDefault = YES;
   [self updateBorderColor];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (void)setCornerRadius:(CGFloat)cornerRadius {
   self.layer.cornerRadius = cornerRadius;
   [self setNeedsLayout];

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -360,14 +360,16 @@ static UIImage *FakeImage(void) {
 
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParametersForCard {
   // Given
-  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCCard *passedCard = nil;
-  self.card.traitCollectionDidChangeBlock = ^(MDCCard * _Nonnull card, UITraitCollection * _Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedCard = card;
-    [expectation fulfill];
-  };
+  self.card.traitCollectionDidChangeBlock =
+      ^(MDCCard *_Nonnull card, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedCard = card;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -358,4 +358,25 @@ static UIImage *FakeImage(void) {
                     [self.cell verticalImageAlignmentForState:MDCCardCellStateHighlighted]);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParametersForCard {
+  // Given
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCCard *passedCard = nil;
+  self.card.traitCollectionDidChangeBlock = ^(MDCCard * _Nonnull card, UITraitCollection * _Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedCard = card;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.card traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedCard, self.card);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCCard, called when its trait collection changes.

Related to #7953