### PR TITLE
[Elevation] Having MDCElevatable conform to NSObject

### DIFF
--- a/components/Elevation/src/MDCElevatable.h
+++ b/components/Elevation/src/MDCElevatable.h
@@ -18,7 +18,7 @@
 /**
  Provides APIs for @c UIViews to communicate their elevation throughout the view hierarchy.
  */
-@protocol MDCElevatable
+@protocol MDCElevatable <NSObject>
 
 /**
  The current elevation of the conforming @c UIView.


### PR DESCRIPTION
Due to the recent change of moving our elevationDidChangeBlocks to not have the type's object but remain id<MDCElevatable>, for a client to be able to safely cast the object, they will need to use `isKindOfClass:` which is only available if the protocol conforms to NSObject.

