### PR TITLE
[Elevation] Add a UIColor category to support resolving color with elevation.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -974,6 +974,7 @@ Pod::Spec.new do |mdc|
         "components/#{component.base_name}/tests/unit/*.{h,m,swift}",
         "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
       ]
+      unit_tests.dependency "MaterialComponents/private/Color"
     end
   end
 

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -966,6 +966,8 @@ Pod::Spec.new do |mdc|
       "components/#{component.base_name}/src/*.{h,m}",
       "components/#{component.base_name}/src/private/*.{h,m}"
     ]
+    component.dependency "MaterialComponents/private/Color"
+    component.dependency "MaterialComponents/private/Math"
 
     component.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -47,7 +47,6 @@ mdc_unit_test_objc_library(
     deps = [
         ":Elevation",
         "//components/private/Color",
-        "//components/private/Math",
     ],
 )
 

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -30,6 +30,9 @@ mdc_public_objc_library(
     sdk_frameworks = [
         "CoreGraphics",
     ],
+    deps = [
+        "//components/private/Color",
+    ],
 )
 
 mdc_unit_test_objc_library(
@@ -41,6 +44,8 @@ mdc_unit_test_objc_library(
     visibility = ["//visibility:private"],
     deps = [
         ":Elevation",
+        "//components/private/Color",
+        "//components/private/Math",
     ],
 )
 

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -32,6 +32,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/private/Color",
+        "//components/private/Math",
     ],
 )
 

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -41,6 +41,7 @@ mdc_unit_test_objc_library(
     testonly = 1,
     sdk_frameworks = [
         "UIKit",
+        "CoreGraphics",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/components/Elevation/src/MaterialElevation.h
+++ b/components/Elevation/src/MaterialElevation.h
@@ -15,3 +15,4 @@
 #import "MDCElevatable.h"
 #import "MDCElevationOverriding.h"
 #import "UIView+MaterialElevationResponding.h"
+#import "UIColor+MaterialElevation.h"

--- a/components/Elevation/src/MaterialElevation.h
+++ b/components/Elevation/src/MaterialElevation.h
@@ -14,5 +14,5 @@
 
 #import "MDCElevatable.h"
 #import "MDCElevationOverriding.h"
-#import "UIView+MaterialElevationResponding.h"
 #import "UIColor+MaterialElevation.h"
+#import "UIView+MaterialElevationResponding.h"

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -40,7 +40,6 @@
  */
 - (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:
                          (nonnull UITraitCollection *)traitCollection
-                                                elevation:(CGFloat)elevation
-    API_AVAILABLE(ios(13.0));
+                                                elevation:(CGFloat)elevation;
 
 @end

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -22,6 +22,8 @@
 
 /**
  Returns a color that takes the specified elevation value into account.
+ The color is the blended color of Surface and Elevation Overlay in
+ https://material.io/design/color/dark-theme.html#properties
  @param elevation The elevation to use when resolving the color.
  */
 - (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param elevation The elevation to use when resolving the color.
 - (UIColor *)resolvedColorWithElevation:(CGFloat)elevation;
 
-
 /// Returns a color that takes the specified elevation value and traits into account.
 /// @param traitCollection The traits to use when resolving the color.
 /// @param elevation The elevation to use when resolving the color.

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -36,7 +36,7 @@
  UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
 
  @param traitCollection The traits to use when resolving the color.
- @param elevation The elevation to use when resolving the color.
+ @param elevation The mdc_absoluteElevation to use when resolving the color.
  */
 - (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:
                          (nonnull UITraitCollection *)traitCollection

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -24,7 +24,9 @@
  Returns a color that takes the specified elevation value into account.
  The color is the blended color of Surface and Elevation Overlay in
  https://material.io/design/color/dark-theme.html#properties
- @param elevation The mdc_absoluteElevation value to use when resolving the color.
+ Negative elevation is treated as 0.
+ Pattern-based UIColor is not supported.
+ @param elevation The @c mdc_absoluteElevation value to use when resolving the color.
  */
 - (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 
@@ -32,14 +34,16 @@
  Returns a color that takes the specified elevation value and traits into account.
  When userInterfaceStyle is UIUserInterfaceStyleDark in traitCollection, elevation will be used
  to resolve the color.
- Negative elevation is treated as 0. Pattern-based UIColor is not supported.
+ Negative elevation is treated as 0.
+ Pattern-based UIColor is not supported.
  UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
 
  @param traitCollection The traits to use when resolving the color.
- @param elevation The mdc_absoluteElevation to use when resolving the color.
+ @param elevation The @c mdc_absoluteElevation to use when resolving the color.
  */
 - (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:
                          (nonnull UITraitCollection *)traitCollection
-                                                elevation:(CGFloat)elevation;
+                                                elevation:(CGFloat)elevation
+    API_AVAILABLE(ios(13.0));
 
 @end

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -1,0 +1,34 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIColor (MaterialElevation)
+
+/// Returns a color that takes the specified elevation value into account.
+/// @param elevation The elevation to use when resolving the color.
+- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation;
+
+
+/// Returns a color that takes the specified elevation value and traits into account.
+/// @param traitCollection The traits to use when resolving the color.
+/// @param elevation The elevation to use when resolving the color.
+- (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
+                                 andElevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -24,7 +24,7 @@
  Returns a color that takes the specified elevation value into account.
  The color is the blended color of Surface and Elevation Overlay in
  https://material.io/design/color/dark-theme.html#properties
- @param elevation The elevation to use when resolving the color.
+ @param elevation The mdc_absoluteElevation value to use when resolving the color.
  */
 - (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
-
-NS_ASSUME_NONNULL_BEGIN
 
 /**
  Provides extension to UIColor for Material Elevation usage.
@@ -25,16 +24,21 @@ NS_ASSUME_NONNULL_BEGIN
  Returns a color that takes the specified elevation value into account.
  @param elevation The elevation to use when resolving the color.
  */
-- (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
+- (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 
 /**
  Returns a color that takes the specified elevation value and traits into account.
+ When userInterfaceStyle is UIUserInterfaceStyleDark in traitCollection, elevation will be used
+ to resolve the color.
+ Negative elevation is treated as 0. Pattern-based UIColor is not supported.
+ UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
+
  @param traitCollection The traits to use when resolving the color.
  @param elevation The elevation to use when resolving the color.
  */
-- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
-                                        elevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
+- (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:
+                         (nonnull UITraitCollection *)traitCollection
+                                                elevation:(CGFloat)elevation
+    API_AVAILABLE(ios(13.0));
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param traitCollection The traits to use when resolving the color.
 /// @param elevation The elevation to use when resolving the color.
 - (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
-                                 andElevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
+                                    elevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
 
 @end
 

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -16,17 +16,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Provides extension to UIColor for Material Elevation usage.
+ */
 @interface UIColor (MaterialElevation)
 
-/// Returns a color that takes the specified elevation value into account.
-/// @param elevation The elevation to use when resolving the color.
-- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation;
+/**
+ Returns a color that takes the specified elevation value into account.
+ @param elevation The elevation to use when resolving the color.
+ */
+- (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 
-/// Returns a color that takes the specified elevation value and traits into account.
-/// @param traitCollection The traits to use when resolving the color.
-/// @param elevation The elevation to use when resolving the color.
-- (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
-                                    elevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
+/**
+ Returns a color that takes the specified elevation value and traits into account.
+ @param traitCollection The traits to use when resolving the color.
+ @param elevation The elevation to use when resolving the color.
+ */
+- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
+                                        elevation:(CGFloat)elevation API_AVAILABLE(ios(13.0));
 
 @end
 

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -19,7 +19,7 @@
 @implementation UIColor (MaterialElevation)
 
 - (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
-                                 andElevation:(CGFloat)elevation {
+                                    elevation:(CGFloat)elevation {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     UIColor *resolvedColor = [self resolvedColorWithTraitCollection:traitCollection];

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -1,0 +1,52 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "UIColor+MaterialElevation.h"
+
+#import "UIColor+MaterialBlending.h"
+
+@implementation UIColor (MaterialElevation)
+
+- (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
+                                 andElevation:(CGFloat)elevation {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    UIColor *resolvedColor = [self resolvedColorWithTraitCollection:traitCollection];
+    if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+      return [resolvedColor resolvedColorWithElevation:elevation];
+    } else {
+      return resolvedColor;
+    }
+  } else {
+    return [self resolvedColorWithElevation:elevation];
+  }
+#else
+  return [self resolvedColorWithElevation:elevation];
+#endif
+}
+
+- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation {
+  UIColor *overlayColor = UIColor.whiteColor;
+  return [self resolvedColorWithElevation:elevation
+                             overlayColor:overlayColor];
+}
+
+- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation
+                           overlayColor:(UIColor *)overlayColor {
+  CGFloat alphaValue = 4.5 * log(elevation + 1) + 2;
+  return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * 0.01]
+             withBackgroundColor:self];
+}
+
+@end

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -49,6 +49,9 @@
   elevation = MAX(elevation, 0);
   CGFloat alphaValue = 0;
   if (!MDCCGFloatEqual(elevation, 0)) {
+    // A formula is used here to simulate the alpha percentage stated on
+    // https://material.io/design/color/dark-theme.html#properties
+    // AlphaValue = 4.5 * ln (elevationValue + 1) + 2
     alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
   }
   return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * (CGFloat)0.01]

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -38,12 +38,10 @@
 
 - (UIColor *)resolvedColorWithElevation:(CGFloat)elevation {
   UIColor *overlayColor = UIColor.whiteColor;
-  return [self resolvedColorWithElevation:elevation
-                             overlayColor:overlayColor];
+  return [self resolvedColorWithElevation:elevation overlayColor:overlayColor];
 }
 
-- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation
-                           overlayColor:(UIColor *)overlayColor {
+- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation overlayColor:(UIColor *)overlayColor {
   CGFloat alphaValue = 4.5 * log(elevation + 1) + 2;
   return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * 0.01]
              withBackgroundColor:self];

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -40,21 +40,16 @@
 }
 
 - (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation {
-  UIColor *overlayColor = UIColor.whiteColor;
-  return [self mdc_resolvedColorWithElevation:elevation overlayColor:overlayColor];
-}
-
-- (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation
-                               overlayColor:(UIColor *)overlayColor {
   if (CGColorGetPattern(self.CGColor)) {
-    [NSException
-         raise:NSGenericException
-        format:@"Pattern-Base Color %@ is not supported in %@", self, NSStringFromSelector(_cmd)];
+    [NSException raise:NSGenericException
+                format:@"Pattern-based colors are not supported by %@", NSStringFromSelector(_cmd)];
   }
+
+  UIColor *overlayColor = UIColor.whiteColor;
   elevation = MAX(elevation, 0);
   CGFloat alphaValue = 0;
   if (!MDCCGFloatEqual(elevation, 0)) {
-    alphaValue = 4.5 * log(elevation + 1) + (CGFloat)2;
+    alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
   }
   return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * (CGFloat)0.01]
              withBackgroundColor:self];

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -54,9 +54,9 @@
   elevation = MAX(elevation, 0);
   CGFloat alphaValue = 0;
   if (!MDCCGFloatEqual(elevation, 0)) {
-    alphaValue = 4.5 * log(elevation + 1) + 2;
+    alphaValue = 4.5 * log(elevation + 1) + (CGFloat)2;
   }
-  return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * 0.01]
+  return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * (CGFloat)0.01]
              withBackgroundColor:self];
 }
 

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -32,10 +32,10 @@
       return resolvedColor;
     }
   } else {
-    return [self mdc_resolvedColorWithElevation:elevation];
+    return self;
   }
 #else
-  return [self mdc_resolvedColorWithElevation:elevation];
+  return self;
 #endif
 }
 

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -14,35 +14,48 @@
 
 #import "UIColor+MaterialElevation.h"
 
+#import <CoreGraphics/CoreGraphics.h>
+
+#import "MaterialMath.h"
 #import "UIColor+MaterialBlending.h"
 
 @implementation UIColor (MaterialElevation)
 
-- (UIColor *)resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
-                                    elevation:(CGFloat)elevation {
+- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
+                                        elevation:(CGFloat)elevation {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     UIColor *resolvedColor = [self resolvedColorWithTraitCollection:traitCollection];
     if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-      return [resolvedColor resolvedColorWithElevation:elevation];
+      return [resolvedColor mdc_resolvedColorWithElevation:elevation];
     } else {
       return resolvedColor;
     }
   } else {
-    return [self resolvedColorWithElevation:elevation];
+    return [self mdc_resolvedColorWithElevation:elevation];
   }
 #else
-  return [self resolvedColorWithElevation:elevation];
+  return [self mdc_resolvedColorWithElevation:elevation];
 #endif
 }
 
-- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation {
+- (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation {
   UIColor *overlayColor = UIColor.whiteColor;
-  return [self resolvedColorWithElevation:elevation overlayColor:overlayColor];
+  return [self mdc_resolvedColorWithElevation:elevation overlayColor:overlayColor];
 }
 
-- (UIColor *)resolvedColorWithElevation:(CGFloat)elevation overlayColor:(UIColor *)overlayColor {
-  CGFloat alphaValue = 4.5 * log(elevation + 1) + 2;
+- (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation
+                               overlayColor:(UIColor *)overlayColor {
+  if (CGColorGetPattern(self.CGColor)) {
+    [NSException
+         raise:NSGenericException
+        format:@"Pattern-Base Color %@ is not supported in %@", self, NSStringFromSelector(_cmd)];
+  }
+  elevation = MAX(elevation, 0);
+  CGFloat alphaValue = 0;
+  if (!MDCCGFloatEqual(elevation, 0)) {
+    alphaValue = 4.5 * log(elevation + 1) + 2;
+  }
   return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * 0.01]
              withBackgroundColor:self];
 }

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -31,12 +31,11 @@
     } else {
       return resolvedColor;
     }
-  } else {
-    return self;
   }
-#else
-  return self;
 #endif
+  [NSException raise:NSGenericException
+              format:@"%@ is only supported on iOS 13 and above", NSStringFromSelector(_cmd)];
+  return nil;
 }
 
 - (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation {

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -54,6 +54,8 @@
     // AlphaValue = 4.5 * ln (elevationValue + 1) + 2
     alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
   }
+  // TODO (https://github.com/material-components/material-components-ios/issues/8096):
+  // Grayscale color should be returned if color space is UIExtendedGrayColorSpace.
   return [UIColor mdc_blendColor:[overlayColor colorWithAlphaComponent:alphaValue * (CGFloat)0.01]
              withBackgroundColor:self];
 }

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -55,7 +55,7 @@
     UITraitCollection *traitCollection =
         [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UIColor *resolvedColor = [dynamicColor resolvedColorWithTraitCollection:traitCollection
-                                                               andElevation:elevation];
+                                                                  elevation:elevation];
 
     // Then
     UIColor *expectedColor = [darkColor resolvedColorWithElevation:elevation];
@@ -76,7 +76,7 @@
     UITraitCollection *traitCollection =
         [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UIColor *resolvedColor = [staticColor resolvedColorWithTraitCollection:traitCollection
-                                                              andElevation:elevation];
+                                                                 elevation:elevation];
 
     // Then
     UIColor *expectedColor = [staticColor resolvedColorWithElevation:elevation];

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -213,6 +213,22 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 #endif
 }
 
+- (void)testResolvedColorWithElevationForStaticColorOnPreiOS13 {
+  // Given
+  CGFloat elevation = (CGFloat)10;
+  UIColor *staticColor = UIColor.blackColor;
+
+  // When
+  UITraitCollection *traitCollection = [[UITraitCollection alloc] init];
+  UIColor *resolvedColor = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection
+                                                                   elevation:elevation];
+
+  // Then
+  UIColor *expectedColor = staticColor;
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor
+                                          secondColor:expectedColor];
+}
+
 - (void)testResolvedColorWithElevationForPatternBasedColorThrowException {
   // Given
   CGFloat elevation = (CGFloat)10;

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -18,27 +18,169 @@
 #import "MaterialMath.h"
 #import "UIColor+MaterialDynamic.h"
 
+/** Returns a generated image of the given color and bounds. */
+static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
+  UIGraphicsBeginImageContext(bounds.size);
+  [color setFill];
+  UIRectFill(bounds);
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
+}
+
 @interface MaterialElevationColorTests : XCTestCase
+
+@property(nonatomic, readwrite) UIColor *rgbColor;
+@property(nonatomic, readwrite) UIColor *greyScaleColor;
+@property(nonatomic, readwrite) UIColor *p3DisplayColor;
+@property(nonatomic, readwrite) UIColor *patternColor;
 
 @end
 
 @implementation MaterialElevationColorTests
 
-- (void)testResolvedColorWithElevation {
+- (void)setUp {
+  [super setUp];
+
+  self.rgbColor = [UIColor colorWithRed:(CGFloat)0.9
+                                  green:(CGFloat)0.8
+                                   blue:(CGFloat)0.6
+                                  alpha:(CGFloat)0.6];
+  self.greyScaleColor = [UIColor colorWithRed:(CGFloat)0.9
+                                        green:(CGFloat)0.9
+                                         blue:(CGFloat)0.9
+                                        alpha:(CGFloat)0.6];
+  if (@available(iOS 10.0, *)) {
+    self.p3DisplayColor = [UIColor colorWithDisplayP3Red:0.8 green:0.7 blue:0.5 alpha:0.4];
+  } else {
+    self.p3DisplayColor = nil;
+  }
+}
+
+- (void)tearDown {
+  self.rgbColor = nil;
+  self.greyScaleColor = nil;
+  self.p3DisplayColor = nil;
+
+  [super tearDown];
+}
+
+- (void)testResolvedColorWithZeroElevation {
   // Given
-  CGFloat elevation = (CGFloat)10;
-  UIColor *color = UIColor.blackColor;
+  CGFloat elevation = (CGFloat)0;
 
   // When
-  UIColor *resolvedColor = [color resolvedColorWithElevation:elevation];
-  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.1279052872759267
-                                           green:(CGFloat)0.1279052872759267
-                                            blue:(CGFloat)0.1279052872759267
-                                           alpha:(CGFloat)1];
+  UIColor *resolvedRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedGreyScaleColor = [self.greyScaleColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedP3DisplayColor = [self.p3DisplayColor mdc_resolvedColorWithElevation:elevation];
 
   // Then
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
-                                                    secondColor:expectedColor]);
+  UIColor *expectedRGBColor = self.rgbColor;
+  UIColor *expectedGreyScaleColor = self.greyScaleColor;
+  UIColor *expectedP3Display = self.p3DisplayColor;
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                                    secondColor:expectedRGBColor],
+                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                                    secondColor:expectedGreyScaleColor],
+                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                                    secondColor:expectedP3Display],
+                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+}
+
+- (void)testResolvedColorWithLowElevation {
+  // Given
+  CGFloat elevation = (CGFloat)10;
+
+  // When
+  UIColor *resolvedRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedGreyScaleColor = [self.greyScaleColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedP3DisplayColor = [self.p3DisplayColor mdc_resolvedColorWithElevation:elevation];
+
+  // Then
+  UIColor *expectedRGBColor = [UIColor colorWithRed:(CGFloat)0.91964261807423053
+                                              green:(CGFloat)0.83928523614846129
+                                               blue:(CGFloat)0.67857047229692247
+                                              alpha:(CGFloat)0.65116211491037057];
+  ;
+  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.91964261807423053
+                                                    green:(CGFloat)0.91964261807423053
+                                                     blue:(CGFloat)0.91964261807423053
+                                                    alpha:(CGFloat)0.65116211491037057];
+  ;
+  UIColor *expectedP3Display = [UIColor colorWithRed:(CGFloat)0.86849367970437186
+                                               green:(CGFloat)0.77713910118968843
+                                                blue:(CGFloat)0.61272176809458923
+                                               alpha:(CGFloat)0.47674317236555602];
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                                    secondColor:expectedRGBColor],
+                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                                    secondColor:expectedGreyScaleColor],
+                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                                    secondColor:expectedP3Display],
+                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+}
+
+- (void)testResolvedColorWithHighElevation {
+  // Given
+  CGFloat elevation = (CGFloat)10000;
+
+  // When
+  UIColor *resolvedRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedGreyScaleColor = [self.greyScaleColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedP3DisplayColor = [self.p3DisplayColor mdc_resolvedColorWithElevation:elevation];
+
+  // Then
+  UIColor *expectedRGBColor = [UIColor colorWithRed:(CGFloat)0.95614843571155961
+                                              green:(CGFloat)0.91229687142311943
+                                               blue:(CGFloat)0.82459374284623876
+                                              alpha:(CGFloat)0.77378792660557727];
+  ;
+  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.95614843571155961
+                                                    green:(CGFloat)0.95614843571155961
+                                                     blue:(CGFloat)0.95614843571155961
+                                                    alpha:(CGFloat)0.77378792660557727];
+  ;
+  UIColor *expectedP3Display = [UIColor colorWithRed:(CGFloat)0.9384637763413608
+                                               green:(CGFloat)0.89571590108272103
+                                                blue:(CGFloat)0.81877950928077237
+                                               alpha:(CGFloat)0.66068188990836596];
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                                    secondColor:expectedRGBColor],
+                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                                    secondColor:expectedGreyScaleColor],
+                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                                    secondColor:expectedP3Display],
+                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+}
+
+- (void)testResolvedColorWithNegativeElevation {
+  // Given
+  CGFloat elevation = (CGFloat)-10;
+
+  // When
+  UIColor *resolvedRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedGreyScaleColor = [self.greyScaleColor mdc_resolvedColorWithElevation:elevation];
+  UIColor *resolvedP3DisplayColor = [self.p3DisplayColor mdc_resolvedColorWithElevation:elevation];
+
+  // Then
+  UIColor *expectedRGBColor = self.rgbColor;
+  UIColor *expectedGreyScaleColor = self.greyScaleColor;
+  UIColor *expectedP3Display = self.p3DisplayColor;
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                                    secondColor:expectedRGBColor],
+                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                                    secondColor:expectedGreyScaleColor],
+                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                                    secondColor:expectedP3Display],
+                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
 }
 
 - (void)testResolvedColorWithElevationForDynamicColorOniOS13AndAbove {
@@ -54,13 +196,14 @@
     // When
     UITraitCollection *traitCollection =
         [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
-    UIColor *resolvedColor = [dynamicColor resolvedColorWithTraitCollection:traitCollection
-                                                                  elevation:elevation];
+    UIColor *resolvedColor = [dynamicColor mdc_resolvedColorWithTraitCollection:traitCollection
+                                                                      elevation:elevation];
 
     // Then
-    UIColor *expectedColor = [darkColor resolvedColorWithElevation:elevation];
+    UIColor *expectedColor = [darkColor mdc_resolvedColorWithElevation:elevation];
     XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
-                                                      secondColor:expectedColor]);
+                                                      secondColor:expectedColor],
+                  @"(%@) is not equal to (%@)", resolvedColor, expectedColor);
   }
 #endif
 }
