### PR TITLE
[Elevation] Add absoluteElevation property and clarify the elevationDidChange block param

### DIFF
--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -36,6 +36,6 @@
  @param object The receiver (self) which conforms to the protocol.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation);
 
 @end

--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -31,8 +31,9 @@
 
  Use this block to respond to elevation changes in the view or its ancestor views.
 
- @param absoluteElevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views. This equates to @c mdc_absoluteElevation of the UIView+MaterialElevationResponding category.
+ @param absoluteElevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all
+ ancestor views. This equates to @c mdc_absoluteElevation of the UIView+MaterialElevationResponding
+ category.
  @param object The receiver (self) which conforms to the protocol.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)

--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -31,8 +31,8 @@
 
  Use this block to respond to elevation changes in the view or its ancestor views.
 
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
+ @param absoluteElevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
+ views. This equates to @c mdc_absoluteElevation of the UIView+MaterialElevationResponding category.
  @param object The receiver (self) which conforms to the protocol.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)

--- a/components/Elevation/src/UIView+MaterialElevationResponding.h
+++ b/components/Elevation/src/UIView+MaterialElevationResponding.h
@@ -34,8 +34,8 @@
 @property(nonatomic, assign, readonly) CGFloat mdc_baseElevation;
 
 /**
- Returns the sum of the view's @c mdc_currentElevation with the @c mdc_currentElevation of its superviews
- going up the view hierarchy recursively.
+ Returns the sum of the view's @c mdc_currentElevation with the @c mdc_currentElevation of its
+ superviews going up the view hierarchy recursively.
 
  This value is effectively the sum of @c mdc_baseElevation and @c mdc_currentElevation.
  */

--- a/components/Elevation/src/UIView+MaterialElevationResponding.h
+++ b/components/Elevation/src/UIView+MaterialElevationResponding.h
@@ -34,6 +34,14 @@
 @property(nonatomic, assign, readonly) CGFloat mdc_baseElevation;
 
 /**
+ Returns the sum of the view's @c mdc_currentElevation with the @c mdc_currentElevation of its superviews
+ going up the view hierarchy recursively.
+
+ This value is effectively the sum of @c mdc_baseElevation and @c mdc_currentElevation.
+ */
+@property(nonatomic, assign, readonly) CGFloat mdc_absoluteElevation;
+
+/**
  Should be called when the view's @c mdc_currentElevation has changed. Will be called on the
  reciever's @c subviews.
 

--- a/components/Elevation/src/UIView+MaterialElevationResponding.m
+++ b/components/Elevation/src/UIView+MaterialElevationResponding.m
@@ -58,6 +58,13 @@
   return totalElevation;
 }
 
+- (CGFloat)mdc_absoluteElevation {
+  CGFloat elevation = self.mdc_baseElevation;
+  id<MDCElevatable> elevatableSelf = [self objectConformingToElevationInResponderChain];
+  elevation += elevatableSelf.mdc_currentElevation;
+  return elevation;
+}
+
 /**
  Checks whether a @c UIView or it's managing @c UIViewController conform to @c
  MDCOverrideElevation.

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -111,7 +111,7 @@
  Tests for the @c MaterialElevationResponding category on @c UIView.
  */
 @interface MDCMaterialElevationRespondingTests : XCTestCase
-@property(nonatomic, strong, nullable) UIView *view;
+@property(nonatomic, strong, nullable) MDCConformingMDCElevatableView *view;
 @property(nonatomic, strong, nullable) MDCConformingMDCElevatableView *elevationView;
 @property(nonatomic, strong, nullable)
     MDCConformingMDCElevatableOverrideView *elevationOverrideView;
@@ -127,7 +127,7 @@
 - (void)setUp {
   [super setUp];
 
-  self.view = [[UIView alloc] init];
+  self.view = [[MDCConformingMDCElevatableView alloc] init];
   self.elevationView = [[MDCConformingMDCElevatableView alloc] init];
   self.elevationOverrideView = [[MDCConformingMDCElevatableOverrideView alloc] init];
   self.viewController = [[UIViewController alloc] init];
@@ -153,12 +153,13 @@
   // Given
   CGFloat fakeElevation = 3;
   self.elevationView.elevation = fakeElevation;
-
+  self.view.elevation = fakeElevation;
   // When
   [self.elevationView addSubview:self.view];
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation, 0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation, fakeElevation + fakeElevation, 0.001);
 }
 
 // + self.elevationView
@@ -169,6 +170,7 @@
   UIView *middleView = [[UIView alloc] init];
   CGFloat fakeElevation = 3;
   self.elevationView.elevation = fakeElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationView addSubview:middleView];
@@ -176,6 +178,7 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation, 0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation, fakeElevation + fakeElevation, 0.001);
 }
 
 // + self.elevationOverrideView
@@ -186,6 +189,7 @@
   CGFloat fakeCurrentElevation = 20;
   self.elevationOverrideView.elevation = fakeCurrentElevation;
   self.elevationOverrideView.mdc_overrideBaseElevation = fakeElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationOverrideView addSubview:self.view];
