### PR TITLE
[*] Correct `elevationDidChangeBlock` type.

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -142,17 +142,4 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 
-/**
- This block is called after a change of the bottom app bar's elevation or one of its view
- hierarchy ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This bottom app bar.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull bottomAppBar, CGFloat elevation);
-
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.h
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.h
@@ -153,6 +153,6 @@ typedef NS_ENUM(NSInteger, MDCBottomAppBarFloatingButtonPosition) {
  @param object This bottom app bar.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCBottomAppBarView *_Nonnull bottomAppBar, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull bottomAppBar, CGFloat elevation);
 
 @end

--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -57,6 +57,7 @@ static const int kMDCButtonAnimationDuration = 200;
 @implementation MDCBottomAppBarView
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -221,7 +221,7 @@ traitCollectionDidChange:. The block is called after the call to the superclass.
  @param object This bottom navigation bar.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCBottomNavigationBar *_Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 
 /**
  Returns the navigation bar subview associated with the specific item.

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.h
@@ -211,19 +211,6 @@ traitCollectionDidChange:. The block is called after the call to the superclass.
      UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- This block is called after a change of the bottom navigation bar's elevation or one of its view
- hierarchy ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This bottom navigation bar.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
-
-/**
  Returns the navigation bar subview associated with the specific item.
 
  @param item A UITabBarItem

--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -67,6 +67,7 @@ static NSString *const kOfAnnouncement = @"of";
 @implementation MDCBottomNavigationBar
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -181,7 +181,7 @@
  @param object This button.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCButton *_Nonnull button, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull button, CGFloat elevation);
 
 /**
  A color used as the button's @c backgroundColor for @c state.

--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -171,19 +171,6 @@
     (UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- This block is called after a change of the button's elevation or one of its view hierarchy
- ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This button.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull button, CGFloat elevation);
-
-/**
  A color used as the button's @c backgroundColor for @c state.
 
  @param state The state.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -102,6 +102,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 @implementation MDCButton
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 @dynamic layer;
 
 + (Class)layerClass {

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -163,14 +163,4 @@
  */
 @property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator;
 
