### PR TITLE
[Elevation] Doc clarification

### DIFF
--- a/components/Elevation/src/MDCElevationOverriding.h
+++ b/components/Elevation/src/MDCElevationOverriding.h
@@ -25,6 +25,8 @@
 
  This can be used in cases where there is elevation behind an object that is not part of the
  view hierarchy, like a @c UIPresentationController.
+
+ Note: If set to a negative value, this property is ignored as part of the @c mdc_baseElevation calculation.
  */
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
 

--- a/components/Elevation/src/MDCElevationOverriding.h
+++ b/components/Elevation/src/MDCElevationOverriding.h
@@ -26,7 +26,8 @@
  This can be used in cases where there is elevation behind an object that is not part of the
  view hierarchy, like a @c UIPresentationController.
 
- Note: If set to a negative value, this property is ignored as part of the @c mdc_baseElevation calculation.
+ Note: If set to a negative value, this property is ignored as part of the @c mdc_baseElevation
+ calculation.
  */
 @property(nonatomic, assign, readwrite) CGFloat mdc_overrideBaseElevation;
 

--- a/components/Elevation/src/UIView+MaterialElevationResponding.h
+++ b/components/Elevation/src/UIView+MaterialElevationResponding.h
@@ -25,8 +25,9 @@
  Returns the sum of all @c mdc_currentElevation of the superviews going up the view hierarchy
  recursively.
 
- If a view in the hierarchy conforms to @c MDCElevationOveriding and  @c mdc_overrideBaseElevation is non-negative,
- then  the sum of the current total plus the value of @c mdc_overrideBaseElevation is returned.
+ If a view in the hierarchy conforms to @c MDCElevationOveriding and  @c mdc_overrideBaseElevation
+ is non-negative, then  the sum of the current total plus the value of @c mdc_overrideBaseElevation
+ is returned.
 
  If a @c UIViewController conforms to @c MDCElevatable or @c MDCElevationOveriding then its @c view
  will report the view controllers base elevation.

--- a/components/Elevation/src/UIView+MaterialElevationResponding.h
+++ b/components/Elevation/src/UIView+MaterialElevationResponding.h
@@ -25,8 +25,8 @@
  Returns the sum of all @c mdc_currentElevation of the superviews going up the view hierarchy
  recursively.
 
- If a view in the hierarchy conforms to @c MDCElevationOveriding the sum of the current total plus
- that value is returned.
+ If a view in the hierarchy conforms to @c MDCElevationOveriding and  @c mdc_overrideBaseElevation is non-negative,
+ then  the sum of the current total plus the value of @c mdc_overrideBaseElevation is returned.
 
  If a @c UIViewController conforms to @c MDCElevatable or @c MDCElevationOveriding then its @c view
  will report the view controllers base elevation.


### PR DESCRIPTION
Explaining that the override property is ignored if set to a negative value.