### PR TITLE
[OverlayWindow] Use more Starlark macros.

### DIFF
--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -17,6 +17,7 @@ load(
     "//:material_components_ios.bzl",
     "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -26,24 +27,14 @@ mdc_public_objc_library(
     name = "OverlayWindow",
     sdk_frameworks = [
         "CoreGraphics",
-        "UIKit",
     ],
     deps = [
         "//components/private/Application",
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
-    ]),
-    sdk_frameworks = [
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":OverlayWindow",
     ],


### PR DESCRIPTION
Uses more Starlark macros to make BUILD file transforms easier. Helps reduce
the burden of releasing.

Part of #8150