### PR TITLE
[Ripple] Add traitCollectionDidChange block

### DIFF
--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -121,6 +121,15 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
  */
 - (void)beginRippleTouchUpAnimated:(BOOL)animated
                         completion:(nullable MDCRippleCompletionBlock)completion;
+
+/**
+ A block that is invoked when the @c MDCRippleView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+(MDCRippleView *_Nonnull ripple,
+UITraitCollection *_Nullable previousTraitCollection);
+
 @end
 
 /**

--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -74,6 +74,13 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
 @property(nonatomic, strong, nonnull) UIColor *activeRippleColor;
 
 /**
+ A block that is invoked when the @c MDCRippleView receives a call to @c
+ traitCollectionDidChange:. The block is called after the call to the superclass.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
+    (MDCRippleView *_Nonnull ripple, UITraitCollection *_Nullable previousTraitCollection);
+
+/**
  Cancels all the existing ripples.
 
  @param animated Whether to animate the cancellation of the ripples or not.
@@ -121,13 +128,6 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
  */
 - (void)beginRippleTouchUpAnimated:(BOOL)animated
                         completion:(nullable MDCRippleCompletionBlock)completion;
-
-/**
- A block that is invoked when the @c MDCRippleView receives a call to @c
- traitCollectionDidChange:. The block is called after the call to the superclass.
- */
-@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-    (MDCRippleView *_Nonnull ripple, UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -127,8 +127,7 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-(MDCRippleView *_Nonnull ripple,
-UITraitCollection *_Nullable previousTraitCollection);
+    (MDCRippleView *_Nonnull ripple, UITraitCollection *_Nullable previousTraitCollection);
 
 @end
 

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -78,6 +78,14 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (self.traitCollectionDidChangeBlock) {
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
 - (void)layoutSublayersOfLayer:(CALayer *)layer {
   [super layoutSublayersOfLayer:layer];
   for (CALayer *sublayer in self.layer.sublayers) {

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -249,4 +249,29 @@
   XCTAssertEqual(rippleView.activeRippleLayer.maximumRadius, fakeRippleRadius);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCRippleView *testRippleView = [[MDCRippleView alloc] init];
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCRippleView *passedRippleView = nil;
+  testRippleView.traitCollectionDidChangeBlock =
+  ^(MDCRippleView *_Nonnull ripple,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedRippleView = ripple;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [testRippleView traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedRippleView, testRippleView);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -253,16 +253,15 @@
   // Given
   MDCRippleView *testRippleView = [[MDCRippleView alloc] init];
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCRippleView *passedRippleView = nil;
   testRippleView.traitCollectionDidChangeBlock =
-  ^(MDCRippleView *_Nonnull ripple,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedRippleView = ripple;
-    [expectation fulfill];
-  };
+      ^(MDCRippleView *_Nonnull ripple, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedRippleView = ripple;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -153,16 +153,15 @@
   // Given
   MDCStatefulRippleView *testRippleView = [[MDCStatefulRippleView alloc] init];
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+      [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
   __block UITraitCollection *passedTraitCollection = nil;
   __block MDCRippleView *passedRippleView = nil;
   testRippleView.traitCollectionDidChangeBlock =
-  ^(MDCRippleView *_Nonnull ripple,
-    UITraitCollection *_Nullable previousTraitCollection) {
-    passedTraitCollection = previousTraitCollection;
-    passedRippleView = ripple;
-    [expectation fulfill];
-  };
+      ^(MDCRippleView *_Nonnull ripple, UITraitCollection *_Nullable previousTraitCollection) {
+        passedTraitCollection = previousTraitCollection;
+        passedRippleView = ripple;
+        [expectation fulfill];
+      };
   UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -149,4 +149,29 @@
   XCTAssertTrue(rippleView.rippleHighlighted);
 }
 
+- (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {
+  // Given
+  MDCStatefulRippleView *testRippleView = [[MDCStatefulRippleView alloc] init];
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"traitCollection"];
+  __block UITraitCollection *passedTraitCollection = nil;
+  __block MDCRippleView *passedRippleView = nil;
+  testRippleView.traitCollectionDidChangeBlock =
+  ^(MDCRippleView *_Nonnull ripple,
+    UITraitCollection *_Nullable previousTraitCollection) {
+    passedTraitCollection = previousTraitCollection;
+    passedRippleView = ripple;
+    [expectation fulfill];
+  };
+  UITraitCollection *fakeTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
+
+  // When
+  [testRippleView traitCollectionDidChange:fakeTraitCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedRippleView, testRippleView);
+  XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
+}
+
 @end


### PR DESCRIPTION
Adds a traitCollectionDidChangeBlock to MDCRippleView and its subclass, called when its trait collection changes.

Closes #8043 