### PR TITLE
[AppBar] Set headerView elevation when shadow intensity changes

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -56,9 +56,11 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 - (void)MDCAppBarViewController_commonInit {
   // Shadow layer
+  __weak MDCAppBarViewController *weakSelf = self;
   MDCFlexibleHeaderShadowIntensityChangeBlock intensityBlock =
       ^(CALayer *_Nonnull shadowLayer, CGFloat intensity) {
         CGFloat elevation = MDCShadowElevationAppBar * intensity;
+        weakSelf.headerView.elevation = elevation;
         [(MDCShadowLayer *)shadowLayer setElevation:elevation];
       };
   [self.headerView setShadowLayer:[MDCShadowLayer layer] intensityDidChangeBlock:intensityBlock];

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -16,10 +16,6 @@
 
 #import "MDCAppBarViewController.h"
 
-@interface MDCFlexibleHeaderView ()
-- (void)fhv_accumulatorDidChange;
-@end
-
 @interface MDCAppBarViewControllerTests : XCTestCase
 
 @end
@@ -86,9 +82,7 @@
       };
 
   // When
-  // fhv_accumulatorDidChange is an internal method in MDCFlexibleHeaderView that triggers a call
-  // to its shadowIntensityDidChange block
-  [appBarController.headerView fhv_accumulatorDidChange];
+  [appBarController.headerView setVisibleShadowOpacity:1];
 
   // Then
   [self waitForExpectations:@[ expectation ] timeout:1];

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -16,6 +16,10 @@
 
 #import "MDCAppBarViewController.h"
 
+@interface MDCFlexibleHeaderView ()
+- (void)fhv_accumulatorDidChange;
+@end
+
 @interface MDCAppBarViewControllerTests : XCTestCase
 
 @end
@@ -63,6 +67,32 @@
   [self waitForExpectations:@[ expectation ] timeout:1];
   XCTAssertEqual(passedTraitCollection, testCollection);
   XCTAssertEqual(passedAppBarViewController, appBarController);
+}
+
+- (void)testHeaderViewElevationSetByShadowIntensityChange {
+  // Given
+  MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
+  UIScrollView *trackingScrollView = [[UIScrollView alloc] init];
+  appBarController.headerView.trackingScrollView = trackingScrollView;
+  appBarController.headerView.elevation = 0;
+  __block BOOL blockCalled = NO;
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Invoked mdc_elevationDidChangeBlock"];
+  appBarController.headerView.mdc_elevationDidChangeBlock =
+      ^(MDCFlexibleHeaderView *headerView, CGFloat elevation) {
+        blockCalled = YES;
+        [expectation fulfill];
+      };
+
+  // When
+  // fhv_accumulatorDidChange is an internal method in MDCFlexibleHeaderView that triggers a call
+  // to its shadowIntensityDidChange block
+  [appBarController.headerView fhv_accumulatorDidChange];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertTrue(blockCalled);
 }
 
 @end


### PR DESCRIPTION
Sets AppBar's headerView elevation to the elevation value computed in the header view's `intensityDidChangeBlock`.

Closes #8029 