### PR TITLE
[BottomNavigation] Don't set `sizeThatFitsIncludesSafeArea`.

### DIFF
--- a/components/BottomNavigation/examples/BottomNavigationBlurExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationBlurExample.m
@@ -44,7 +44,6 @@
 }
 
 - (void)configureNavigationBar {
-  self.bottomNavBar.sizeThatFitsIncludesSafeArea = NO;
   self.bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   self.bottomNavBar.alignment = MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles;
 

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -73,7 +73,6 @@ class BottomNavigationExplicitlySetColorExample: UIViewController {
     view.backgroundColor = MDCPalette.grey.tint300
     view.addSubview(bottomNavBar)
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     bottomNavBar.alignment = .centered
 
     // Add items to the bottom navigation bar.

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -38,7 +38,6 @@ class BottomNavigationNilBadges : UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     // Always show bottom navigation bar item titles.
     bottomNavBar.titleVisibility = .always
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -85,7 +85,6 @@ class BottomNavigationResetExample: UIViewController {
     view.backgroundColor = colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     bottomNavBar.alignment = .centered
 
     // Add items to the bottom navigation bar.

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -26,7 +26,6 @@ class BottomNavigationSelectedIconExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     colorScheme.backgroundColor = .white
     view.backgroundColor = colorScheme.backgroundColor
 

--- a/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
@@ -39,7 +39,6 @@ class BottomNavigationTitleVisibilityChangeExample: UIViewController, MDCBottomN
     view.backgroundColor = colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     // Always show bottom navigation bar item titles.
     bottomNavBar.titleVisibility = .always
     

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -42,7 +42,6 @@
 
 - (void)commonBottomNavigationTypicalUseExampleViewDidLoad {
   self.bottomNavBar = [[MDCBottomNavigationBar alloc] initWithFrame:CGRectZero];
-  self.bottomNavBar.sizeThatFitsIncludesSafeArea = NO;
   self.bottomNavBar.titleVisibility = MDCBottomNavigationBarTitleVisibilitySelected;
   self.bottomNavBar.alignment = MDCBottomNavigationBarAlignmentJustifiedAdjacentTitles;
   self.bottomNavBar.delegate = self;

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -26,7 +26,6 @@ class BottomNavigationTypicalUseSwiftExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    bottomNavBar.sizeThatFitsIncludesSafeArea = false
     view.backgroundColor = colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 


### PR DESCRIPTION
The default value is false, so setting it to `false`/`NO` is unnecessary.

Part of #6783
