### PR TITLE
[Typography] Use Starlark macros in BUILD file.

### DIFF
--- a/components/schemes/Typography/BUILD
+++ b/components/schemes/Typography/BUILD
@@ -17,8 +17,8 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
 
@@ -35,30 +35,16 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":Typography",
-        "//components/schemes/Color",
         "//components/Typography",
+        "//components/schemes/Color",
     ],
 )
 
-package_group(
-    name = "test_targets",
-    packages = [
-        "//components/schemes/Typography/...",
-    ],
-)
-
-mdc_objc_library(
+mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    testonly = 1,
-    srcs = glob(["tests/unit/*.m"]),
-    hdrs = glob(["tests/unit/*.h"]),
-    includes = ["src"],
     sdk_frameworks = [
         "CoreGraphics",
-        "UIKit",
-        "XCTest",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         ":Typography",
     ],


### PR DESCRIPTION
Use more Starlark macros to make BUILD file transforms easier during releases.

Part of #8150