### PR TITLE
[ActionSheet] BUILD file uses Skylark macros.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -22,6 +22,8 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
+    "mdc_unit_test_swift_library",
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -82,12 +84,6 @@ mdc_objc_library(
     deps = [":ActionSheet"],
 )
 
-mdc_objc_library(
-    name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
-)
-
 mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
@@ -112,90 +108,33 @@ mdc_examples_swift_library(
     ],
 )
 
-swift_library(
+mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    srcs = glob(["tests/unit/*.swift"]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
-    deps = [
-        ":ActionSheet",
-        ":private",
-    ],
-)
-
-swift_library(
-    name = "unit_test_color_themer_swift_sources",
-    srcs = glob(["tests/unit/ColorThemer/*.swift"]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
+    extra_srcs = glob(["tests/unit/ColorThemer/*.swift"]),
     deps = [
         ":ActionSheet",
         ":ColorThemer",
-        ":private",
-    ],
-)
-
-mdc_objc_library(
-    name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob(["tests/unit/*.m"]),
-    hdrs = native.glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "CoreImage",
-        "XCTest",
-    ],
-    deps = [
-        ":ActionSheet",
-        ":ActionSheetThemer",
-        ":ColorThemer",
-        ":Theming",
-        ":TypographyThemer",
         ":privateHeaders",
     ],
 )
 
-mdc_objc_library(
-    name = "unit_test_theming_sources",
-    testonly = 1,
-    srcs = native.glob([
+mdc_unit_test_objc_library(
+    name = "unit_test_sources",
+    hdrs = glob(["tests/unit/*.h"]),
+    extra_srcs = glob([
+        "tests/unit/ActionSheetThemer/*.m",
         "tests/unit/Theming/*.m",
     ]),
     sdk_frameworks = [
-        "UIKit",
         "CoreImage",
-        "XCTest",
-    ],
-    deps = [
-        ":ActionSheet",
-        ":Theming",
-        ":privateHeaders",
-        ":unit_test_sources",
-    ],
-)
-
-mdc_objc_library(
-    name = "unit_test_themer_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/ActionSheetThemer/*.m",
-    ]),
-    sdk_frameworks = [
-        "UIKit",
-        "CoreImage",
-        "XCTest",
     ],
     deps = [
         ":ActionSheet",
         ":ActionSheetThemer",
         ":ColorThemer",
+        ":Theming",
         ":TypographyThemer",
         ":privateHeaders",
-        ":unit_test_sources",
     ],
 )
 


### PR DESCRIPTION
Updates the BUILD file to use as many Skylark macros as possible to reduce
boilerplate and make it easier to transform the BUILD files when releasing each
week.

Part of #8150