### PR TITLE
[BottomNavigation] Make KVO safe for `nil`.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -30,6 +30,9 @@
 // The Bundle for string resources.
 static NSString *const kBundleName = @"MaterialBottomNavigation.bundle";
 
+// KVO context
+static char *const kKVOContextMDCBottomNavigationBar = "kKVOContextMDCBottomNavigationBar";
+
 static const CGFloat kMinItemWidth = 80;
 static const CGFloat kPreferredItemWidth = 120;
 static const CGFloat kMaxItemWidth = 168;
@@ -38,19 +41,6 @@ static const CGFloat kItemHorizontalPadding = 12;
 static const CGFloat kBarHeightStackedTitle = 56;
 static const CGFloat kBarHeightAdjacentTitle = 40;
 static const CGFloat kItemsHorizontalMargin = 12;
-static NSString *const kBadgeColorString = @"badgeColor";
-static NSString *const kBadgeValueString = @"badgeValue";
-static NSString *const kAccessibilityValueString = @"accessibilityValue";
-static NSString *const kImageString = @"image";
-static NSString *const kSelectedImageString = @"selectedImage";
-// TODO: - Change to NSKeyValueChangeNewKey
-static NSString *const kNewString = @"new";
-static NSString *const kTitleString = @"title";
-static NSString *const kAccessibilityIdentifier = @"accessibilityIdentifier";
-static NSString *const kAccessibilityLabel = @"accessibilityLabel";
-static NSString *const kAccessibilityHint = @"accessibilityHint";
-static NSString *const kIsAccessibilityElement = @"isAccessibilityElement";
-static NSString *const kTitlePositionAdjustment = @"titlePositionAdjustment";
 
 static NSString *const kOfAnnouncement = @"of";
 
@@ -349,72 +339,47 @@ static NSString *const kOfAnnouncement = @"of";
   [self removeObserversFromTabBarItems];
 }
 
