### PR TITLE
[Typography] Use Starlark macros.

### DIFF
--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -20,6 +20,7 @@ load(
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -29,7 +30,6 @@ mdc_public_objc_library(
     name = "Typography",
     sdk_frameworks = [
         "QuartzCore",
-        "UIKit",
     ],
     deps = [
         "//components/private/Application",
@@ -41,7 +41,6 @@ mdc_public_objc_library(
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),
-    includes = ["src/private"],
     visibility = ["//visibility:private"],
 )
 
@@ -61,16 +60,8 @@ mdc_examples_swift_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Typography",
         ":private",


### PR DESCRIPTION
Use more Starlark macros in the BUILD file. This makes releasing easier.

Part of #8150