### PR TITLE
[Snackbar] Use Starlark macros in BUILD file.

### DIFF
--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -21,7 +21,9 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
+    "mdc_unit_test_swift_library",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
@@ -33,7 +35,6 @@ mdc_public_objc_library(
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",
-        "UIKit",
     ],
     deps = [
         "//components/AnimationTiming",
@@ -106,18 +107,11 @@ mdc_examples_objc_library(
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
 )
 
-swift_library(
+mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    srcs = glob(["tests/unit/*.swift"]),
-    copts = [
-        "-swift-version",
-        "4.2",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",
         ":Snackbar",
@@ -126,20 +120,12 @@ swift_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
+    extra_srcs = glob([
         "tests/unit/supplemental/*.m",
         "tests/unit/supplemental/*.h",
     ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",
         ":FontThemer",

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -18,7 +18,7 @@
 // isn't imported first.
 // clang-format off
 #import "MaterialSnackbar.h"
-#import "MDCSnackbarMessageViewInternal.h"
+#import "../../src/private/MDCSnackbarMessageViewInternal.h"
 // clang-format on
 
 /** The width of the Snackbar for testing. */


### PR DESCRIPTION
Adds more Starlark macro use in the BUILD file to make releasing easier. Also
removes the need for `includes` in the test targets.

Part of #8150