### PR TITLE
 [FlexibleHeader] Conform to MDCElevatable, MDCElevationOverriding

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1068,6 +1068,9 @@ Pod::Spec.new do |mdc|
     ]
 
     component.dependency 'MDFTextAccessibility'
+    component.dependency "MaterialComponents/Elevation"
+    component.dependency "MaterialComponents/ShadowElevations"
+    component.dependency "MaterialComponents/ShadowLayer"
     component.dependency "MaterialComponents/private/Application"
     component.dependency "MaterialComponents/private/Math"
     component.dependency "MaterialComponents/private/UIMetrics"

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -34,6 +34,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/Elevation",
+        "//components/ShadowElevations",
         "//components/private/Application",
         "//components/private/Math",
         "//components/private/UIMetrics",

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -33,6 +33,7 @@ mdc_public_objc_library(
         "UIKit",
     ],
     deps = [
+        "//components/Elevation",
         "//components/private/Application",
         "//components/private/Math",
         "//components/private/UIMetrics",

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -14,8 +14,11 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialElevation.h"
+#import "MaterialShadowElevations.h"
+
 typedef void (^MDCFlexibleHeaderChangeContentInsetsBlock)(void);
-typedef void (^MDCFlexibleHeaderShadowIntensityChangeBlock)(CALayer *_Nonnull shadowLayer,
+typedef void (^MDCFlexibleHeaderShadowIntensityChangeBlock)(__kindof CALayer *_Nonnull shadowLayer,
                                                             CGFloat intensity);
 
 /** Mutually exclusive phases that the flexible header view can be in. */
@@ -55,14 +58,14 @@ typedef NS_ENUM(NSInteger, MDCFlexibleHeaderScrollPhase) {
  events are listed in the UIScrollViewDelegate events section.
  */
 IB_DESIGNABLE
-@interface MDCFlexibleHeaderView : UIView
+@interface MDCFlexibleHeaderView : UIView <MDCElevatable, MDCElevationOverriding>
 
 #pragma mark Custom shadow
 
 /**
  Custom shadow shown under flexible header content.
  */
-@property(nonatomic, strong, nullable) CALayer *shadowLayer;
+@property(nonatomic, strong, nullable) __kindof CALayer *shadowLayer;
 
 /** The shadow color of the @c shadowLayer. Defaults to black. */
 @property(nonatomic, copy, nonnull) UIColor *shadowColor;
@@ -70,7 +73,7 @@ IB_DESIGNABLE
 /**
  Sets a custom shadow layer and a block that should be executed when shadow intensity changes.
  */
-- (void)setShadowLayer:(nonnull CALayer *)shadowLayer
+- (void)setShadowLayer:(nonnull __kindof CALayer *)shadowLayer
     intensityDidChangeBlock:(nonnull MDCFlexibleHeaderShadowIntensityChangeBlock)block;
 
 #pragma mark UIScrollViewDelegate events
@@ -385,6 +388,24 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCFlexibleHeaderView *_Nonnull flexibleHeaderView,
      UITraitCollection *_Nullable previousTraitCollection);
+
+/**
+ The elevation of the header. Defaults to @c MDCShadowElevationAppBar .
+ */
+@property(nonatomic, assign) MDCShadowElevation elevation;
+
+/**
+ This block is called after a change of the flexible header view's elevation or one of its view
+ hierarchy ancestors.
+
+ Use this block to respond to elevation changes in the view or its ancestor views.
+
+ @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
+ views.
+ @param object This flexible header view
+ */
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
+    (MDCFlexibleHeaderView *_Nonnull flexibleHeaderView, CGFloat elevation);
 
 @end
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -390,7 +390,7 @@ IB_DESIGNABLE
      UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- The elevation of the header. Defaults to @c MDCShadowElevationAppBar .
+ The elevation of the header.
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -17,6 +17,7 @@
 #import "MDCFlexibleHeaderView+ShiftBehavior.h"
 #import "MaterialApplication.h"
 #import "MaterialMath.h"
+#import "MaterialShadowElevations.h"
 #import "MaterialUIMetrics.h"
 #import "private/MDCFlexibleHeaderMinMaxHeight.h"
 #import "private/MDCFlexibleHeaderTopSafeArea.h"
@@ -208,6 +209,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 @dynamic minMaxHeightIncludesSafeArea;
 
 // MDCFlexibleHeader properties
+@synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
 @synthesize trackingScrollViewIsBeingScrubbed = _trackingScrollViewIsBeingScrubbed;
 @synthesize scrollPhase = _scrollPhase;
 @synthesize scrollPhaseValue = _scrollPhaseValue;
@@ -324,6 +326,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
                                            selector:@selector(fhv_updateLayout)
                                                name:voiceOverNotification
                                              object:nil];
+
+  _mdc_overrideBaseElevation = -1;
 }
 
 - (void)setVisibleShadowOpacity:(float)visibleShadowOpacity {
@@ -1888,6 +1892,21 @@ static BOOL isRunningiOS10_3OrAbove() {
   // Translucent content means that the status bar shifter should not use snapshotting. Otherwise,
   // stale visual content under the status bar region may be snapshotted.
   _statusBarShifter.snapshottingEnabled = !contentIsTranslucent;
+}
+
+#pragma mark - MDCElevation
+
+- (void)setElevation:(MDCShadowElevation)elevation {
+  if (MDCCGFloatEqual(elevation, _elevation)) {
+    return;
+  }
+
+  _elevation = elevation;
+  [self mdc_elevationDidChange];
+}
+
+- (CGFloat)mdc_currentElevation {
+  return self.elevation;
 }
 
 @end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderElevationTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderElevationTests.m
@@ -1,0 +1,75 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "MaterialFlexibleHeader.h"
+
+@interface FlexibleHeaderElevationTests : XCTestCase
+@end
+
+@implementation FlexibleHeaderElevationTests {
+  MDCFlexibleHeaderView *_flexibleHeaderView;
+}
+
+- (void)setUp {
+  [super setUp];
+
+  _flexibleHeaderView = [[MDCFlexibleHeaderView alloc] init];
+}
+
+- (void)tearDown {
+  _flexibleHeaderView = nil;
+
+  [super tearDown];
+}
+
+- (void)testElevationDidChangeBlockCalledWhenElevationChangesValue {
+  // Given
+  const CGFloat finalElevation = 6;
+  _flexibleHeaderView.elevation = finalElevation - 1;
+  __block CGFloat newElevation = -1;
+  _flexibleHeaderView.mdc_elevationDidChangeBlock =
+      ^(MDCFlexibleHeaderView *blockHeaderView, CGFloat elevation) {
+        newElevation = elevation;
+      };
+
+  // When
+  _flexibleHeaderView.elevation = _flexibleHeaderView.elevation + 1;
+
+  // Then
+  XCTAssertEqualWithAccuracy(newElevation, finalElevation, 0.001);
+}
+
+- (void)testElevationDidChangeBlockNotCalledWhenElevationIsSetWithoutChangingValue {
+  // Given
+  _flexibleHeaderView.elevation = 5;
+  __block BOOL blockCalled = NO;
+  _flexibleHeaderView.mdc_elevationDidChangeBlock =
+      ^(MDCFlexibleHeaderView *blockHeaderView, CGFloat elevation) {
+        blockCalled = YES;
+      };
+
+  // When
+  _flexibleHeaderView.elevation = _flexibleHeaderView.elevation;
+
+  // Then
+  XCTAssertFalse(blockCalled);
+}
+
+- (void)testDefaultValueForOverrideBaseElevationIsNegative {
+  // Then
+  XCTAssertLessThan(_flexibleHeaderView.mdc_overrideBaseElevation, 0);
+}
+
+@end


### PR DESCRIPTION
Add elevation property and elevationDidChange block to `MDCFlexibleHeaderView`. Elevation will be set in an upcoming PR by `MDCAppBarViewController`. 

Closes #8018 