### PR TITLE
[schemes/Color] Use Starlark macros in BUILD file.

### DIFF
--- a/components/schemes/Color/BUILD
+++ b/components/schemes/Color/BUILD
@@ -16,8 +16,8 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -30,25 +30,11 @@ mdc_public_objc_library(
     ],
 )
 
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/schemes/Color/...",
-    ],
-)
-
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    includes = ["src"],
     sdk_frameworks = [
         "CoreGraphics",
-        "UIKit",
-        "XCTest",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Color",
         "//components/Palettes",


### PR DESCRIPTION
Use Starlark macros in the BUILD file to simplify releases.

Part of #8150