### PR TITLE
[ShapeLibrary] Use Starlark macros.

### DIFF
--- a/components/ShapeLibrary/BUILD
+++ b/components/ShapeLibrary/BUILD
@@ -19,6 +19,7 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -28,7 +29,6 @@ mdc_public_objc_library(
     name = "ShapeLibrary",
     sdk_frameworks = [
         "CoreGraphics",
-        "UIKit",
     ],
     deps = [
         "//components/Shapes",
@@ -36,18 +36,8 @@ mdc_public_objc_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
-    ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ShapeLibrary",
     ],


### PR DESCRIPTION
Use more Starlark macros in the BUILD file to make releases easier.

Part of #8150