@@ -75,15 +218,28 @@
     // When
     UITraitCollection *traitCollection =
         [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
-    UIColor *resolvedColor = [staticColor resolvedColorWithTraitCollection:traitCollection
-                                                                 elevation:elevation];
+    UIColor *resolvedColor = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection
+                                                                     elevation:elevation];
 
     // Then
-    UIColor *expectedColor = [staticColor resolvedColorWithElevation:elevation];
+    UIColor *expectedColor = [staticColor mdc_resolvedColorWithElevation:elevation];
     XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
-                                                      secondColor:expectedColor]);
+                                                      secondColor:expectedColor],
+                  @"(%@) is not equal to (%@)", resolvedColor, expectedColor);
   }
 #endif
+}
+
+- (void)testResolvedColorWithElevationForPatternBasedColor {
+  // Given
+  UIImage *patternImage = fakeImageWithColorAndSize(UIColor.blueColor, CGRectMake(0, 0, 100, 100));
+  UIColor *patternColor = [UIColor colorWithPatternImage:patternImage];
+  CGFloat elevation = (CGFloat)10;
+
+  // When/Then
+  XCTAssertThrowsSpecificNamed(
+      [patternColor mdc_resolvedColorWithElevation:elevation], NSException, NSGenericException,
+      @"Expected exception when resolving a Pattern-Based color with elevation");
 }
 
 - (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -15,7 +15,6 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialElevation.h"
-#import "MaterialMath.h"
 #import "UIColor+MaterialDynamic.h"
 
 /** Returns a generated image of the given color and bounds. */
@@ -81,15 +80,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedRGBColor = self.rgbColor;
   UIColor *expectedGreyScaleColor = self.greyScaleColor;
   UIColor *expectedP3Display = self.p3DisplayColor;
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
-                                                    secondColor:expectedRGBColor],
-                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
-                                                    secondColor:expectedGreyScaleColor],
-                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
-                                                    secondColor:expectedP3Display],
-                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
 }
 
 - (void)testResolvedColorWithLowElevation {
@@ -116,15 +109,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                green:(CGFloat)0.77713910118968843
                                                 blue:(CGFloat)0.61272176809458923
                                                alpha:(CGFloat)0.47674317236555602];
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
-                                                    secondColor:expectedRGBColor],
-                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
-                                                    secondColor:expectedGreyScaleColor],
-                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
-                                                    secondColor:expectedP3Display],
-                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
 }
 
 - (void)testResolvedColorWithHighElevation {
@@ -151,15 +138,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                green:(CGFloat)0.89571590108272103
                                                 blue:(CGFloat)0.81877950928077237
                                                alpha:(CGFloat)0.66068188990836596];
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
-                                                    secondColor:expectedRGBColor],
-                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
-                                                    secondColor:expectedGreyScaleColor],
-                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
-                                                    secondColor:expectedP3Display],
-                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
 }
 
 - (void)testResolvedColorWithNegativeElevation {
@@ -175,15 +156,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedRGBColor = self.rgbColor;
   UIColor *expectedGreyScaleColor = self.greyScaleColor;
   UIColor *expectedP3Display = self.p3DisplayColor;
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedRGBColor
-                                                    secondColor:expectedRGBColor],
-                @"(%@) is not equal to (%@)", resolvedRGBColor, expectedRGBColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
-                                                    secondColor:expectedGreyScaleColor],
-                @"(%@) is not equal to (%@)", resolvedGreyScaleColor, expectedGreyScaleColor);
-  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
-                                                    secondColor:expectedP3Display],
-                @"(%@) is not equal to (%@)", resolvedP3DisplayColor, expectedP3Display);
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
 }
 
 - (void)testResolvedColorWithElevationForDynamicColorOniOS13AndAbove {
@@ -204,9 +179,7 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
     // Then
     UIColor *expectedColor = [darkColor mdc_resolvedColorWithElevation:elevation];
-    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
-                                                      secondColor:expectedColor],
-                  @"(%@) is not equal to (%@)", resolvedColor, expectedColor);
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor secondColor:expectedColor];
   }
 #endif
 }
