### PR TITLE
[Color] add method for regular color blending.

### DIFF
--- a/components/private/Color/BUILD
+++ b/components/private/Color/BUILD
@@ -38,6 +38,7 @@ mdc_objc_library(
     ],
     deps = [
         ":Color",
+        "//components/private/Math",
     ],
     visibility = ["//visibility:private"],
 )

--- a/components/private/Color/src/UIColor+MaterialBlending.h
+++ b/components/private/Color/src/UIColor+MaterialBlending.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param color UIColor value that sits on top.
  @param backgroundColor UIColor on the background.
  */
-+ (nonnull UIColor *)blendColor:(nonnull UIColor *)color
-            withBackgroundColor:(nonnull UIColor *)backgroundColor;
++ (nonnull UIColor *)mdc_blendColor:(nonnull UIColor *)color
+                withBackgroundColor:(nonnull UIColor *)backgroundColor;
 
 @end
 

--- a/components/private/Color/src/UIColor+MaterialBlending.h
+++ b/components/private/Color/src/UIColor+MaterialBlending.h
@@ -1,0 +1,33 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIColor (MaterialBlending)
+
+/**
+ Blending a color over a background color using Alpha compositing technique.
+ More info about Alpha compositing: https://en.wikipedia.org/wiki/Alpha_compositing
+
+ @param color UIColor value that sits on top.
+ @param backgroundColor UIColor on the background.
+ */
++ (nonnull UIColor *)blendColor:(nonnull UIColor *)color
+            withBackgroundColor:(nonnull UIColor *)backgroundColor;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/components/private/Color/src/UIColor+MaterialBlending.m
+++ b/components/private/Color/src/UIColor+MaterialBlending.m
@@ -30,7 +30,7 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
 
 @implementation UIColor (MaterialBlending)
 
-+ (UIColor *)blendColor:(UIColor *)color withBackgroundColor:(UIColor *)backgroundColor {
++ (UIColor *)mdc_blendColor:(UIColor *)color withBackgroundColor:(UIColor *)backgroundColor {
   CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
   [color getRed:&red green:&green blue:&blue alpha:&alpha];
   CGFloat bRed = 0.0, bGreen = 0.0, bBlue = 0.0, bAlpha = 0.0;

--- a/components/private/Color/src/UIColor+MaterialBlending.m
+++ b/components/private/Color/src/UIColor+MaterialBlending.m
@@ -1,0 +1,45 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "UIColor+MaterialBlending.h"
+
+/**
+ Helper method to blend a color channel with a background color channel using alpha composition.
+ More info about Alpha compositing: https://en.wikipedia.org/wiki/Alpha_compositing
+
+ @params value is the value of color channel
+ @params bValue is the value of background color channel
+ @params alpha is the alpha of color channel
+ @params bAlpha is the alpha of background color channel
+ */
+
+static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, CGFloat bAlpha) {
+  return ((1 - alpha) * bValue * bAlpha + alpha * value) / (alpha + bAlpha * (1 - alpha));
+}
+
+@implementation UIColor (MaterialBlending)
+
++ (UIColor *)blendColor:(UIColor *)color withBackgroundColor:(UIColor *)backgroundColor {
+  CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
+  [color getRed:&red green:&green blue:&blue alpha:&alpha];
+  CGFloat bRed = 0.0, bGreen = 0.0, bBlue = 0.0, bAlpha = 0.0;
+  [backgroundColor getRed:&bRed green:&bGreen blue:&bBlue alpha:&bAlpha];
+
+  return [UIColor colorWithRed:blendColorChannel(red, bRed, alpha, bAlpha)
+                         green:blendColorChannel(green, bGreen, alpha, bAlpha)
+                          blue:blendColorChannel(blue, bBlue, alpha, bAlpha)
+                         alpha:alpha + bAlpha * (1 - alpha)];
+}
+
+@end

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -18,6 +18,16 @@
 #import "UIColor+MaterialBlending.h"
 #import "UIColor+MaterialDynamic.h"
 
+/** Returns a generated image of the given color and bounds. */
+static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
+  UIGraphicsBeginImageContext(bounds.size);
+  [color setFill];
+  UIRectFill(bounds);
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
+}
+
 @interface MaterialColorTests : XCTestCase
 @end
 
