### PR TITLE
[Slider] Add traitCollectionDidChange block

### DIFF
--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -310,6 +310,14 @@ IB_DESIGNABLE
  */
 @property(nonatomic, assign, getter=isThumbHollowAtStart) BOOL thumbHollowAtStart;
 
+/**
+ A block that is invoked when the @c MDCSlider receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection);
+
+
 #pragma mark - To be deprecated
 
 /**

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -315,8 +315,7 @@ IB_DESIGNABLE
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection);
-
+    (MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection);
 
 #pragma mark - To be deprecated
 

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -458,6 +458,14 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   _thumbTrack.frame = self.bounds;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (CGSize)sizeThatFits:(__unused CGSize)size {
   CGSize result = self.bounds.size;
   result.height = kSliderFrameHeight;

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -1245,6 +1245,29 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   }
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCSlider *passedSlider = nil;
+  self.slider.traitCollectionDidChangeBlock = ^(
+                                                 MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedSlider = slider;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.slider traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedSlider, self.slider);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 #pragma mark Private test helpers
 
 - (CGFloat)randomNumber {

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -1248,15 +1248,15 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCSlider *passedSlider = nil;
-  self.slider.traitCollectionDidChangeBlock = ^(
-                                                 MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedSlider = slider;
-    [expectation fulfill];
-  };
+  self.slider.traitCollectionDidChangeBlock =
+      ^(MDCSlider *_Nonnull slider, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedSlider = slider;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCSlider, called when its trait collection changes.

Closes #8042