### PR TITLE
[Elevation] Improve protocol naming

### DIFF
--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -18,7 +18,7 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevating
+@protocol MDCElevatable
 
 /**
  The current elevation of the conforming @c UIView.

--- a/components/Elevation/src/MDCElevating.h
+++ b/components/Elevation/src/MDCElevating.h
@@ -18,14 +18,22 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevationOverride
+@protocol MDCElevating
 
 /**
- Used by @c MaterialElevationResponding instead of @c mdc_baseElevation.
-
- This can be used in cases where there is elevation behind an object that is not part of the
- view hierarchy, like a @c UIPresentationController.
+ The current elevation of the conforming @c UIView.
  */
-@property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
+@property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
+
+/**
+ This block is called when the elevation changes for the conforming @c UIView or @c UIViewController
+ reciever or one of its direct ancestors in the view hierarchy.
+
+ Use this block to respond to elevation changes in the view or its ancestor views.
+
+ @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
+ views.
+ */
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
 
 @end

--- a/components/Elevation/src/MDCElevationOverriding.h
+++ b/components/Elevation/src/MDCElevationOverriding.h
@@ -18,22 +18,14 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevation
+@protocol MDCElevationOverriding
 
 /**
- The current elevation of the conforming @c UIView.
+ Used by @c MaterialElevationResponding instead of @c mdc_baseElevation.
+
+ This can be used in cases where there is elevation behind an object that is not part of the
+ view hierarchy, like a @c UIPresentationController.
  */
-@property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-
-/**
- This block is called when the elevation changes for the conforming @c UIView or @c UIViewController
- reciever or one of its direct ancestors in the view hierarchy.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
 
 @end

--- a/components/Elevation/src/MaterialElevation.h
+++ b/components/Elevation/src/MaterialElevation.h
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCElevating.h"
+#import "MDCElevatable.h"
 #import "MDCElevationOverriding.h"

--- a/components/Elevation/src/MaterialElevation.h
+++ b/components/Elevation/src/MaterialElevation.h
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCElevation.h"
-#import "MDCElevationOverride.h"
+#import "MDCElevating.h"
+#import "MDCElevationOverriding.h"


### PR DESCRIPTION
To conform to proper Objective-C naming, I have updated the protocol names to use a gerund form "ing"

https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingBasics.html

