### PR TITLE
[Ink] Use Starlark macros.

### DIFF
--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -20,6 +20,7 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -30,7 +31,6 @@ mdc_public_objc_library(
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",
-        "UIKit",
     ],
     deps = [
         "//components/private/Math",
@@ -47,8 +47,8 @@ mdc_extension_objc_library(
 
 mdc_objc_library(
     name = "private",
+    testonly = 1,
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
     deps = [":Ink"],
 )
@@ -62,16 +62,8 @@ mdc_examples_objc_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",
         ":Ink",

--- a/components/Ink/tests/unit/MDCInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCInkLayerTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCInkLayer.h"
+#import "../../src/private/MDCInkLayer.h"
 
 #pragma mark - Fake classes
 

--- a/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
+++ b/components/Ink/tests/unit/MDCLegacyInkLayerTests.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "MDCLegacyInkLayer+Private.h"
+#import "../../src/private/MDCLegacyInkLayer+Private.h"
 #import "MaterialInk.h"
 
 #pragma mark - Property exposure


### PR DESCRIPTION
Use more Starlark macros in the BUILD file. This makes it easier for releasing
each week. Also removed the `includes` requirement by making testing imports
relative.

Part of #8150