### PR TITLE
[UIMetrics] Use Starlark macros in the BUILD file.

### DIFF
--- a/components/private/UIMetrics/BUILD
+++ b/components/private/UIMetrics/BUILD
@@ -15,7 +15,7 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_public_objc_library",
-    "mdc_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -29,17 +29,9 @@ mdc_public_objc_library(
     ],
 )
 
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob([
-        "tests/unit/*.m",
-    ]),
-    sdk_frameworks = [
-        "UIKit",
-        "XCTest",
-    ],
-    visibility = ["//visibility:private"],
+    deps = [":UIMetrics"],
 )
 
 mdc_unit_test_suite(


### PR DESCRIPTION
Use Starlark macro to simplify the BUILD file.

Part of #8150