@@ -184,6 +194,29 @@
                                              green:(CGFloat)0.25595822821963915
                                               blue:(CGFloat)0.30395004586739971
                                              alpha:(CGFloat)0.88];
+    UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
+    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                      secondColor:expectedColor]);
+  }
+}
+
+
+- (void)testColorWithPatternImageMergeTest {
+  if (@available(iOS 10.0, *)) {
+    UIColor *backgroundColor = [UIColor colorWithHue:(CGFloat)0.7
+                                          saturation:(CGFloat)0.6
+                                          brightness:(CGFloat)0.2
+                                               alpha:(CGFloat)0.7];
+    UIColor *imageColor = [UIColor colorWithRed:(CGFloat)0.3
+                                          green:(CGFloat)0.3
+                                           blue:(CGFloat)0.2
+                                          alpha:(CGFloat)0.8];
+    UIImage *fakeImage = fakeImageWithColorAndSize(imageColor, CGRectMake(0, 0, 100, 100));
+    UIColor *blendColor = [UIColor colorWithPatternImage:fakeImage];
+    UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.10399999999999993
+                                             green:(CGFloat)0.080000000000000016
+                                              blue:(CGFloat)0.19999999999999998
+                                             alpha:(CGFloat)0.69999999999999996];
     UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
     XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                       secondColor:expectedColor]);

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -14,6 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MDCMath.h"
+#import "UIColor+MaterialBlending.h"
 #import "UIColor+MaterialDynamic.h"
 
 @interface MaterialColorTests : XCTestCase
@@ -75,6 +77,115 @@
     // Then
     XCTAssertEqualObjects(dynamicColor, lightColor);
   }
+}
+
+- (void)testColorMergeForOpaqueColor {
+  UIColor *backgroundColor = [UIColor whiteColor];
+  UIColor *blendColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1.0];
+  UIColor *expectedColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  XCTAssertEqualObjects(resultColor, expectedColor);
+}
+
+- (void)testColorMergeFor50OpacityBlackOnWhite {
+  UIColor *backgroundColor = [UIColor whiteColor];
+  UIColor *blendColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:(CGFloat)0.5];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.5
+                                           green:(CGFloat)0.5
+                                            blue:(CGFloat)0.5
+                                           alpha:1];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  XCTAssertEqualObjects(resultColor, expectedColor);
+}
+
+- (void)testColorMergeFor60GrayOpacityOnWhite {
+  UIColor *backgroundColor = [UIColor whiteColor];
+  UIColor *blendColor = [UIColor colorWithRed:(CGFloat)0.9
+                                        green:(CGFloat)0.9
+                                         blue:(CGFloat)0.9
+                                        alpha:(CGFloat)0.6];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.94000000000000006
+                                           green:(CGFloat)0.94000000000000006
+                                            blue:(CGFloat)0.94000000000000006
+                                           alpha:(CGFloat)1];
+
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                    secondColor:expectedColor]);
+}
+
+- (void)testColorMergeFor50OpacityWhiteOnBlack {
+  UIColor *backgroundColor = [UIColor blackColor];
+  UIColor *blendColor = [UIColor colorWithRed:1 green:1 blue:1 alpha:(CGFloat)0.5];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.5
+                                           green:(CGFloat)0.5
+                                            blue:(CGFloat)0.5
+                                           alpha:1];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  XCTAssertEqualObjects(resultColor, expectedColor);
+}
+
+- (void)testBasicColorMergeTest {
+  UIColor *backgroundColor = [UIColor colorWithRed:(CGFloat)0.4
+                                             green:(CGFloat)0.6
+                                              blue:(CGFloat)0.9
+                                             alpha:(CGFloat)0.8];
+  UIColor *blendColor = [UIColor colorWithRed:(CGFloat)0.1
+                                        green:(CGFloat)0.8
+                                         blue:(CGFloat)0.8
+                                        alpha:(CGFloat)0.2];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.32857142857142863
+                                           green:(CGFloat)0.64761904761904765
+                                            blue:(CGFloat)0.87619047619047618
+                                           alpha:(CGFloat)0.84000000000000008];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                    secondColor:expectedColor]);
+}
+
+- (void)testHBSColorMergeTest {
+  UIColor *backgroundColor = [UIColor colorWithHue:(CGFloat)0.7
+                                        saturation:(CGFloat)0.6
+                                        brightness:(CGFloat)0.2
+                                             alpha:(CGFloat)0.7];
+  UIColor *blendColor = [UIColor colorWithRed:(CGFloat)0.3
+                                        green:(CGFloat)0.3
+                                         blue:(CGFloat)0.2
+                                        alpha:(CGFloat)0.8];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.27080851063829786
+                                           green:(CGFloat)0.2672340425531915
+                                            blue:(CGFloat)0.20000000000000004
+                                           alpha:(CGFloat)0.93999999999999994];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                    secondColor:expectedColor]);
+}
+
+- (void)testGrayScaleColorMergeTest {
+  UIColor *backgroundColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.8];
+  UIColor *blendColor = [UIColor colorWithRed:(CGFloat)0.9
+                                        green:(CGFloat)0.82
+                                         blue:(CGFloat)0.1
+                                        alpha:(CGFloat)0.6];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.69130434782608696
+                                           green:(CGFloat)0.63913043478260867
+                                            blue:(CGFloat)0.16956521739130434
+                                           alpha:(CGFloat)0.92000000000000004];
+  UIColor *resultColor = [UIColor blendColor:blendColor
+                         withBackgroundColor:backgroundColor];
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                    secondColor:expectedColor]);
+}
+
+- (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
+                                      secondColor:(UIColor *)secondColor {
+  CGFloat fRed = 0.0, fGreen = 0.0, fBlue = 0.0, fAlpha = 0.0;
+  [firstColor getRed:&fRed green:&fGreen blue:&fBlue alpha:&fAlpha];
+  CGFloat sRed = 0.0, sGreen = 0.0, sBlue = 0.0, sAlpha = 0.0;
+  [secondColor getRed:&sRed green:&sGreen blue:&sBlue alpha:&sAlpha];
+
+  return (MDCCGFloatEqual(fRed, sRed) && MDCCGFloatEqual(fGreen, sGreen) &&
+          MDCCGFloatEqual(fBlue, sBlue) && MDCCGFloatEqual(fAlpha, sAlpha));
 }
 
 @end

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -200,7 +200,6 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   }
 }
 
