### PR TITLE
[BottomNavigation] Test for `additionalSafeAreaInsets` behavior.

### DIFF
--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerTests.m
@@ -313,6 +313,39 @@ static CGFloat const kDefaultExpectationTimeout = 15;
   XCTAssertFalse(childViewController2.viewLoaded);
 }
 
+- (void)testOverwritesAdditionalSafeAreaInsetsOfSelectedViewController {
+  // Given
+  UIViewController *childViewController1 = [[UIViewController alloc] init];
+  UIViewController *childViewController2 = [[UIViewController alloc] init];
+  const UIEdgeInsets originalAdditionalSafeAreaInsets = UIEdgeInsetsMake(1, 2, 3, 4);
+  if (@available(iOS 11.0, *)) {
+    childViewController1.additionalSafeAreaInsets = originalAdditionalSafeAreaInsets;
+    childViewController2.additionalSafeAreaInsets = originalAdditionalSafeAreaInsets;
+  }
+
+  // When
+  self.bottomNavigationBarController.viewControllers =
+      @[ childViewController1, childViewController2 ];
+  [self.bottomNavigationBarController.view layoutIfNeeded];
+
+  // Then
+  const UIEdgeInsets expectedAdditionalSafeaAreaInsets = UIEdgeInsetsMake(
+      0, 0, CGRectGetHeight(self.bottomNavigationBarController.navigationBar.bounds), 0);
+  XCTAssertEqual(self.bottomNavigationBarController.selectedViewController, childViewController1);
+  if (@available(iOS 11.0, *)) {
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(childViewController1.additionalSafeAreaInsets,
+                                                expectedAdditionalSafeaAreaInsets),
+                  @"(%@) is not equal to (%@)",
+                  NSStringFromUIEdgeInsets(childViewController1.additionalSafeAreaInsets),
+                  NSStringFromUIEdgeInsets(expectedAdditionalSafeaAreaInsets));
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(childViewController2.additionalSafeAreaInsets,
+                                                originalAdditionalSafeAreaInsets),
+                  @"(%@) is not equal to (%@)",
+                  NSStringFromUIEdgeInsets(childViewController2.additionalSafeAreaInsets),
+                  NSStringFromUIEdgeInsets(originalAdditionalSafeAreaInsets));
+  }
+}
+
 #pragma mark - MDCBottomNavigationBarControllerDelegate Methods
 
 - (void)bottomNavigationBarController:


### PR DESCRIPTION
This test ensures that the `additionalSafeAreaInsets` property of child VCs is
correctly set to account for the bottom navigation bar.

Confirmation of #8112