### PR TITLE
[BottomSheet] Add CocoaPod dependency to MaterialElevation

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -366,6 +366,7 @@ Pod::Spec.new do |mdc|
       "components/#{component.base_name}/src/private/*.{h,m}"
     ]
 
+    component.dependency "MaterialComponents/Elevation"
     component.dependency "MaterialComponents/ShapeLibrary"
     component.dependency "MaterialComponents/Shapes"
     component.dependency "MaterialComponents/ShadowElevations"


### PR DESCRIPTION
In #8102 I didn't add the dependency to MaterialElevation in Cocoapods this is a follow up to add that dependency.

Related to #8025 
Follow up to #8102 