### PR TITLE
[Cards] Add traitCollectionDidChange block to MDCCardCollectionCell

### DIFF
--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -319,4 +319,12 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  */
 @property(nonatomic, readonly) MDCCardCellState state;
 
+/**
+ A block that is invoked when the @c MDCCardCollectionCell receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCCardCollectionCell *_Nonnull collectionCell,
+     UITraitCollection *_Nullable previousTraitCollection);
+
 @end

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -149,6 +149,14 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
   [self updateImageAlignment];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (void)updateCardCellVisuals {
   [self updateShadowElevation];
   [self updateBorderColor];

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -358,7 +358,6 @@ static UIImage *FakeImage(void) {
                     [self.cell verticalImageAlignmentForState:MDCCardCellStateHighlighted]);
 }
 
-
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParametersForCard {
   // Given
   XCTestExpectation *expectation =
@@ -383,13 +382,27 @@ static UIImage *FakeImage(void) {
 }
 
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParametersForCardCollectionCell {
-  __block MDCCardCollectionCell *passedCardCollectionCell = nil;
+  // Given
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCCardCollectionCell *passedCollectionCell = nil;
   self.cell.traitCollectionDidChangeBlock =
-  ^(MDCCardCollectionCell *_Nonnull collectionCell,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedCardCollectionCell = collectionCell;
-XCTAssertEqual(passedCardCollectionCell, self.cell);
+      ^(MDCCardCollectionCell *_Nonnull collectionCell,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedCollectionCell = collectionCell;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.cell traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedCollectionCell, self.cell);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
 }
 
 @end

--- a/components/Cards/tests/unit/MDCCardTests.m
+++ b/components/Cards/tests/unit/MDCCardTests.m
@@ -358,4 +358,28 @@ static UIImage *FakeImage(void) {
                     [self.cell verticalImageAlignmentForState:MDCCardCellStateHighlighted]);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParametersForCardCollectionCell {
+  // Given
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCCardCollectionCell *passedCardCollectionCell = nil;
+  self.cell.traitCollectionDidChangeBlock =
+      ^(MDCCardCollectionCell *_Nonnull collectionCell,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedCardCollectionCell = collectionCell;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.card traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedCardCollectionCell, self.cell);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCCardCollectionCell, called when its trait collection changes.