@@ -226,9 +199,8 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
     // Then
     UIColor *expectedColor = [staticColor mdc_resolvedColorWithElevation:elevation];
-    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
-                                                      secondColor:expectedColor],
-                  @"(%@) is not equal to (%@)", resolvedColor, expectedColor);
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor
+                                            secondColor:expectedColor];
   }
 #endif
 }
@@ -243,15 +215,17 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
       @"Expected exception when resolving a Pattern-Based color with elevation");
 }
 
-- (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
-                                      secondColor:(UIColor *)secondColor {
+- (void)assertEqualColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
+                                          secondColor:(UIColor *)secondColor {
   CGFloat fRed = 0.0, fGreen = 0.0, fBlue = 0.0, fAlpha = 0.0;
   [firstColor getRed:&fRed green:&fGreen blue:&fBlue alpha:&fAlpha];
   CGFloat sRed = 0.0, sGreen = 0.0, sBlue = 0.0, sAlpha = 0.0;
   [secondColor getRed:&sRed green:&sGreen blue:&sBlue alpha:&sAlpha];
 
-  return (MDCCGFloatEqual(fRed, sRed) && MDCCGFloatEqual(fGreen, sGreen) &&
-          MDCCGFloatEqual(fBlue, sBlue) && MDCCGFloatEqual(fAlpha, sAlpha));
+  XCTAssertEqualWithAccuracy(fRed, sRed, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
+  XCTAssertEqualWithAccuracy(fGreen, sGreen, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
+  XCTAssertEqualWithAccuracy(fBlue, sBlue, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
+  XCTAssertEqualWithAccuracy(fAlpha, sAlpha, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
 }
 
 @end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -82,7 +82,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedP3Display = self.p3DisplayColor;
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  if (@available(iOS 10.0, *)) {
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  }
 }
 
 - (void)testResolvedColorWithLowElevation {
@@ -111,7 +113,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                alpha:(CGFloat)0.47674317236555602];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  if (@available(iOS 10.0, *)) {
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  }
 }
 
 - (void)testResolvedColorWithHighElevation {
@@ -140,7 +144,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                alpha:(CGFloat)0.66068188990836596];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  if (@available(iOS 10.0, *)) {
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  }
 }
 
 - (void)testResolvedColorWithNegativeElevation {
@@ -158,7 +164,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedP3Display = self.p3DisplayColor;
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
   [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  if (@available(iOS 10.0, *)) {
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+  }
 }
 
 - (void)testResolvedColorWithElevationForDynamicColorOniOS13AndAbove {

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -80,10 +80,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedRGBColor = self.rgbColor;
   UIColor *expectedGreyScaleColor = self.greyScaleColor;
   UIColor *expectedP3Display = self.p3DisplayColor;
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                          secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                          secondColor:expectedGreyScaleColor];
   if (@available(iOS 10.0, *)) {
-    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                            secondColor:expectedP3Display];
   }
 }
 
@@ -111,10 +114,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                green:(CGFloat)0.77713910118968843
                                                 blue:(CGFloat)0.61272176809458923
                                                alpha:(CGFloat)0.47674317236555602];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                          secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                          secondColor:expectedGreyScaleColor];
   if (@available(iOS 10.0, *)) {
-    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                            secondColor:expectedP3Display];
   }
 }
 
