### PR TITLE
[Chips] Fix default value for mdc_overrideBaseElevation.

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -137,6 +137,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.rippleAllowsSelection = YES;
   self.isAccessibilityElement = YES;
+  _mdc_overrideBaseElevation = -1;
   _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }
 

--- a/components/Chips/tests/unit/MDCChipViewTests.m
+++ b/components/Chips/tests/unit/MDCChipViewTests.m
@@ -22,7 +22,27 @@
 
 @implementation MDCChipViewTests
 
-#pragma mark - MDCElevation
+#pragma mark - MaterialElevation
+
+- (void)testDefaultValueForOverrideBaseElevationIsNegative {
+  // Given
+  MDCChipView *chip = [[MDCChipView alloc] init];
+
+  // Then
+  XCTAssertLessThan(chip.mdc_overrideBaseElevation, 0);
+}
+
+- (void)testSettingOverrideBaseElevationReturnsSetValue {
+  // Given
+  MDCChipView *chip = [[MDCChipView alloc] init];
+  CGFloat expectedBaseElevation = 99;
+
+  // When
+  chip.mdc_overrideBaseElevation = expectedBaseElevation;
+
+  // Then
+  XCTAssertEqualWithAccuracy(chip.mdc_overrideBaseElevation, expectedBaseElevation, 0.001);
+}
 
 - (void)testCurrentElevationMatchesElevationForState {
   // Given


### PR DESCRIPTION
It should be negative.

Part of #8021