### PR TITLE
[BottomAppBar] Add conformance to MDCElevatable, MDCElevationOverriding

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -138,7 +138,7 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
      UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- The elevation of the bottom app bar. Defaults to @c MDCShadowElevationBottomNavigationBar.
+ The elevation of the bottom app bar. Defaults to @c MDCShadowElevationBottomAppBar.
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 
@@ -153,6 +153,6 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  @param object This bottom app bar.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCBottomAppBarView *_Nonnull object, CGFloat elevation);
+    (MDCBottomAppBarView *_Nonnull bottomAppBar, CGFloat elevation);
 
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  The bottom app bar is a bar docked at the bottom of the screen. A floating action button is
  provided for a primary action.
  */
-@interface MDCBottomAppBarView : UIView
+@interface MDCBottomAppBarView : UIView <MDCElevatable, MDCElevationOverriding>
 
 /**
  Is the floating button on the bottom bar hidden.
@@ -136,5 +136,23 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCBottomAppBarView *_Nonnull bottomAppBar,
      UITraitCollection *_Nullable previousTraitCollection);
+
+/**
+ The elevation of the bottom app bar. Defaults to @c MDCShadowElevationBottomNavigationBar.
+ */
+@property(nonatomic, assign) MDCShadowElevation elevation;
+
+/**
+ This block is called after a change of the bottom app bar's elevation or one of its view
+ hierarchy ancestors.
+
+ Use this block to respond to elevation changes in the view or its ancestor views.
+
+ @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
+ views.
+ @param object This bottom app bar.
+ */
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCBottomAppBarView *_Nonnull object, CGFloat elevation);
 
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -18,6 +18,7 @@
 
 #import <MDFInternationalization/MDFInternationalization.h>
 
+#import "MaterialMath.h"
 #import "MaterialNavigationBar.h"
 #import "private/MDCBottomAppBarAttributes.h"
 #import "private/MDCBottomAppBarLayer.h"
@@ -88,7 +89,7 @@ static const int kMDCButtonAnimationDuration = 200;
 
   self.barTintColor = UIColor.whiteColor;
   self.shadowColor = UIColor.blackColor;
-  self.elevation = MDCShadowElevationBottomNavigationBar;
+  _elevation = MDCShadowElevationBottomAppBar;
   _mdc_overrideBaseElevation = -1;
 }
 
@@ -307,7 +308,7 @@ static const int kMDCButtonAnimationDuration = 200;
 #pragma mark - Setters
 
 - (void)setElevation:(MDCShadowElevation)elevation {
-  if (elevation == _elevation) {
+  if (MDCCGFloatEqual(elevation, _elevation)) {
     return;
   }
   _elevation = elevation;

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -55,6 +55,8 @@ static const int kMDCButtonAnimationDuration = 200;
 
 @implementation MDCBottomAppBarView
 
+@synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
@@ -86,6 +88,8 @@ static const int kMDCButtonAnimationDuration = 200;
 
   self.barTintColor = UIColor.whiteColor;
   self.shadowColor = UIColor.blackColor;
+  self.elevation = MDCShadowElevationBottomNavigationBar;
+  _mdc_overrideBaseElevation = -1;
 }
 
 - (void)addFloatingButton {
@@ -302,6 +306,14 @@ static const int kMDCButtonAnimationDuration = 200;
 
 #pragma mark - Setters
 
+- (void)setElevation:(MDCShadowElevation)elevation {
+  if (elevation == _elevation) {
+    return;
+  }
+  _elevation = elevation;
+  [self mdc_elevationDidChange];
+}
+
 - (void)setFloatingButton:(MDCFloatingButton *)floatingButton {
   if (_floatingButton == floatingButton) {
     return;
@@ -431,6 +443,12 @@ static const int kMDCButtonAnimationDuration = 200;
   if (self.traitCollectionDidChangeBlock) {
     self.traitCollectionDidChangeBlock(self, previousTraitCollection);
   }
+}
+
+#pragma mark - MDCElevation
+
+- (CGFloat)mdc_currentElevation {
+  return self.elevation;
 }
 
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -202,4 +202,39 @@
   XCTAssertEqual(passedBottomAppBar, bottomAppBar);
 }
 
+- (void)testElevationDidChangeBlockCalledWhenElevationChangesValue {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+  const CGFloat finalElevation = 6;
+  bottomAppBar.elevation = finalElevation - 1;
+  __block CGFloat newElevation = -1;
+  bottomAppBar.mdc_elevationDidChangeBlock =
+      ^(MDCBottomAppBarView *blockAppBar, CGFloat elevation) {
+        newElevation = elevation;
+      };
+
+  // When
+  bottomAppBar.elevation = bottomAppBar.elevation + 1;
+
+  // Then
+  XCTAssertEqualWithAccuracy(newElevation, finalElevation, 0.001);
+}
+
+- (void)testElevationDidChangeBlockNotCalledWhenElevationIsSetWithoutChangingValue {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+  bottomAppBar.elevation = 5;
+  __block BOOL blockCalled = NO;
+  bottomAppBar.mdc_elevationDidChangeBlock =
+      ^(MDCBottomAppBarView *blockAppBar, CGFloat elevation) {
+        blockCalled = YES;
+      };
+
+  // When
+  bottomAppBar.elevation = bottomAppBar.elevation;
+
+  // Then
+  XCTAssertFalse(blockCalled);
+}
+
 @end

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -237,4 +237,12 @@
   XCTAssertFalse(blockCalled);
 }
 
+- (void)testDefaultValueForOverrideBaseElevationIsNegative {
+  // Given
+  MDCBottomAppBarView *bottomAppBar = [[MDCBottomAppBarView alloc] init];
+
+  // Then
+  XCTAssertLessThan(bottomAppBar.mdc_overrideBaseElevation, 0);
+}
+
 @end

--- a/components/ShadowElevations/src/MDCShadowElevations.h
+++ b/components/ShadowElevations/src/MDCShadowElevations.h
@@ -34,6 +34,9 @@ typedef CGFloat MDCShadowElevation MDC_SHADOW_ELEVATION_TYPED_EXTENSIBLE_ENUM;
 static const MDCShadowElevation MDCShadowElevationAppBar = (CGFloat)4.0;
 
 /** The shadow elevation of the Bottom App Bar. */
+static const MDCShadowElevation MDCShadowElevationBottomAppBar = (CGFloat)8.0;
+
+/** The shadow elevation of the Bottom App Bar. */
 static const MDCShadowElevation MDCShadowElevationBottomNavigationBar = (CGFloat)8.0;
 
 /** The shadow elevation of a card in its picked up state. */


### PR DESCRIPTION
Adds Bottom App Bar conformance to `MDCElevatable` `MDCElevationOverriding`. Note that the bottom app bar view's shadow is not using `MDCShapedShadowLayer`. I explored this in #8092, but the work required to adapt `MDCBottomAppBarLayer` seemed out-of-scope.

Closes #8027 