@@ -142,10 +148,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                green:(CGFloat)0.89571590108272103
                                                 blue:(CGFloat)0.81877950928077237
                                                alpha:(CGFloat)0.66068188990836596];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                          secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                          secondColor:expectedGreyScaleColor];
   if (@available(iOS 10.0, *)) {
-    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                            secondColor:expectedP3Display];
   }
 }
 
@@ -162,10 +171,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   UIColor *expectedRGBColor = self.rgbColor;
   UIColor *expectedGreyScaleColor = self.greyScaleColor;
   UIColor *expectedP3Display = self.p3DisplayColor;
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor secondColor:expectedRGBColor];
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor secondColor:expectedGreyScaleColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedRGBColor
+                                          secondColor:expectedRGBColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedGreyScaleColor
+                                          secondColor:expectedGreyScaleColor];
   if (@available(iOS 10.0, *)) {
-    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor secondColor:expectedP3Display];
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedP3DisplayColor
+                                            secondColor:expectedP3Display];
   }
 }
 
@@ -207,8 +219,7 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
     // Then
     UIColor *expectedColor = [staticColor mdc_resolvedColorWithElevation:elevation];
-    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor
-                                            secondColor:expectedColor];
+    [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor secondColor:expectedColor];
   }
 #endif
 }
