### PR TITLE
[ButtonBar] Use Starlark macros.

### DIFF
--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -22,7 +22,9 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
+    "mdc_unit_test_swift_library",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
@@ -90,22 +92,11 @@ mdc_examples_swift_library(
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
-    ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ButtonBar",
         ":ColorThemer",
@@ -114,17 +105,11 @@ mdc_objc_library(
     ],
 )
 
-swift_library(
+mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    srcs = native.glob([
-        "tests/unit/*.swift",
+    extra_srcs = native.glob([
         "tests/unit/Theming/*.swift",
     ]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Theming",
         "//components/Typography",

--- a/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarBuilderTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "MDCAppBarButtonBarBuilder.h"
+#import "../../src/private/MDCAppBarButtonBarBuilder.h"
 #import "MaterialButtonBar.h"
 #import "MaterialButtons.h"
 

--- a/components/ButtonBar/tests/unit/ButtonBarRippleTests.m
+++ b/components/ButtonBar/tests/unit/ButtonBarRippleTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCAppBarButtonBarBuilder.h"
+#import "../../src/private/MDCAppBarButtonBarBuilder.h"
 #import "MaterialButtonBar.h"
 #import "MaterialInk.h"
 #import "MaterialRipple.h"


### PR DESCRIPTION
Adds more Starlark macro usage in the BUILD file. This makes releasing easier. Also removed the need to expand our `includes` path.

Part of #8150