### PR TITLE
[Elevation] passing self to the elevationDidChangeBlock

### DIFF
--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -36,6 +36,6 @@
  @param object The receiver (self) which conforms to the protocol.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable>_Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 
 @end

--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -33,9 +33,9 @@
 
  @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
  views.
- @param elevatableSelf The receiver (self) which conforms to the protocol.
+ @param object The receiver (self) which conforms to the protocol.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable>_Nonnull elevatableSelf, CGFloat elevation);
+    (id<MDCElevatable>_Nonnull object, CGFloat elevation);
 
 @end

--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -33,7 +33,9 @@
 
  @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
  views.
+ @param elevatableSelf The receiver (self) which conforms to the protocol.
  */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (id<MDCElevatable>_Nonnull elevatableSelf, CGFloat elevation);
 
 @end

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -22,7 +22,8 @@
  */
 @interface MDCConformingMDCElevatableView : UIView <MDCElevatable>
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableView *view, CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCConformingMDCElevatableView *view, CGFloat elevation);
 @property(nonatomic, assign) CGFloat elevation;
 @end
 
@@ -40,7 +41,8 @@
  */
 @interface MDCConformingMDCElevatableViewController : UIViewController <MDCElevatable>
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableViewController *viewController, CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCConformingMDCElevatableViewController *viewController, CGFloat elevation);
 @property(nonatomic, assign) CGFloat elevation;
 @end
 
@@ -58,7 +60,8 @@
  */
 @interface MDCConformingMDCElevatableOverrideView : UIView <MDCElevatable, MDCElevationOverriding>
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableOverrideView *view, CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCConformingMDCElevatableOverrideView *view, CGFloat elevation);
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
 @property(nonatomic, assign) CGFloat elevation;
 @end
@@ -90,7 +93,8 @@
 @interface MDCConformingMDCElevatableOverrideViewController
     : UIViewController <MDCElevatable, MDCElevationOverriding>
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableOverrideViewController *viewController, CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCConformingMDCElevatableOverrideViewController *viewController, CGFloat elevation);
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
 @property(nonatomic, assign) CGFloat elevation;
 @end

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -22,7 +22,7 @@
  */
 @interface MDCConformingMDCElevatableView : UIView <MDCElevatable>
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableView *view, CGFloat elevation);
 @property(nonatomic, assign) CGFloat elevation;
 @end
 
@@ -40,7 +40,7 @@
  */
 @interface MDCConformingMDCElevatableViewController : UIViewController <MDCElevatable>
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableViewController *viewController, CGFloat elevation);
 @property(nonatomic, assign) CGFloat elevation;
 @end
 
@@ -58,7 +58,7 @@
  */
 @interface MDCConformingMDCElevatableOverrideView : UIView <MDCElevatable, MDCElevationOverriding>
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableOverrideView *view, CGFloat elevation);
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
 @property(nonatomic, assign) CGFloat elevation;
 @end
@@ -90,7 +90,7 @@
 @interface MDCConformingMDCElevatableOverrideViewController
     : UIViewController <MDCElevatable, MDCElevationOverriding>
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(CGFloat elevation);
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)(MDCConformingMDCElevatableOverrideViewController *viewController, CGFloat elevation);
 @property(nonatomic, assign, readonly) CGFloat mdc_currentElevation;
 @property(nonatomic, assign) CGFloat elevation;
 @end


### PR DESCRIPTION
Similarly to `traitCollectionDidChangeBlock`, we want to pass `self` here in cases where the object is being injected, and also to remove the need from clients to weakify self and possibly cause retain cycles.

When our components conform to this block, they should be more type specific to what self is. As an example in the MDCCard header, I would expect conforming to this block would be declared like:
```
@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
(MDCCard * elevatableSelf, CGFloat elevation);
```