### PR TITLE
[AnimationTiming] Use Skylark macros in BUILD file.

### DIFF
--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -18,6 +18,7 @@ load(
     "mdc_examples_swift_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -32,15 +33,9 @@ mdc_public_objc_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    srcs = glob(["tests/unit/*.m"]),
     hdrs = glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [":AnimationTiming"],
 )
 


### PR DESCRIPTION
Uses our team's Skylark macros in the BUILD file to reduce boilerplate and
make releases easier.

Part of #8150
