### PR TITLE
[Ripple] Use Starlark macros.

### DIFF
--- a/components/Ripple/BUILD
+++ b/components/Ripple/BUILD
@@ -18,9 +18,10 @@ load(
     "mdc_examples_swift_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
-    "mdc_unit_test_suite",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
+    "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
@@ -31,7 +32,6 @@ mdc_public_objc_library(
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",
-        "UIKit",
     ],
     deps = [
         "//components/AnimationTiming",
@@ -42,7 +42,6 @@ mdc_public_objc_library(
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
     deps = [":Ripple"],
 )
@@ -67,16 +66,8 @@ mdc_examples_swift_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Ripple",
         ":private",

--- a/components/Ripple/tests/unit/MDCRippleLayerTests.m
+++ b/components/Ripple/tests/unit/MDCRippleLayerTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCRippleLayer.h"
+#import "../../src/private/MDCRippleLayer.h"
 
 #pragma mark - Fake classes
 

--- a/components/Ripple/tests/unit/MDCRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCRippleLayer.h"
+#import "../../src/private/MDCRippleLayer.h"
 #import "MaterialRipple.h"
 
 @interface FakeMDCRippleViewAnimationDelegate : NSObject <MDCRippleViewDelegate>

--- a/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
+++ b/components/Ripple/tests/unit/MDCStatefulRippleViewTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCRippleLayer.h"
+#import "../../src/private/MDCRippleLayer.h"
 #import "MaterialRipple.h"
 
 @interface MDCStatefulRippleView (UnitTests)


### PR DESCRIPTION
Updates the BUILD file to use more Starlark macros. Also drops the `includes`
update from the private target and fixes the imports in unit tests.

Part of #8150