### PR TITLE
[Elevation] Add second protocol for overrides

### DIFF
--- a/components/Elevation/src/MDCElevation.h
+++ b/components/Elevation/src/MDCElevation.h
@@ -18,7 +18,7 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevation <NSObject>
+@protocol MDCElevation
 
 /**
  The current elevation of the conforming @c UIView.

--- a/components/Elevation/src/MDCElevationOverride.h
+++ b/components/Elevation/src/MDCElevationOverride.h
@@ -18,7 +18,7 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevationOverride <NSObject>
+@protocol MDCElevationOverride
 
 /**
  Used by @c MaterialElevationResponding instead of @c mdc_baseElevation.

--- a/components/Elevation/src/MDCElevationOverride.h
+++ b/components/Elevation/src/MDCElevationOverride.h
@@ -18,22 +18,14 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevation <NSObject>
+@protocol MDCElevationOverride <NSObject>
 
 /**
- The current elevation of the conforming @c UIView.
+ Used by @c MaterialElevationResponding instead of @c mdc_baseElevation.
+
+ This can be used in cases where there is elevation behind an object that is not part of the
+ view hierarchy, like a @c UIPresentationController.
  */
-@property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-
-/**
- This block is called when the elevation changes for the conforming @c UIView or @c UIViewController
- reciever or one of its direct ancestors in the view hierarchy.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
 
 @end


### PR DESCRIPTION
This change adds a second protocol for clients to override their base elevation. This additionally removes the property from `MDCElevation`.