@@ -225,8 +236,7 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
   // Then
   UIColor *expectedColor = staticColor;
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor
-                                          secondColor:expectedColor];
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor secondColor:expectedColor];
 }
 
 - (void)testResolvedColorWithElevationForPatternBasedColorThrowException {
@@ -246,10 +256,14 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
   CGFloat sRed = 0.0, sGreen = 0.0, sBlue = 0.0, sAlpha = 0.0;
   [secondColor getRed:&sRed green:&sGreen blue:&sBlue alpha:&sAlpha];
 
-  XCTAssertEqualWithAccuracy(fRed, sRed, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
-  XCTAssertEqualWithAccuracy(fGreen, sGreen, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
-  XCTAssertEqualWithAccuracy(fBlue, sBlue, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
-  XCTAssertEqualWithAccuracy(fAlpha, sAlpha, 0.001, @"(%@) is not equal to (%@)", firstColor, secondColor);
+  XCTAssertEqualWithAccuracy(fRed, sRed, 0.001, @"(%@) is not equal to (%@)", firstColor,
+                             secondColor);
+  XCTAssertEqualWithAccuracy(fGreen, sGreen, 0.001, @"(%@) is not equal to (%@)", firstColor,
+                             secondColor);
+  XCTAssertEqualWithAccuracy(fBlue, sBlue, 0.001, @"(%@) is not equal to (%@)", firstColor,
+                             secondColor);
+  XCTAssertEqualWithAccuracy(fAlpha, sAlpha, 0.001, @"(%@) is not equal to (%@)", firstColor,
+                             secondColor);
 }
 
 @end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -225,18 +225,21 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 }
 
 - (void)testResolvedColorWithElevationForStaticColorOnPreiOS13 {
-  // Given
-  CGFloat elevation = (CGFloat)10;
-  UIColor *staticColor = UIColor.blackColor;
+  if (@available(iOS 13.0, *)) {
+  } else {
+    // Given
+    CGFloat elevation = (CGFloat)10;
+    UIColor *staticColor = UIColor.blackColor;
+    UITraitCollection *traitCollection = [[UITraitCollection alloc] init];
 
-  // When
-  UITraitCollection *traitCollection = [[UITraitCollection alloc] init];
-  UIColor *resolvedColor = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection
-                                                                   elevation:elevation];
-
-  // Then
-  UIColor *expectedColor = staticColor;
-  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedColor secondColor:expectedColor];
+    // When/Then
+    XCTAssertThrowsSpecificNamed(
+        [staticColor performSelector:@selector(mdc_resolvedColorWithTraitCollection:elevation:)
+                          withObject:traitCollection
+                          withObject:@(elevation)],
+        NSException, NSGenericException, @"Expected exception when %@ is called on pre iOS13",
+        NSStringFromSelector(@selector(mdc_resolvedColorWithTraitCollection:elevation:)));
+  }
 }
 
 - (void)testResolvedColorWithElevationForPatternBasedColorThrowException {

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -46,21 +46,21 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                   green:(CGFloat)0.8
                                    blue:(CGFloat)0.6
                                   alpha:(CGFloat)0.6];
