### PR TITLE
[Ripple] Fix active ripple layer not using active ripple color.

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -75,7 +75,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [super layoutSubviews];
 
   [self updateRippleStyle];
-  self.activeRippleLayer.fillColor = self.rippleColor.CGColor;
+  self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
 }
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer {


### PR DESCRIPTION
Follow-up of https://github.com/material-components/material-components-ios/pull/8051/commits/5cdb7f95f75a516de2eb208f93ee1ad9e5253ed6