### PR TITLE
[LibraryInfo] Use Starlark macros.

### DIFF
--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -18,8 +18,8 @@ load(
     "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_suite",
+    "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -30,14 +30,8 @@ mdc_public_objc_library(
     ],
 )
 
-swift_library(
+mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    srcs = glob(["tests/unit/*.swift"]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
-    visibility = ["//visibility:private"],
     deps = [":LibraryInfo"],
 )
 


### PR DESCRIPTION
Use more Starlark macros in the BUILD file to make releases easier.

Part of #8150