### PR TITLE
[NavigationDrawer] Add traitCollectionDidChange block

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -138,6 +138,15 @@
  */
 - (void)expandToFullscreenWithDuration:(CGFloat)duration
                             completion:(void (^__nullable)(BOOL finished))completion;
+
+/**
+ A block that is invoked when the @c MDCBottomDrawerViewController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCBottomDrawerViewController *_Nonnull bottomDrawer,
+UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 /**

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -144,8 +144,8 @@
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCBottomDrawerViewController *_Nonnull bottomDrawer,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCBottomDrawerViewController *_Nonnull bottomDrawer,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -65,6 +65,14 @@
   }
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (id<UIViewControllerTransitioningDelegate>)transitioningDelegate {
   return self.transitionController;
 }

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -62,4 +62,28 @@
   }
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCBottomDrawerViewController *passedBottomDrawer = nil;
+  self.navigationDrawer.traitCollectionDidChangeBlock =
+  ^(MDCBottomDrawerViewController *_Nonnull navigationDrawer,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedBottomDrawer = navigationDrawer;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.navigationDrawer traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedBottomDrawer, self.navigationDrawer);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -65,16 +65,16 @@
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCBottomDrawerViewController *passedBottomDrawer = nil;
   self.navigationDrawer.traitCollectionDidChangeBlock =
-  ^(MDCBottomDrawerViewController *_Nonnull navigationDrawer,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedBottomDrawer = navigationDrawer;
-    [expectation fulfill];
-  };
+      ^(MDCBottomDrawerViewController *_Nonnull navigationDrawer,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedBottomDrawer = navigationDrawer;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCBottomDrawerViewController, called when its trait collection changes.