-
 - (void)testColorWithPatternImageMergeTest {
   if (@available(iOS 10.0, *)) {
     UIColor *backgroundColor = [UIColor colorWithHue:(CGFloat)0.7

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -171,8 +171,7 @@
                                            green:(CGFloat)0.63913043478260867
                                             blue:(CGFloat)0.16956521739130434
                                            alpha:(CGFloat)0.92000000000000004];
-  UIColor *resultColor = [UIColor blendColor:blendColor
-                         withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                     secondColor:expectedColor]);
 }

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -83,7 +83,7 @@
   UIColor *backgroundColor = [UIColor whiteColor];
   UIColor *blendColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1.0];
   UIColor *expectedColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertEqualObjects(resultColor, expectedColor);
 }
 
@@ -94,7 +94,7 @@
                                            green:(CGFloat)0.5
                                             blue:(CGFloat)0.5
                                            alpha:1];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertEqualObjects(resultColor, expectedColor);
 }
 
@@ -104,7 +104,7 @@
                                         green:(CGFloat)0.9
                                          blue:(CGFloat)0.9
                                         alpha:(CGFloat)0.6];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.94000000000000006
                                            green:(CGFloat)0.94000000000000006
                                             blue:(CGFloat)0.94000000000000006
@@ -121,7 +121,7 @@
                                            green:(CGFloat)0.5
                                             blue:(CGFloat)0.5
                                            alpha:1];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertEqualObjects(resultColor, expectedColor);
 }
 
@@ -138,7 +138,7 @@
                                            green:(CGFloat)0.64761904761904765
                                             blue:(CGFloat)0.87619047619047618
                                            alpha:(CGFloat)0.84000000000000008];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                     secondColor:expectedColor]);
 }
@@ -156,7 +156,7 @@
                                            green:(CGFloat)0.2672340425531915
                                             blue:(CGFloat)0.20000000000000004
                                            alpha:(CGFloat)0.93999999999999994];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                     secondColor:expectedColor]);
 }