-/**
- This block is called after a change of the card's elevation or one of its view
- hierarchy ancestors.
- Use this block to respond to elevation changes in the view or its ancestor views.
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This card.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 @end

--- a/components/Cards/src/MDCCard.h
+++ b/components/Cards/src/MDCCard.h
@@ -172,5 +172,5 @@
  @param object This card.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCCard *_Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 @end

--- a/components/Cards/src/MDCCard.m
+++ b/components/Cards/src/MDCCard.m
@@ -37,6 +37,7 @@ static const BOOL MDCCardIsInteractableDefault = YES;
 
 @dynamic layer;
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 + (Class)layerClass {
   return [MDCShapedShadowLayer class];

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -337,5 +337,5 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
  @param object This card.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCCardCollectionCell *_Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 @end

--- a/components/Cards/src/MDCCardCollectionCell.h
+++ b/components/Cards/src/MDCCardCollectionCell.h
@@ -328,14 +328,4 @@ typedef NS_ENUM(NSInteger, MDCCardCellVerticalImageAlignment) {
     (MDCCardCollectionCell *_Nonnull collectionCell,
      UITraitCollection *_Nullable previousTraitCollection);
 
-/**
- This block is called after a change of the card's elevation or one of its view
- hierarchy ancestors.
- Use this block to respond to elevation changes in the view or its ancestor views.
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This card.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 @end

--- a/components/Cards/src/MDCCardCollectionCell.m
+++ b/components/Cards/src/MDCCardCollectionCell.m
@@ -45,6 +45,7 @@ static const BOOL MDCCardCellIsInteractableDefault = YES;
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 @synthesize state = _state;
 @dynamic layer;
 

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -213,7 +213,7 @@
  @param object This chip view.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCChipView *_Nonnull chip, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull chip, CGFloat elevation);
 
 /*
  A color used as the chip's @c backgroundColor for @c state.

--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -202,19 +202,6 @@
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCChipView *_Nonnull chip, UITraitCollection *_Nullable previousTraitCollection);
 
-/**
- This block is called after a change of the chip view's elevation or one of its view
- hierarchy ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This chip view.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull chip, CGFloat elevation);
-
 /*
  A color used as the chip's @c backgroundColor for @c state.
 

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -126,6 +126,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 @dynamic layer;
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -159,7 +159,7 @@
  @param absoluteElevation The @c mdc_absoluteElevation this alert controller.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCAlertController *_Nonnull alertController, CGFloat absoluteElevation);
+    (id<MDCElevatable> _Nonnull alertController, CGFloat absoluteElevation);
 
 /**
  Affects the fallback behavior for when a scaled font is not provided.

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -150,18 +150,6 @@
      UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- This block is called after a change of the alert controller's elevation or one of its view
- controller ancestors.
-
- Use this block to respond to elevation changes in the alert controller or its ancestors.
-
- @param alertController This alert controller.
- @param absoluteElevation The @c mdc_absoluteElevation this alert controller.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull alertController, CGFloat absoluteElevation);
-
-/**
  Affects the fallback behavior for when a scaled font is not provided.
 
  If @c YES, the font size will adjust even if a scaled font has not been provided for

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -95,6 +95,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 + (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
                                  message:(nullable NSString *)message {

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -405,7 +405,7 @@ IB_DESIGNABLE
  @param object This flexible header view
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCFlexibleHeaderView *_Nonnull flexibleHeaderView, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull flexibleHeaderView, CGFloat elevation);
 
 @end
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -394,19 +394,6 @@ IB_DESIGNABLE
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 
-/**
- This block is called after a change of the flexible header view's elevation or one of its view
- hierarchy ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This flexible header view
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull flexibleHeaderView, CGFloat elevation);
-
 @end
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -210,6 +210,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 // MDCFlexibleHeader properties
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 @synthesize trackingScrollViewIsBeingScrubbed = _trackingScrollViewIsBeingScrubbed;
 @synthesize scrollPhase = _scrollPhase;
 @synthesize scrollPhaseValue = _scrollPhaseValue;

--- a/components/List/src/MDCBaseCell.h
+++ b/components/List/src/MDCBaseCell.h
@@ -59,7 +59,7 @@
  @param cell This cell.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCBaseCell *_Nonnull cell, CGFloat absoluteElevation);
+    (id<MDCElevatable> _Nonnull cell, CGFloat absoluteElevation);
 
 @end
 

--- a/components/List/src/MDCBaseCell.h
+++ b/components/List/src/MDCBaseCell.h
@@ -48,19 +48,6 @@
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCBaseCell *_Nonnull cell, UITraitCollection *_Nullable previousTraitCollection);
 
-/**
- This block is called after a change of the cell's elevation or one of its view
- hierarchy ancestors.
-
- Use this block to respond to elevation changes in the view or its ancestor views.
-
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param cell This cell.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull cell, CGFloat absoluteElevation);
-
 @end
 
 @interface MDCBaseCell (ToBeDeprecated)

--- a/components/List/src/MDCBaseCell.m
+++ b/components/List/src/MDCBaseCell.m
@@ -29,6 +29,7 @@
 @implementation MDCBaseCell
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 #pragma mark Object Lifecycle
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -118,7 +118,7 @@
  @param object This bottom drawer view controller.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCBottomDrawerViewController *_Nonnull bottomDrawerViewController, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull bottomDrawerViewController, CGFloat elevation);
 
 /**
  Sets the top corners radius for an MDCBottomDrawerState drawerState

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -110,17 +110,6 @@
 @property(nonatomic, weak, nullable) id<MDCBottomDrawerViewControllerDelegate> delegate;
 
 /**
- This block is called after a change of the bottom drawer view controller's elevation or one of its
- view hierarchy ancestors. Use this block to respond to elevation changes in the view or its
- ancestor views.
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This bottom drawer view controller.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull bottomDrawerViewController, CGFloat elevation);
-
-/**
  Sets the top corners radius for an MDCBottomDrawerState drawerState
 
  @param radius The corner radius to set the top corners.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -33,6 +33,7 @@
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nil bundle:nil];

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -119,17 +119,6 @@
     (MDCSnackbarMessageView *_Nonnull messageView,
      UITraitCollection *_Nullable previousTraitCollection);
 
-/**
- This block is called after a change of the snackbar message view's elevation or one of its view
- hierarchy ancestors.
- Use this block to respond to elevation changes in the view or its ancestor views.
- @param elevation The @c mdc_currentElevation plus the @c mdc_currentElevation of all ancestor
- views.
- @param object This snackbar message view.
- */
-@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
-
 @end
 
 // clang-format off

--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -128,7 +128,7 @@
  @param object This snackbar message view.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlock)
-    (MDCSnackbarMessageView *_Nonnull object, CGFloat elevation);
+    (id<MDCElevatable> _Nonnull object, CGFloat elevation);
 
 @end
 

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -194,6 +194,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+@synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   return [self initWithMessage:nil


### PR DESCRIPTION
The property type for `elevationDidChangeBlock` declared in `MDCElevatable` should not be changed when declaring the property in headers. If it is, the compiler can generate a warning or error because the types are incompatible.

Closes #8105