### PR TITLE
[Palettes] Use more Starlark macros in the BUILD file.

### DIFF
--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -17,9 +17,10 @@ load(
     "mdc_examples_swift_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
+    "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -27,14 +28,8 @@ mdc_public_objc_library(
     name = "Palettes",
 )
 
-swift_library(
+mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    srcs = glob(["tests/unit/*.swift"]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
-    visibility = ["//visibility:private"],
     deps = [":Palettes"],
 )
 
@@ -46,15 +41,8 @@ mdc_examples_swift_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [":Palettes"],
 )
 


### PR DESCRIPTION
Adds more Starlark macro use to the BUILD file to make releasing easier.

Part of #8150