### PR TITLE
[Color] Create umbrella header.

### DIFF
--- a/components/Buttons/tests/snapshot/ButtonCustomTraitCollectionSnapshotTests.m
+++ b/components/Buttons/tests/snapshot/ButtonCustomTraitCollectionSnapshotTests.m
@@ -17,8 +17,8 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
 
-#import "../../../private/Color/src/UIColor+MaterialDynamic.h"
 #import "MaterialButtons.h"
+#import "MaterialColor.h"
 #import "MaterialTypography.h"
 
 /** A @c MDCButton test fake to override the @c traitCollection to test for dynamic type. */

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -174,6 +174,7 @@ mdc_snapshot_objc_library(
         ":Dialogs",
         ":Theming",
         ":private",
+        "//components/private/Color",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
@@ -17,8 +17,8 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
 
-#import "../../../private/Color/src/UIColor+MaterialDynamic.h"
 #import "../../src/private/MDCDialogShadowedView.h"
+#import "MaterialColor.h"
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
 

--- a/components/Ink/tests/snapshot/MDCInkViewSnapshotTests.m
+++ b/components/Ink/tests/snapshot/MDCInkViewSnapshotTests.m
@@ -14,8 +14,8 @@
 
 #import "MaterialSnapshot.h"
 
+#import "MaterialColor.h"
 #import "MaterialInk.h"
-#import "UIColor+MaterialDynamic.h"
 
 /**
  Creates a fake MDCInkView that has its traitCollection overridden.

--- a/components/Ripple/tests/snapshot/MDCRippleViewSnapshotTests.m
+++ b/components/Ripple/tests/snapshot/MDCRippleViewSnapshotTests.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialColor.h"
 #import "MaterialRipple.h"
 #import "MaterialSnapshot.h"
-#import "UIColor+MaterialDynamic.h"
 
 /**
  Creates a fake MDCRippleView that has its traitCollection overridden.

--- a/components/private/Color/src/MaterialColor.h
+++ b/components/private/Color/src/MaterialColor.h
@@ -1,0 +1,16 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "UIColor+MaterialBlending.h"
+#import "UIColor+MaterialDynamic.h"

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -14,7 +14,7 @@
 
 #import "MDCSemanticColorScheme.h"
 
-#import "UIColor+MaterialDynamic.h"
+#import "MaterialColor.h"
 
 static UIColor *ColorFromRGB(uint32_t colorValue) {
   return [UIColor colorWithRed:(CGFloat)(((colorValue >> 16) & 0xFF) / 255.0)


### PR DESCRIPTION
All components should have a top-level umbrella header for their includes.
This allows easier refactoring of classes and files within the component.
Creating an umbrella for Color and using it outside the component.

Part of #8086