### PR TITLE
[NavigationBar] Add doc to note UIBarButtonItem cannot be used in UIPopoverPresentationController.

### DIFF
--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -71,7 +71,7 @@ Read the button bar section on
 supported UIBarButtonItem properties.
 
 Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
-anchor point in UIPopoverPresentationController. The sourceView and sourceRect on
+anchor point on UIPopoverPresentationController. The sourceView and sourceRect on
 UIPopoverPresentationController should be used instead.
 
 ## Installation

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -73,6 +73,11 @@ supported UIBarButtonItem properties.
 Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
 anchor point on UIPopoverPresentationController. The sourceView and sourceRect on
 UIPopoverPresentationController should be used instead.
+```objc
+// Set a view controller to be popped over at the center of a target view.
+aViewContoller.popoverPresentationController.sourceView = targetView;
+aViewContoller.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(targetView.bounds)),CGRectGetMidY(targetView.bounds), 0, 0);
+```
 
 ## Installation
 

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -8,7 +8,7 @@ path: /catalog/app-bars/navigation-bars/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using ./scripts/generate_readme NavigationBar -->
+<!-- This file was auto-generated using scripts/generate_readme NavigationBar -->
 
 # Navigation bar
 
@@ -69,6 +69,10 @@ button items.
 Read the button bar section on
 [UIBarButtonItem properties](../ButtonBar/#uibarbuttonitem-properties) to learn more about
 supported UIBarButtonItem properties.
+
+Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
+anchor point in UIPopoverPresentationController. The sourceView and sourceRect on
+UIPopoverPresentationController should be used instead.
 
 ## Installation
 

--- a/components/NavigationBar/README.md
+++ b/components/NavigationBar/README.md
@@ -8,7 +8,7 @@ path: /catalog/app-bars/navigation-bars/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme NavigationBar -->
+<!-- This file was auto-generated using ./scripts/generate_readme NavigationBar -->
 
 # Navigation bar
 

--- a/components/NavigationBar/docs/README.md
+++ b/components/NavigationBar/docs/README.md
@@ -36,6 +36,10 @@ Read the button bar section on
 [UIBarButtonItem properties](../../ButtonBar/#uibarbuttonitem-properties) to learn more about
 supported UIBarButtonItem properties.
 
+Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
+anchor point in UIPopoverPresentationController. The sourceView and sourceRect on
+UIPopoverPresentationController should be used instead.
+
 ## Installation
 
 - [Typical installation](../../../docs/component-installation.md)

--- a/components/NavigationBar/docs/README.md
+++ b/components/NavigationBar/docs/README.md
@@ -39,6 +39,11 @@ supported UIBarButtonItem properties.
 Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
 anchor point on UIPopoverPresentationController. The sourceView and sourceRect on
 UIPopoverPresentationController should be used instead.
+```objc
+// Set a view controller to be popped over at the center of a target view.
+aViewContoller.popoverPresentationController.sourceView = targetView;
+aViewContoller.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(targetView.bounds)),CGRectGetMidY(targetView.bounds), 0, 0);
+```
 
 ## Installation
 

--- a/components/NavigationBar/docs/README.md
+++ b/components/NavigationBar/docs/README.md
@@ -37,7 +37,7 @@ Read the button bar section on
 supported UIBarButtonItem properties.
 
 Note: The UIBarButtonItem instances set on MDCNavigationBar cannot be used to specify the popover's
-anchor point in UIPopoverPresentationController. The sourceView and sourceRect on
+anchor point on UIPopoverPresentationController. The sourceView and sourceRect on
 UIPopoverPresentationController should be used instead.
 
 ## Installation


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/7907.