### PR TITLE
[BottomSheet] Mark init unavailable

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -110,6 +110,8 @@
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 
+- (nonnull instancetype)init NS_DEPRECATED_IOS(9_0, 9_0, "Use initWithContentViewController:");
+
 /**
  Sets the shape generator for state that is used to define the bottom sheet's shape for that state.
 

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -111,7 +111,10 @@
  */
 @property(nonatomic, assign) MDCShadowElevation elevation;
 
-- (nonnull instancetype)init NS_DEPRECATED_IOS(9_0, 9_0, "Use initWithContentViewController:");
+/**
+ Bottom sheet controllers must be created with @c initWithContentViewController:.
+ */
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
 /**
  Initializes the controller with a content view controller.

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -61,12 +61,14 @@
   [super viewDidLoad];
 
   self.view.preservesSuperviewLayoutMargins = YES;
-  self.contentViewController.view.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  self.contentViewController.view.frame = self.view.bounds;
-  [self addChildViewController:self.contentViewController];
-  [self.view addSubview:self.contentViewController.view];
-  [self.contentViewController didMoveToParentViewController:self];
+  if (self.contentViewController) {
+    self.contentViewController.view.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.contentViewController.view.frame = self.view.bounds;
+    [self addChildViewController:self.contentViewController];
+    [self.view addSubview:self.contentViewController.view];
+    [self.contentViewController didMoveToParentViewController:self];
+  }
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -37,15 +37,6 @@
   self.view.elevation = self.elevation;
 }
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    _elevation = MDCShadowElevationModalBottomSheet;
-    _mdc_overrideBaseElevation = -1;
-  }
-  return self;
-}
-
 - (nonnull instancetype)initWithContentViewController:
     (nonnull UIViewController *)contentViewController {
   if (self = [super initWithNibName:nil bundle:nil]) {

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -126,11 +126,8 @@
 #pragma mark - MaterialElevation
 
 - (void)testDefaultOverrideBaseElevationIsNegative {
-  // Given
-  MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
-
   // Then
-  XCTAssertLessThan(bottomSheet.mdc_overrideBaseElevation, 0);
+  XCTAssertLessThan(self.bottomSheet.mdc_overrideBaseElevation, 0);
 }
 
 - (void)testSettingBaseOverrideBaseElevationReturnsSetValue {

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -70,12 +70,11 @@
 
 - (void)testBottonSheetControllerTraitCollectionDidChangeBlockCalledWithExpectedParameters {
   // Given
-  MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] init];
   XCTestExpectation *expectation =
       [[XCTestExpectation alloc] initWithDescription:@"traitCollectionDidChange"];
   __block UITraitCollection *passedTraitCollection;
   __block MDCBottomSheetController *passedBottomSheet;
-  bottomSheet.traitCollectionDidChangeBlock =
+  self.bottomSheet.traitCollectionDidChangeBlock =
       ^(MDCBottomSheetController *_Nonnull bottomSheetController,
         UITraitCollection *_Nullable previousTraitCollection) {
         [expectation fulfill];
@@ -85,12 +84,12 @@
   UITraitCollection *testTraitCollection = [UITraitCollection traitCollectionWithDisplayScale:7];
 
   // When
-  [bottomSheet traitCollectionDidChange:testTraitCollection];
+  [self.bottomSheet traitCollectionDidChange:testTraitCollection];
 
   // Then
   [self waitForExpectations:@[ expectation ] timeout:1];
   XCTAssertEqual(passedTraitCollection, testTraitCollection);
-  XCTAssertEqual(passedBottomSheet, bottomSheet);
+  XCTAssertEqual(passedBottomSheet, self.bottomSheet);
 }
 
 - (void)


### PR DESCRIPTION
Currently the MDCBottomSheet controller does not mark its `init` method as unavailable but the contentViewController is marked as `readonly` so clients would have to _initialize_ with a contentViewController. If the contentViewController is `nil` then when `addChildViewController` is called in `viewDidLoad` this causes a crash as you cannot pass `nil` to an array.

Closes #8109 