### PR TITLE
[Tabs] Add traitCollectionDidChange block

### DIFF
--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -208,6 +208,15 @@ IB_DESIGNABLE
 /** Returns the image tint color associated with the specified state. */
 - (nullable UIColor *)imageTintColorForState:(MDCTabBarItemState)state;
 
+
+/**
+ A block that is invoked when the @c MDCTabBar receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCTabBar *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection);
+
+
 @end
 
 #pragma mark -

--- a/components/Tabs/src/MDCTabBar.h
+++ b/components/Tabs/src/MDCTabBar.h
@@ -208,14 +208,12 @@ IB_DESIGNABLE
 /** Returns the image tint color associated with the specified state. */
 - (nullable UIColor *)imageTintColorForState:(MDCTabBarItemState)state;
 
-
 /**
  A block that is invoked when the @c MDCTabBar receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCTabBar *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection);
-
+    (MDCTabBar *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/Tabs/src/MDCTabBar.m
+++ b/components/Tabs/src/MDCTabBar.m
@@ -187,6 +187,14 @@ static inline UIColor *RippleColor() {
   _itemBar.frame = CGRectMake(0, 0, sizeThatFits.width, sizeThatFits.height);
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark - Public
 
 + (CGFloat)defaultHeightForBarPosition:(UIBarPosition)position

--- a/components/Tabs/src/MDCTabBarViewController.h
+++ b/components/Tabs/src/MDCTabBarViewController.h
@@ -62,7 +62,8 @@ IB_DESIGNABLE
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCTabBarViewController *_Nonnull tabBarViewController, UITraitCollection *_Nullable previousTraitCollection);
+    (MDCTabBarViewController *_Nonnull tabBarViewController,
+     UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/Tabs/src/MDCTabBarViewController.h
+++ b/components/Tabs/src/MDCTabBarViewController.h
@@ -57,6 +57,13 @@ IB_DESIGNABLE
 /** Use this to show and hide the tab bar. If animated, hides by panning the tab bar down. */
 - (void)setTabBarHidden:(BOOL)hidden animated:(BOOL)animated;
 
+/**
+ A block that is invoked when the @c MDCTabBarViewController receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCTabBarViewController *_Nonnull tabBarViewController, UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 /** The delegate protocol for MDCTabBarViewController */

--- a/components/Tabs/src/MDCTabBarViewController.m
+++ b/components/Tabs/src/MDCTabBarViewController.m
@@ -120,6 +120,14 @@ const CGFloat MDCTabBarViewControllerAnimationDuration = (CGFloat)0.3;
   [self updateLayout];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 #pragma mark - Properties
 
 - (BOOL)tabBarHidden {

--- a/components/Tabs/tests/unit/MDCTabBarControllerTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarControllerTests.m
@@ -1,0 +1,50 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialTabs.h"
+
+@interface MDCTabBarViewControllerTests : XCTestCase
+
+@end
+
+@implementation MDCTabBarViewControllerTests
+
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCTabBarViewController *testTabBarController = [[MDCTabBarViewController alloc] init];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCTabBarViewController *passedTabBarController = nil;
+  testTabBarController.traitCollectionDidChangeBlock =
+      ^(MDCTabBarViewController *_Nonnull tabBarViewController,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedTabBarController = tabBarViewController;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [testTabBarController traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTabBarController, testTabBarController);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
+@end

--- a/components/Tabs/tests/unit/MDCTabBarTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarTests.m
@@ -51,16 +51,15 @@
   // Given
   MDCTabBar *testTabBar = [[MDCTabBar alloc] init];
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCTabBar *passedTabBar = nil;
   testTabBar.traitCollectionDidChangeBlock =
-  ^(MDCTabBar *_Nonnull tabBar,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedTabBar = tabBar;
-    [expectation fulfill];
-  };
+      ^(MDCTabBar *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedTabBar = tabBar;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When

--- a/components/Tabs/tests/unit/MDCTabBarTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarTests.m
@@ -47,4 +47,29 @@
   XCTAssertTrue(tabBar.displaysUppercaseTitles);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCTabBar *testTabBar = [[MDCTabBar alloc] init];
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCTabBar *passedTabBar = nil;
+  testTabBar.traitCollectionDidChangeBlock =
+  ^(MDCTabBar *_Nonnull tabBar,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedTabBar = tabBar;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [testTabBar traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTabBar, testTabBar);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCTabBar and MDCTabBarViewController, called when its trait collection changes.

Closes #8041 