### PR TITLE
[BottomNavigation] Deprecate `sizeThatFitsIncludesSafeArea`.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -230,7 +230,8 @@ traitCollectionDidChange:. The block is called after the call to the superclass.
 
  Defaults to @c NO.
  */
-@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea __deprecated_msg("This was a migration API and is being removed.");
+@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea __deprecated_msg(
+    "This was a migration API and is being removed.");
 
 @end
 

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -218,8 +218,8 @@ traitCollectionDidChange:. The block is called after the call to the superclass.
 
 @end
 
-/** APIs that will be deprecated in the near future. No new code should rely on these APIs. */
-@interface MDCBottomNavigationBar (ToBeDeprecated)
+/** APIs that are deprecated. No new code should rely on these APIs. */
+@interface MDCBottomNavigationBar (Deprecated)
 
 /**
  Flag to allow clients to gradually correct the size/position of the Bottom Navigation bar relative
@@ -230,7 +230,7 @@ traitCollectionDidChange:. The block is called after the call to the superclass.
 
  Defaults to @c NO.
  */
-@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea;
+@property(nonatomic, assign) BOOL sizeThatFitsIncludesSafeArea __deprecated_msg("This was a migration API and is being removed.");
 
 @end
 


### PR DESCRIPTION
Closes #6783
