### PR TITLE
[TabBarView] Add traitCollectionDidChange block

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -163,6 +163,13 @@ __attribute__((objc_subclassing_restricted)) @interface MDCTabBarView : UIScroll
 - (CGRect)rectForItem:(nonnull UITabBarItem *)item
     inCoordinateSpace:(nonnull id<UICoordinateSpace>)coordinateSpace;
 
+/**
+ A block that is invoked when the @c MDCTabBarView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCTabBarView *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection);
+
 #pragma mark - Animation
 
 /**

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -633,6 +633,14 @@ typedef NS_ENUM(NSUInteger, MDCTabBarViewInternalLayoutStyle) {
   }
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (BOOL)isScrollableLayoutStyle {
   return [self layoutStyle] == MDCTabBarViewInternalLayoutStyleScrollable;
 }

--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -976,4 +976,27 @@ static UIImage *fakeImage(CGSize size) {
   XCTAssertEqualWithAccuracy(actualControlPoint4[1], expectedControlPoint4[1], 0.0001);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCTabBarView *passedTabBar = nil;
+  self.tabBarView.traitCollectionDidChangeBlock =
+      ^(MDCTabBarView *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedTabBar = tabBar;
+        [expectation fulfill];
+      };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [self.tabBarView traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTabBar, self.tabBarView);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCTabBarView, called when its trait collection changes.

Closes #8040 