@@ -193,6 +197,8 @@
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
                              0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeCurrentElevation, 0.001);
 }
 
 // + self.elevationOverrideView
@@ -205,6 +211,7 @@
   CGFloat fakeCurrentElevation = 20;
   self.elevationOverrideView.elevation = fakeCurrentElevation;
   self.elevationOverrideView.mdc_overrideBaseElevation = fakeElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationOverrideView addSubview:middleView];
@@ -212,6 +219,9 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeCurrentElevation,
                              0.001);
 }
 
@@ -224,13 +234,17 @@
   CGFloat fakeElevationOverride = 4;
   self.elevationView.elevation = fakeElevation;
   self.elevationOverrideView.mdc_overrideBaseElevation = fakeElevationOverride;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationOverrideView addSubview:self.elevationView];
   [self.elevationView addSubview:self.view];
 
   // Then
-  XCTAssertEqual(self.view.mdc_baseElevation, fakeElevation + fakeElevationOverride);
+  XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeElevationOverride,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeElevationOverride, 0.001);
 }
 
 // + self.elevationViewController
@@ -239,12 +253,14 @@
   // Given
   CGFloat fakeElevation = 3;
   self.elevationViewController.elevation = fakeElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationViewController.view addSubview:self.view];
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation, 0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation, fakeElevation + fakeElevation, 0.001);
 }
 
 // + self.elevationOverrideViewController
@@ -255,12 +271,16 @@
   CGFloat fakeCurrentElevation = 20;
   self.elevationOverrideViewController.elevation = fakeCurrentElevation;
   self.elevationOverrideViewController.mdc_overrideBaseElevation = fakeElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationOverrideViewController.view addSubview:self.view];
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeCurrentElevation,
                              0.001);
 }
 
@@ -271,6 +291,7 @@
   // Given
   CGFloat fakeElevation = 3;
   self.elevationViewController.elevation = fakeElevation;
+  self.view.elevation = fakeElevation;
   UIView *middleView = [[UIView alloc] init];
 
   // When
@@ -279,6 +300,7 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation, 0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation, fakeElevation + fakeElevation, 0.001);
 }
 
 // + self.elevationOverrideViewController
@@ -290,6 +312,7 @@
   CGFloat fakeCurrentElevation = 20;
   self.elevationOverrideViewController.elevation = fakeCurrentElevation;
   self.elevationOverrideViewController.mdc_overrideBaseElevation = fakeElevation;
+  self.view.elevation = fakeElevation;
   UIView *middleView = [[UIView alloc] init];
 
   // When
@@ -298,6 +321,9 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeCurrentElevation,
                              0.001);
 }
 
@@ -312,6 +338,7 @@
       [[MDCConformingMDCElevatableOverrideViewSubclass alloc] init];
   subclassView.elevation = fakeElevationOne;
   self.elevationView.elevation = fakeElevationTwo;
+  self.view.elevation = fakeElevationOne;
 
   // When
   [self.elevationView addSubview:subclassView];
@@ -319,6 +346,9 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevationOne + fakeElevationTwo,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
+                             fakeElevationOne + fakeElevationOne + fakeElevationTwo,
                              0.001);
 }
 
@@ -331,6 +361,7 @@
   CGFloat fakeOverrideElevation = 7;
   self.elevationOverrideView.elevation = fakeElevation;
   self.elevationOverrideView.mdc_overrideBaseElevation = fakeOverrideElevation;
+  self.elevationView.elevation = fakeElevation;
 
   // When
   [self.elevationOverrideView addSubview:self.view];
@@ -339,6 +370,8 @@
   // Then
   XCTAssertEqualWithAccuracy(self.elevationView.mdc_baseElevation,
                              fakeElevation + fakeOverrideElevation, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationView.mdc_absoluteElevation,
+                             fakeElevation + fakeElevation + fakeOverrideElevation, 0.001);
 }
 
 // + self.elevationView
@@ -348,8 +381,9 @@
   // Given
   CGFloat fakeElevation = 100;
   CGFloat fakeOverideElevation = 3;
-  self.elevationView.elevation = fakeElevation;
+  self.elevationOverrideView.elevation = fakeElevation;
   self.elevationOverrideView.mdc_overrideBaseElevation = fakeOverideElevation;
+  self.view.elevation = fakeElevation;
 
   // When
   [self.elevationView addSubview:self.view];
@@ -357,6 +391,8 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_baseElevation, fakeOverideElevation,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_absoluteElevation, fakeElevation + fakeOverideElevation,
                              0.001);
 }
 
@@ -372,6 +408,7 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.elevationView.mdc_baseElevation, 0, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationView.mdc_absoluteElevation, fakeElevation, 0.001);
 }
 
 // + self.view
@@ -388,6 +425,9 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_baseElevation, fakeElevationOverride,
+                             0.001);
+  XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_absoluteElevation,
+                             fakeElevationOverride + fakeElevation,
                              0.001);
 }
 
@@ -407,6 +447,8 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.elevationView.mdc_baseElevation,
+                             fakeViewControllerElevation + fakeViewControllerOverride, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationView.mdc_absoluteElevation,
                              fakeViewControllerElevation + fakeViewControllerOverride, 0.001);
 }
 
