### PR TITLE
[List] Add traitCollectionDidChange block to MDCBaseCell

### DIFF
--- a/components/List/src/MDCBaseCell.h
+++ b/components/List/src/MDCBaseCell.h
@@ -40,6 +40,13 @@
  */
 @property(nonatomic, strong, nullable) UIColor *rippleColor;
 
+/**
+ A block that is invoked when the @c MDCBaseCell receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCBaseCell *_Nonnull cell, UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 @interface MDCBaseCell (ToBeDeprecated)

--- a/components/List/src/MDCBaseCell.m
+++ b/components/List/src/MDCBaseCell.m
@@ -102,6 +102,14 @@
   self.inkView.frame = self.bounds;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark UICollectionViewCell Overrides
 
 - (void)setHighlighted:(BOOL)highlighted {

--- a/components/List/tests/unit/MDCBaseCellTests.m
+++ b/components/List/tests/unit/MDCBaseCellTests.m
@@ -24,13 +24,13 @@
 @property(nonatomic, strong) MDCInkView *inkView;
 @end
 
-@interface MDCBaseCellRippleTests : XCTestCase
+@interface MDCBaseCellTests : XCTestCase
 
 @property(nonatomic, strong, nullable) MDCBaseCell *baseCell;
 
 @end
 
-@implementation MDCBaseCellRippleTests
+@implementation MDCBaseCellTests
 
 - (void)setUp {
   [super setUp];
@@ -107,6 +107,29 @@
 
   // Then
   XCTAssertEqualObjects(self.baseCell.rippleView.rippleColor, color);
+}
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCBaseCell *passedCell = nil;
+  self.baseCell.traitCollectionDidChangeBlock =
+      ^(MDCBaseCell *_Nonnull cell, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedCell = cell;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.baseCell traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedCell, self.baseCell);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
 }
 
 @end

--- a/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
+++ b/components/List/tests/unit/MDCSelfSizingStereoCellTests.m
@@ -177,4 +177,28 @@
   XCTAssert(attributes.size.height > initialAttributeSize.height);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCSelfSizingStereoCell *stereoCell = [[MDCSelfSizingStereoCell alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCBaseCell *passedCell = nil;
+  stereoCell.traitCollectionDidChangeBlock =
+      ^(MDCBaseCell *_Nonnull cell, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedCell = cell;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [stereoCell traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedCell, stereoCell);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCBaseCell and its supclasses, called when its trait collection changes.

This change also does a `mv` operation to move the _BaseCellRippleTests_ to _BaseCellTests_ to make the test cell more generic to the type and less specific to the tests.