@@ -171,7 +171,7 @@
                                            green:(CGFloat)0.63913043478260867
                                             blue:(CGFloat)0.16956521739130434
                                            alpha:(CGFloat)0.92000000000000004];
-  UIColor *resultColor = [UIColor blendColor:blendColor withBackgroundColor:backgroundColor];
+  UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
   XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                     secondColor:expectedColor]);
 }

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -189,7 +189,10 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 - (void)testP3ColorMergeTest {
   if (@available(iOS 10.0, *)) {
     UIColor *backgroundColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.8];
-    UIColor *blendColor = [UIColor colorWithDisplayP3Red:0.1 green:0.2 blue:0.3 alpha:0.4];
+    UIColor *blendColor = [UIColor colorWithDisplayP3Red:(CGFloat)0.1
+                                                   green:(CGFloat)0.2
+                                                    blue:(CGFloat)0.3
+                                                   alpha:(CGFloat)0.4];
     UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.19059444720094854
                                              green:(CGFloat)0.25595822821963915
                                               blue:(CGFloat)0.30395004586739971

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -176,6 +176,23 @@
                                                     secondColor:expectedColor]);
 }
 
+- (void)testP3ColorMergeTest {
+  if (@available(iOS 10.0, *)) {
+    UIColor *backgroundColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.8];
+    UIColor *blendColor = [UIColor colorWithDisplayP3Red:0.1
+                                                   green:0.2
+                                                    blue:0.3
+                                                   alpha:0.4];
+    UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.19059444720094854
+                                             green:(CGFloat)0.25595822821963915
+                                              blue:(CGFloat)0.30395004586739971
+                                             alpha:(CGFloat)0.88];
+    UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
+    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
+                                                      secondColor:expectedColor]);
+  }
+}
+
 - (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
                                       secondColor:(UIColor *)secondColor {
   CGFloat fRed = 0.0, fGreen = 0.0, fBlue = 0.0, fAlpha = 0.0;

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -179,10 +179,7 @@
 - (void)testP3ColorMergeTest {
   if (@available(iOS 10.0, *)) {
     UIColor *backgroundColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.8];
-    UIColor *blendColor = [UIColor colorWithDisplayP3Red:0.1
-                                                   green:0.2
-                                                    blue:0.3
-                                                   alpha:0.4];
+    UIColor *blendColor = [UIColor colorWithDisplayP3Red:0.1 green:0.2 blue:0.3 alpha:0.4];
     UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.19059444720094854
                                              green:(CGFloat)0.25595822821963915
                                               blue:(CGFloat)0.30395004586739971

--- a/components/private/Color/tests/unit/MaterialColorTests.m
+++ b/components/private/Color/tests/unit/MaterialColorTests.m
@@ -189,14 +189,14 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 - (void)testP3ColorMergeTest {
   if (@available(iOS 10.0, *)) {
     UIColor *backgroundColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.8];
-    UIColor *blendColor = [UIColor colorWithDisplayP3Red:(CGFloat)0.1
-                                                   green:(CGFloat)0.2
-                                                    blue:(CGFloat)0.3
-                                                   alpha:(CGFloat)0.4];
-    UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.19059444720094854
-                                             green:(CGFloat)0.25595822821963915
-                                              blue:(CGFloat)0.30395004586739971
-                                             alpha:(CGFloat)0.88];
+    UIColor *blendColor = [UIColor colorWithRed:(CGFloat)0.9
+                                          green:(CGFloat)0.82
+                                           blue:(CGFloat)0.1
+                                          alpha:(CGFloat)0.6];
+    UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.69130434782608696
+                                             green:(CGFloat)0.63913043478260867
+                                              blue:(CGFloat)0.16956521739130434
+                                             alpha:(CGFloat)0.92000000000000004];
     UIColor *resultColor = [UIColor mdc_blendColor:blendColor withBackgroundColor:backgroundColor];
     XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resultColor
                                                       secondColor:expectedColor]);


### PR DESCRIPTION
Prepare for b/137091265.

This method is copied from the one in MDCSemanticColorScheme. 

We need to add it here for a clear structure and to avoid depending on the scheme target for low level elevation classes. (This method intuitively doesn't need to exist under scheme). 

The original method in MDCSemanticColorScheme will need to redirect/call this method internally if we don't want to deprecate it as a public available API, which will be addressed in a follow-up PR.