-  self.greyScaleColor = [UIColor colorWithRed:(CGFloat)0.9
-                                        green:(CGFloat)0.9
-                                         blue:(CGFloat)0.9
-                                        alpha:(CGFloat)0.6];
+  self.greyScaleColor = [UIColor colorWithWhite:0.8 alpha:0.6];
   if (@available(iOS 10.0, *)) {
     self.p3DisplayColor = [UIColor colorWithDisplayP3Red:0.8 green:0.7 blue:0.5 alpha:0.4];
   } else {
     self.p3DisplayColor = nil;
   }
+  UIImage *patternImage = fakeImageWithColorAndSize(UIColor.blueColor, CGRectMake(0, 0, 100, 100));
+  self.patternColor = [UIColor colorWithPatternImage:patternImage];
 }
 
 - (void)tearDown {
   self.rgbColor = nil;
   self.greyScaleColor = nil;
   self.p3DisplayColor = nil;
+  self.patternColor = nil;
 
   [super tearDown];
 }
@@ -104,9 +104,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                blue:(CGFloat)0.67857047229692247
                                               alpha:(CGFloat)0.65116211491037057];
   ;
-  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.91964261807423053
-                                                    green:(CGFloat)0.91964261807423053
-                                                     blue:(CGFloat)0.91964261807423053
+  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.83928523614846129
+                                                    green:(CGFloat)0.83928523614846129
+                                                     blue:(CGFloat)0.83928523614846129
                                                     alpha:(CGFloat)0.65116211491037057];
   ;
   UIColor *expectedP3Display = [UIColor colorWithRed:(CGFloat)0.86849367970437186
@@ -139,9 +139,9 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                blue:(CGFloat)0.82459374284623876
                                               alpha:(CGFloat)0.77378792660557727];
   ;