@@ -429,6 +471,8 @@
   // Then
   XCTAssertEqualWithAccuracy(self.elevationOverrideViewController.view.mdc_baseElevation,
                              fakeViewControllerOverride, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationOverrideViewController.view.mdc_absoluteElevation,
+                             fakeViewControllerOverride + fakeViewControllerElevation, 0.001);
 }
 
 // + self.view
@@ -442,6 +486,7 @@
 
   // Then
   XCTAssertEqualWithAccuracy(self.elevationViewController.view.mdc_baseElevation, 0, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationViewController.view.mdc_absoluteElevation, 100, 0.001);
 }
 
 // + self.view
@@ -459,6 +504,8 @@
   // Then
   XCTAssertEqualWithAccuracy(self.elevationOverrideViewController.view.mdc_baseElevation,
                              fakeElevationOverride, 0.001);
+  XCTAssertEqualWithAccuracy(self.elevationOverrideViewController.view.mdc_absoluteElevation,
+                             fakeElevationOverride + fakeElevation, 0.001);
 }
 
 #pragma mark - Elevation did change

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -535,4 +535,19 @@
   XCTAssertEqualWithAccuracy(viewBaseElevation, fakeOverrideElevation, 0.001);
 }
 
+- (void)testAbsoluteElevationReturnsCorrectValue {
+  // Given
+  CGFloat fakeElevation = 3;
+  CGFloat fakeCurrentElevation = 20;
+  self.elevationOverrideViewController.elevation = fakeCurrentElevation;
+  self.elevationOverrideViewController.mdc_overrideBaseElevation = fakeElevation;
+
+  // When
+  [self.elevationOverrideViewController.view addSubview:self.view];
+
+  // Then
+  XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, self.view.mdc_absoluteElevation,
+                             0.001);
+}
+
 @end

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -221,8 +221,7 @@
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
                              0.001);
   XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
-                             fakeElevation + fakeElevation + fakeCurrentElevation,
-                             0.001);
+                             fakeElevation + fakeElevation + fakeCurrentElevation, 0.001);
 }
 
 // + self.elevationOverrideView
@@ -280,8 +279,7 @@
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
                              0.001);
   XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
-                             fakeElevation + fakeElevation + fakeCurrentElevation,
-                             0.001);
+                             fakeElevation + fakeElevation + fakeCurrentElevation, 0.001);
 }
 
 // + self.elevationViewController
@@ -323,8 +321,7 @@
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevation + fakeCurrentElevation,
                              0.001);
   XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
-                             fakeElevation + fakeElevation + fakeCurrentElevation,
-                             0.001);
+                             fakeElevation + fakeElevation + fakeCurrentElevation, 0.001);
 }
 
 // + self.elevationView
@@ -348,8 +345,7 @@
   XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, fakeElevationOne + fakeElevationTwo,
                              0.001);
   XCTAssertEqualWithAccuracy(self.view.mdc_absoluteElevation,
-                             fakeElevationOne + fakeElevationOne + fakeElevationTwo,
-                             0.001);
+                             fakeElevationOne + fakeElevationOne + fakeElevationTwo, 0.001);
 }
 
 // + self.overrideElevationView
@@ -392,8 +388,8 @@
   // Then
   XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_baseElevation, fakeOverideElevation,
                              0.001);
-  XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_absoluteElevation, fakeElevation + fakeOverideElevation,
-                             0.001);
+  XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_absoluteElevation,
+                             fakeElevation + fakeOverideElevation, 0.001);
 }
 
 // + self.view
@@ -427,8 +423,7 @@
   XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_baseElevation, fakeElevationOverride,
                              0.001);
   XCTAssertEqualWithAccuracy(self.elevationOverrideView.mdc_absoluteElevation,
-                             fakeElevationOverride + fakeElevation,
-                             0.001);
+                             fakeElevationOverride + fakeElevation, 0.001);
 }
 
 // + self.elevationOverrideViewController

--- a/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
+++ b/components/Elevation/tests/unit/MDCMaterialElevationRespondingTests.m
@@ -546,8 +546,7 @@
   [self.elevationOverrideViewController.view addSubview:self.view];
 
   // Then
-  XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, self.view.mdc_absoluteElevation,
-                             0.001);
+  XCTAssertEqualWithAccuracy(self.view.mdc_baseElevation, self.view.mdc_absoluteElevation, 0.001);
 }
 
 @end


### PR DESCRIPTION
As clients will initialize their material components and want to provide a background color that fits the component's elevation, they will need to get its absolute elevation value. Therefore, currently they need to add mdc_currentElevation + mdc_baseElevation themselves to get that.

In this PR I am adding an mdc_absoluteElevation getter where clients can get that and not have to do unneeded calculation in their code. Furthermore, because elevationDidChangeBlock effectively returns the absolute elevation, it would be easier for clients to understand that concept by also providing an absoluteElevation property.

Added easier to understand description of what exactly the elevationDidChangeBlock elevation param it provides.