+- (NSArray<NSString *> *)kvoKeyPaths {
+  static NSArray<NSString *> *keyPaths;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    keyPaths = @[
+      NSStringFromSelector(@selector(badgeColor)), NSStringFromSelector(@selector(badgeValue)),
+      NSStringFromSelector(@selector(title)), NSStringFromSelector(@selector(image)),
+      NSStringFromSelector(@selector(selectedImage)),
+      NSStringFromSelector(@selector(accessibilityValue)),
+      NSStringFromSelector(@selector(accessibilityLabel)),
+      NSStringFromSelector(@selector(accessibilityHint)),
+      NSStringFromSelector(@selector(accessibilityIdentifier)),
+      NSStringFromSelector(@selector(isAccessibilityElement)),
+      NSStringFromSelector(@selector(titlePositionAdjustment))
+    ];
+  });
+  return keyPaths;
+}
+
 - (void)addObserversToTabBarItems {
+  NSArray<NSString *> *keyPaths = [self kvoKeyPaths];
   for (UITabBarItem *item in self.items) {
-    [item addObserver:self
-           forKeyPath:kBadgeColorString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kBadgeValueString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kAccessibilityValueString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kImageString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kSelectedImageString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kTitleString
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kAccessibilityIdentifier
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kAccessibilityLabel
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kAccessibilityHint
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kIsAccessibilityElement
-              options:NSKeyValueObservingOptionNew
-              context:nil];
-    [item addObserver:self
-           forKeyPath:kTitlePositionAdjustment
-              options:NSKeyValueObservingOptionNew
-              context:nil];
+    for (NSString *keyPath in keyPaths) {
+      [item addObserver:self
+             forKeyPath:keyPath
+                options:NSKeyValueObservingOptionNew
+                context:kKVOContextMDCBottomNavigationBar];
+    }
   }
 }
 
 - (void)removeObserversFromTabBarItems {
+  NSArray<NSString *> *keyPaths = [self kvoKeyPaths];
   for (UITabBarItem *item in self.items) {
-    @try {
-      [item removeObserver:self forKeyPath:kBadgeColorString];
-      [item removeObserver:self forKeyPath:kBadgeValueString];
-      [item removeObserver:self forKeyPath:kAccessibilityValueString];
-      [item removeObserver:self forKeyPath:kImageString];
-      [item removeObserver:self forKeyPath:kSelectedImageString];
-      [item removeObserver:self forKeyPath:kTitleString];
-      [item removeObserver:self forKeyPath:kAccessibilityIdentifier];
-      [item removeObserver:self forKeyPath:kAccessibilityLabel];
-      [item removeObserver:self forKeyPath:kAccessibilityHint];
-      [item removeObserver:self forKeyPath:kIsAccessibilityElement];
-      [item removeObserver:self forKeyPath:kTitlePositionAdjustment];
-    } @catch (NSException *exception) {
-      if (exception) {
-        // No need to do anything if there are no observers.
+    for (NSString *keyPath in keyPaths) {
+      @try {
+        [item removeObserver:self forKeyPath:keyPath context:kKVOContextMDCBottomNavigationBar];
+      } @catch (NSException *exception) {
+        if (exception) {
+          // No need to do anything if there are no observers.
+        }
       }
     }
   }
@@ -424,39 +389,45 @@ static NSString *const kOfAnnouncement = @"of";
                       ofObject:(id)object
                         change:(NSDictionary<NSKeyValueChangeKey, id> *)change
                        context:(void *)context {
-  if (!context) {
-    NSInteger selectedItemNum = 0;
-    for (NSUInteger i = 0; i < self.items.count; i++) {
-      UITabBarItem *item = self.items[i];
-      if (object == item) {
-        selectedItemNum = i;
-        break;
-      }
+  if (context == kKVOContextMDCBottomNavigationBar) {
+    if (!object) {
+      return;
     }
-    MDCBottomNavigationItemView *itemView = _itemViews[selectedItemNum];
-    if ([keyPath isEqualToString:kBadgeColorString]) {
-      itemView.badgeColor = change[kNewString];
-    } else if ([keyPath isEqualToString:kAccessibilityValueString]) {
-      itemView.accessibilityValue = change[NSKeyValueChangeNewKey];
-    } else if ([keyPath isEqualToString:kBadgeValueString]) {
-      itemView.badgeValue = change[kNewString];
-    } else if ([keyPath isEqualToString:kImageString]) {
-      itemView.image = change[kNewString];
-    } else if ([keyPath isEqualToString:kSelectedImageString]) {
-      itemView.selectedImage = change[kNewString];
-    } else if ([keyPath isEqualToString:kTitleString]) {
-      itemView.title = change[kNewString];
-    } else if ([keyPath isEqualToString:kAccessibilityIdentifier]) {
-      itemView.accessibilityIdentifier = change[kNewString];
-    } else if ([keyPath isEqualToString:kAccessibilityLabel]) {
-      itemView.accessibilityLabel = change[kNewString];
-    } else if ([keyPath isEqualToString:kAccessibilityHint]) {
-      itemView.accessibilityHint = change[kNewString];
-    } else if ([keyPath isEqualToString:kIsAccessibilityElement]) {
-      itemView.isAccessibilityElement = [change[kNewString] boolValue];
-    } else if ([keyPath isEqualToString:kTitlePositionAdjustment]) {
-      itemView.titlePositionAdjustment = [change[kNewString] UIOffsetValue];
+    NSUInteger itemIndex = [self.items indexOfObject:object];
+    if (itemIndex == NSNotFound || itemIndex >= _itemViews.count) {
+      return;
     }
+    id newValue = [object valueForKey:keyPath];
+    if (newValue == [NSNull null]) {
+      newValue = nil;
+    }
+
+    MDCBottomNavigationItemView *itemView = _itemViews[itemIndex];
+    if ([keyPath isEqualToString:NSStringFromSelector(@selector(badgeColor))]) {
+      itemView.badgeColor = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityValue))]) {
+      itemView.accessibilityValue = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(badgeValue))]) {
+      itemView.badgeValue = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(image))]) {
+      itemView.image = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(selectedImage))]) {
+      itemView.selectedImage = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
+      itemView.title = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityIdentifier))]) {
+      itemView.accessibilityIdentifier = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityLabel))]) {
+      itemView.accessibilityLabel = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityHint))]) {
+      itemView.accessibilityHint = newValue;
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(isAccessibilityElement))]) {
+      itemView.isAccessibilityElement = [newValue boolValue];
+    } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(titlePositionAdjustment))]) {
+      itemView.titlePositionAdjustment = [newValue UIOffsetValue];
+    }
+  } else {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }
 }
 

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
@@ -1,0 +1,315 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCBottomNavigationItemView.h"
+#import "MDCBottomNavigationBar.h"
+
+/** Returns a generated image of the given size. */
+static UIImage *fakeImage() {
+  UIGraphicsBeginImageContext(CGSizeMake(24, 24));
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
+}
+
+/** Category to expose internals for testing. */
+@interface MDCBottomNavigationBar (MDCBottomNavigationBarKVOTests)
+@property(nonatomic, strong) NSMutableArray<MDCBottomNavigationItemView *> *itemViews;
+@end
+
+/** Unit tests focusing on Key-Value Observing (KVO) within MDCBottomNavigationBar. */
+@interface MDCBottomNavigationBarKVOTests : XCTestCase
+
+/** The Bottom Navigation to use for testing. */
+@property(nonatomic, strong) MDCBottomNavigationBar *bottomNavigationBar;
+/** The bar item assigned to the Bottom Navigationbar. */
+@property(nonatomic, strong) UITabBarItem *barItem;
+@end
+
+@implementation MDCBottomNavigationBarKVOTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.bottomNavigationBar = [[MDCBottomNavigationBar alloc] init];
+  self.barItem = [[UITabBarItem alloc] initWithTitle:@"title" image:fakeImage() tag:0];
+  self.barItem.selectedImage = fakeImage();
+  self.barItem.badgeValue = @"badge";
+  self.barItem.titlePositionAdjustment = UIOffsetMake(1, 2);
+  self.barItem.accessibilityLabel = @"label";
+  self.barItem.accessibilityHint = @"hint";
+  self.barItem.accessibilityValue = @"value";
+  self.barItem.accessibilityTraits = UIAccessibilityTraitLink;
+  self.barItem.accessibilityIdentifier = @"identifier";
+  self.barItem.isAccessibilityElement = YES;
+  if (@available(iOS 10.0, *)) {
+    self.barItem.badgeColor = UIColor.darkGrayColor;
+  }
+  self.bottomNavigationBar.items = @[ self.barItem ];
+}
+
+- (void)tearDown {
+  self.barItem = nil;
+  self.bottomNavigationBar = nil;
+
+  [super tearDown];
+}
+
+- (void)testChangeTitleToNonEmptyString {
+  // When
+  self.barItem.title = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.title, self.barItem.title);
+}
+
+- (void)testChangeTitleToEmptyString {
+  // When
+  self.barItem.title = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.title, self.barItem.title);
+}
+
+- (void)testChangeTitleToNil {
+  // When
+  self.barItem.title = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.title);
+}
+
+- (void)testChangeImageToNewImageDoesNotRaiseException {
+  // Then
+  XCTAssertNoThrow(self.barItem.image = fakeImage());
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNotNil(itemView.image);
+}
+
+- (void)testChangeImageToNil {
+  // When
+  self.barItem.image = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.image);
+}
+
+- (void)testChangeSelectedImageToNewImageDoesNotRaiseException {
+  // Then
+  XCTAssertNoThrow(self.barItem.selectedImage = fakeImage());
+}
+
+- (void)testChangeSelectedImageToNilDoesNotRaiseException {
+  // Then
+  XCTAssertNoThrow(self.barItem.selectedImage = nil);
+}
+
+- (void)testChangeBadgeValueToNonEmptyString {
+  // When
+  self.barItem.badgeValue = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.badgeValue, self.barItem.badgeValue);
+}
+
+- (void)testChangeBadgeValueToEmptyString {
+  // When
+  self.barItem.badgeValue = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.badgeValue, self.barItem.badgeValue);
+}
+
+- (void)testChangeBadgeValueToNil {
+  // When
+  self.barItem.badgeValue = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.badgeValue);
+}
+
+- (void)testChangeBadgeColorToNewColor {
+  // When
+  if (@available(iOS 10.0, *)) {
+    self.barItem.badgeColor = [UIColor.purpleColor colorWithAlphaComponent:(CGFloat)0.712];
+
+    // Then
+    MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+    XCTAssertEqualObjects(itemView.badgeColor, self.barItem.badgeColor);
+  }
+}
+
+- (void)testChangeBadgeColorToNil {
+  // When
+  if (@available(iOS 10.0, *)) {
+    self.barItem.badgeColor = nil;
+
+    // Then
+    MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+    XCTAssertNil(itemView.badgeColor);
+  }
+}
+
+- (void)testChangeTitlePositionAdjustmentToNonZeroOffsetDoesNotRaiseException {
+  // Then
+  XCTAssertNoThrow(self.barItem.titlePositionAdjustment = UIOffsetMake(17, 2));
+}
+
+- (void)testChangeTitlePositionAdjustmentToOffsetZeroDoesNotRaiseException {
+  // Then
+  XCTAssertNoThrow(self.barItem.titlePositionAdjustment = UIOffsetZero);
+}
+
+- (void)testChangeAccessibilityLabelToNonEmptyString {
+  // When
+  self.barItem.accessibilityLabel = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityLabel, self.barItem.accessibilityLabel);
+}
+
+- (void)testChangeAccessibilityLabelToEmptyString {
+  // When
+  self.barItem.accessibilityLabel = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityLabel, self.barItem.accessibilityLabel);
+}
+
+- (void)testChangeAccessibilityLabelToNil {
+  // When
+  self.barItem.accessibilityLabel = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.accessibilityLabel);
+}
+
+- (void)testChangeAccessibilityHintToNonEmptyString {
+  // When
+  self.barItem.accessibilityHint = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityHint, self.barItem.accessibilityHint);
+}
+
+- (void)testChangeAccessibilityHintToEmptyString {
+  // When
+  self.barItem.accessibilityHint = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityHint, self.barItem.accessibilityHint);
+}
+
+- (void)testChangeAccessibilityHintToNil {
+  // When
+  self.barItem.accessibilityHint = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.accessibilityHint);
+}
+
+- (void)testChangeAccessibilityValueToNonEmptyString {
+  // When
+  self.barItem.accessibilityValue = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityValue, self.barItem.accessibilityValue);
+}
+
+- (void)testChangeAccessibilityValueToEmptyString {
+  // When
+  self.barItem.accessibilityValue = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityValue, self.barItem.accessibilityValue);
+}
+
+- (void)testChangeAccessibilityValueToNil {
+  // When
+  self.barItem.accessibilityValue = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.accessibilityValue);
+}
+
+- (void)testChangeAccessibilityIdentifierToNonEmptyString {
+  // When
+  self.barItem.accessibilityIdentifier = @"string";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityIdentifier, self.barItem.accessibilityIdentifier);
+}
+
+- (void)testChangeAccessibilityIdentifierToEmptyString {
+  // When
+  self.barItem.accessibilityIdentifier = @"";
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertEqualObjects(itemView.accessibilityIdentifier, self.barItem.accessibilityIdentifier);
+}
+
+- (void)testChangeAccessibilityIdentifierToNil {
+  // When
+  self.barItem.accessibilityIdentifier = nil;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertNil(itemView.accessibilityIdentifier);
+}
+
+- (void)testChangeIsAccessibilityElementNoToYes {
+  // Given
+  self.barItem.isAccessibilityElement = NO;
+
+  // When
+  self.barItem.isAccessibilityElement = YES;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertTrue(itemView.isAccessibilityElement);
+}
+
+- (void)testChangeIsAccessibilityElementYesToNo {
+  // Given
+  self.barItem.isAccessibilityElement = YES;
+
+  // When
+  self.barItem.isAccessibilityElement = NO;
+
+  // Then
+  MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
+  XCTAssertFalse(itemView.isAccessibilityElement);
+}
+
+@end


### PR DESCRIPTION
For most of the `UITabBarItem` `NSString` properties, setting them to `nil` after assigning the item to the Bottom Navigation bar resulted in a raised exception that can crash an app. The KVO code is being updated to match the style in MDCButtonBar to make it safe for `nil` values.

Closes #8082