### PR TITLE
[Tabs] Use Starlark macros in BUILD file.

### DIFF
--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -22,6 +22,7 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -30,9 +31,6 @@ licenses(["notice"])  # Apache 2.0
 mdc_public_objc_library(
     name = "Tabs",
     bundles = [":Bundle"],
-    sdk_frameworks = [
-        "UIKit",
-    ],
     deps = [
         "//components/AnimationTiming",
         "//components/Elevation",
@@ -143,70 +141,34 @@ mdc_examples_swift_library(
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
     name = "privateTabBarView",
     hdrs = native.glob(["src/TabBarView/private/*.h"]),
-    includes = ["src/TabBarView/private"],
     visibility = ["//visibility:private"],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/*.m",
-        "tests/unit/*.h",
+    extra_srcs = glob([
+        "tests/unit/Theming/*.m" +
+        "tests/unit/TabBarView/*.m",
     ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":ColorThemer",
         ":FontThemer",
-        ":Tabs",
-        ":TypographyThemer",
-        ":private",
-        "@material_internationalization_ios//:MDFInternationalization",
-    ],
-)
-
-mdc_objc_library(
-    name = "unit_test_theming_sources",
-    testonly = 1,
-    srcs = native.glob([
-        "tests/unit/Theming/*.m",
-    ]),
-    sdk_frameworks = [
-        "XCTest",
-    ],
-    deps = [
+        ":TabBarView",
         ":Tabs",
         ":Theming",
+        ":TypographyThemer",
+        ":private",
+        ":privateTabBarView",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",
-    ],
-)
-
-mdc_objc_library(
-    name = "unit_test_tabbarview_sources",
-    srcs = native.glob([
-        "tests/unit/TabBarView/*.m",
-    ]),
-    sdk_frameworks = [
-        "CoreGraphics",
-        "XCTest",
-    ],
-    deps = [
-        ":TabBarView",
-        ":privateTabBarView",
-        "//components/Typography",
+        "@material_internationalization_ios//:MDFInternationalization",
     ],
 )
 
@@ -214,8 +176,6 @@ mdc_unit_test_suite(
     name = "unit_tests",
     deps = [
         ":unit_test_sources",
-        ":unit_test_tabbarview_sources",
-        ":unit_test_theming_sources",
     ],
 )
 

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewLayoutStyleSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewLayoutStyleSnapshotTests.m
@@ -14,8 +14,8 @@
 
 #import "MaterialSnapshot.h"
 
+#import "../../../src/TabBarView/private/MDCTabBarViewItemView.h"
 #import "MDCTabBarView.h"
-#import "MDCTabBarViewItemView.h"
 
 /** The typical size of an image in a Tab bar. */
 static const CGSize kTypicalImageSize = (CGSize){24, 24};

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
@@ -14,10 +14,10 @@
 
 #import "MaterialSnapshot.h"
 
+#import "../../../src/TabBarView/private/MDCTabBarViewItemView.h"
 #import "MDCTabBarItem.h"
 #import "MDCTabBarView.h"
 #import "MDCTabBarViewCustomViewable.h"
-#import "MDCTabBarViewItemView.h"
 
 /** The typical size of an image in a Tab bar. */
 static const CGSize kTypicalImageSize = (CGSize){24, 24};

--- a/components/Tabs/tests/unit/MDCItemBarCellTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarCellTests.m
@@ -14,9 +14,9 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCItemBarCell+Private.h"
-#import "MDCItemBarCell.h"
-#import "MDCItemBarStyle.h"
+#import "../../src/private/MDCItemBarCell+Private.h"
+#import "../../src/private/MDCItemBarCell.h"
+#import "../../src/private/MDCItemBarStyle.h"
 
 @interface MDCItemBarCellTests : XCTestCase
 

--- a/components/Tabs/tests/unit/MDCItemBarTests.m
+++ b/components/Tabs/tests/unit/MDCItemBarTests.m
@@ -15,7 +15,7 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "MDCItemBar.h"
+#import "../../src/private/MDCItemBar.h"
 
 @interface MDCItemBar (Testing)
 - (UITabBarItem *)itemAtIndexPath:(NSIndexPath *)indexPath;

--- a/components/Tabs/tests/unit/MDCTabBarDisplayDelegateTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarDisplayDelegateTests.m
@@ -14,7 +14,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCItemBar.h"
+#import "../../src/private/MDCItemBar.h"
 #import "MDCTabBarDisplayDelegate.h"
 #import "MaterialTabs.h"
 

--- a/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarLayoutTests.m
@@ -15,7 +15,7 @@
 #import <MDFInternationalization/MDFInternationalization.h>
 #import <XCTest/XCTest.h>
 
-#import "MDCItemBar.h"
+#import "../../src/private/MDCItemBar.h"
 #import "MDCTabBar.h"
 
 // Returns the underlying collection view from a given tabBar. If one cannot be extracted, returns

--- a/components/Tabs/tests/unit/MDCTabBarRippleTests.m
+++ b/components/Tabs/tests/unit/MDCTabBarRippleTests.m
@@ -14,9 +14,9 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCItemBar.h"
-#import "MDCItemBarCell.h"
-#import "MDCItemBarStyle.h"
+#import "../../src/private/MDCItemBar.h"
+#import "../../src/private/MDCItemBarCell.h"
+#import "../../src/private/MDCItemBarStyle.h"
 #import "MaterialInk.h"
 #import "MaterialRipple.h"
 #import "MaterialTabs.h"


### PR DESCRIPTION
Use more Starlark macros in the BUILD file. Also gets rid of the `include`
path extension.

Part of #8150