### PR TITLE
[Shape] Use Starlark macros in BUILD file.

### DIFF
--- a/components/schemes/Shape/BUILD
+++ b/components/schemes/Shape/BUILD
@@ -17,8 +17,8 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -57,25 +57,11 @@ mdc_examples_objc_library(
     ],
 )
 
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/schemes/Shape/...",
-    ],
-)
-
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    includes = ["src"],
     sdk_frameworks = [
         "CoreGraphics",
-        "UIKit",
-        "XCTest",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Shape",
     ],


### PR DESCRIPTION
Using more macros to make it easier to perform releases.

Part of #8150