-  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.95614843571155961
-                                                    green:(CGFloat)0.95614843571155961
-                                                     blue:(CGFloat)0.95614843571155961
+  UIColor *expectedGreyScaleColor = [UIColor colorWithRed:(CGFloat)0.91229687142311943
+                                                    green:(CGFloat)0.91229687142311943
+                                                     blue:(CGFloat)0.91229687142311943
                                                     alpha:(CGFloat)0.77378792660557727];
   ;
   UIColor *expectedP3Display = [UIColor colorWithRed:(CGFloat)0.9384637763413608
@@ -230,15 +230,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 #endif
 }
 
-- (void)testResolvedColorWithElevationForPatternBasedColor {
+- (void)testResolvedColorWithElevationForPatternBasedColorThrowException {
   // Given
-  UIImage *patternImage = fakeImageWithColorAndSize(UIColor.blueColor, CGRectMake(0, 0, 100, 100));
-  UIColor *patternColor = [UIColor colorWithPatternImage:patternImage];
   CGFloat elevation = (CGFloat)10;
 
   // When/Then
   XCTAssertThrowsSpecificNamed(
-      [patternColor mdc_resolvedColorWithElevation:elevation], NSException, NSGenericException,
+      [self.patternColor mdc_resolvedColorWithElevation:elevation], NSException, NSGenericException,
       @"Expected exception when resolving a Pattern-Based color with elevation");
 }
 

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -52,7 +52,8 @@
                                                              defaultColor:lightColor];
 
     // When
