### PR TITLE
[CollectionLayoutAttributes] Use more Starlark macros.

### DIFF
--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -18,6 +18,7 @@ load(
     "//:material_components_ios.bzl",
     "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -38,18 +39,8 @@ package_group(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
-    ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":CollectionLayoutAttributes",
     ],


### PR DESCRIPTION
Add more Starlark macro usage to the BUILD file. Makes releases easier.

Part of #8150