-    UITraitCollection *traitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UITraitCollection *traitCollection =
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UIColor *resolvedColor = [dynamicColor resolvedColorWithTraitCollection:traitCollection
                                                                andElevation:elevation];
 
@@ -72,9 +73,10 @@
     UIColor *staticColor = UIColor.blackColor;
 
     // When
-    UITraitCollection *traitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UITraitCollection *traitCollection =
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UIColor *resolvedColor = [staticColor resolvedColorWithTraitCollection:traitCollection
-                                                               andElevation:elevation];
+                                                              andElevation:elevation];
 
     // Then
     UIColor *expectedColor = [staticColor resolvedColorWithElevation:elevation];

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -1,0 +1,98 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialElevation.h"
+#import "MaterialMath.h"
+#import "UIColor+MaterialDynamic.h"
+
+@interface MaterialElevationColorTests : XCTestCase
+
+@end
+
+@implementation MaterialElevationColorTests
+
+- (void)testResolvedColorWithElevation {
+  // Given
+  CGFloat elevation = (CGFloat)10;
+  UIColor *color = UIColor.blackColor;
+
+  // When
+  UIColor *resolvedColor = [color resolvedColorWithElevation:elevation];
+  UIColor *expectedColor = [UIColor colorWithRed:(CGFloat)0.1279052872759267
+                                           green:(CGFloat)0.1279052872759267
+                                            blue:(CGFloat)0.1279052872759267
+                                           alpha:(CGFloat)1];
+
+  // Then
+  XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
+                                                    secondColor:expectedColor]);
+}
+
+- (void)testResolvedColorWithElevationForDynamicColorOniOS13AndAbove {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    // Given
+    CGFloat elevation = (CGFloat)10;
+    UIColor *darkColor = UIColor.blackColor;
+    UIColor *lightColor = UIColor.whiteColor;
+    UIColor *dynamicColor = [UIColor colorWithUserInterfaceStyleDarkColor:darkColor
+                                                             defaultColor:lightColor];
+
+    // When
+    UITraitCollection *traitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UIColor *resolvedColor = [dynamicColor resolvedColorWithTraitCollection:traitCollection
+                                                               andElevation:elevation];
+
+    // Then
+    UIColor *expectedColor = [darkColor resolvedColorWithElevation:elevation];
+    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
+                                                      secondColor:expectedColor]);
+  }
+#endif
+}
+
+- (void)testResolvedColorWithElevationForStaticColorOniOS13AndAbove {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    // Given
+    CGFloat elevation = (CGFloat)10;
+    UIColor *staticColor = UIColor.blackColor;
+
+    // When
+    UITraitCollection *traitCollection = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UIColor *resolvedColor = [staticColor resolvedColorWithTraitCollection:traitCollection
+                                                               andElevation:elevation];
+
+    // Then
+    UIColor *expectedColor = [staticColor resolvedColorWithElevation:elevation];
+    XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:resolvedColor
+                                                      secondColor:expectedColor]);
+  }
+#endif
+}
+
+- (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
+                                      secondColor:(UIColor *)secondColor {
+  CGFloat fRed = 0.0, fGreen = 0.0, fBlue = 0.0, fAlpha = 0.0;
+  [firstColor getRed:&fRed green:&fGreen blue:&fBlue alpha:&fAlpha];
+  CGFloat sRed = 0.0, sGreen = 0.0, sBlue = 0.0, sAlpha = 0.0;
+  [secondColor getRed:&sRed green:&sGreen blue:&sBlue alpha:&sAlpha];
+
+  return (MDCCGFloatEqual(fRed, sRed) && MDCCGFloatEqual(fGreen, sGreen) &&
+          MDCCGFloatEqual(fBlue, sBlue) && MDCCGFloatEqual(fAlpha, sAlpha));
+}
+
+@end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -46,9 +46,12 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                   green:(CGFloat)0.8
                                    blue:(CGFloat)0.6
                                   alpha:(CGFloat)0.6];
-  self.greyScaleColor = [UIColor colorWithWhite:0.8 alpha:0.6];
+  self.greyScaleColor = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.6];
   if (@available(iOS 10.0, *)) {
-    self.p3DisplayColor = [UIColor colorWithDisplayP3Red:0.8 green:0.7 blue:0.5 alpha:0.4];
+    self.p3DisplayColor = [UIColor colorWithDisplayP3Red:(CGFloat)0.8
+                                                   green:(CGFloat)0.7
+                                                    blue:(CGFloat)0.5
+                                                   alpha:(CGFloat)0.4];
   } else {
     self.p3DisplayColor = nil;
   }


### PR DESCRIPTION
This PR provides two methods to allow users resolving color with elevation.

closes https://github.com/material-components/material-components-ios/issues/8086.

