### PR TITLE
[Elevation] Add smooth continuous formula for values between 0 and 1

### DIFF
--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -53,13 +53,13 @@
       // as in the main formula below there is a jump between any number larger than 0 to an
       // alpha value of 2. This formula provides a gradual polynomial curve that makes the delta
       // of the alpha value between lower numbers to be smaller than the higher numbers.
-      // AlphaValue = 5 * elevationValue ^ 2
-      alphaValue = 5 * MDCPow((CGFloat)elevation, 2);
+      // AlphaValue = 5.11916 * elevationValue ^ 2
+      alphaValue = (CGFloat)5.11916 * MDCPow((CGFloat)elevation, 2);
     } else {
       // A formula is used here to simulate the alpha percentage stated on
       // https://material.io/design/color/dark-theme.html#properties
       // AlphaValue = 4.5 * ln (elevationValue + 1) + 2
-      // Note: Both formulas meet at the transition point of (1,5).
+      // Note: Both formulas meet at the transition point of (1, 5.11916).
       alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
     }
   }

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -48,10 +48,20 @@
   elevation = MAX(elevation, 0);
   CGFloat alphaValue = 0;
   if (!MDCCGFloatEqual(elevation, 0)) {
-    // A formula is used here to simulate the alpha percentage stated on
-    // https://material.io/design/color/dark-theme.html#properties
-    // AlphaValue = 4.5 * ln (elevationValue + 1) + 2
-    alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
+    if (elevation < 1) {
+      // A formula for values between 0 to 1 is used here to simulate the alpha percentage
+      // as in the main formula below there is a jump between any number larger than 0 to an
+      // alpha value of 2. This formula provides a gradual polynomial curve that makes the delta
+      // of the alpha value between lower numbers to be smaller than the higher numbers.
+      // AlphaValue = 5 * elevationValue ^ 2
+      alphaValue = 5 * MDCPow((CGFloat)elevation, 2);
+    } else {
+      // A formula is used here to simulate the alpha percentage stated on
+      // https://material.io/design/color/dark-theme.html#properties
+      // AlphaValue = 4.5 * ln (elevationValue + 1) + 2
+      // Note: Both formulas meet at the transition point of (1,5).
+      alphaValue = (CGFloat)4.5 * (CGFloat)log(elevation + 1) + 2;
+    }
   }
   // TODO (https://github.com/material-components/material-components-ios/issues/8096):
   // Grayscale color should be returned if color space is UIExtendedGrayColorSpace.

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -269,4 +269,18 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                              secondColor);
 }
 
+- (void)testSmoothJumpBetweenElevationToAlphaForValuesBetweenZeroAndOne {
+  // Given
+  CGFloat firstElevation = (CGFloat)0.01;
+  CGFloat secondElevation = (CGFloat)0;
+
+  // When
+  UIColor *resolvedFirstRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:firstElevation];
+  UIColor *resolvedSecondRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:secondElevation];
+
+  // Then
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedFirstRGBColor
+                                          secondColor:resolvedSecondRGBColor];
+}
+
 @end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -269,10 +269,24 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                              secondColor);
 }
 
-- (void)testSmoothJumpBetweenElevationToAlphaForValuesBetweenZeroAndOne {
+- (void)testSmoothJumpBetweenElevationToAlphaForValuesCloseToZero {
   // Given
   CGFloat firstElevation = (CGFloat)0.01;
   CGFloat secondElevation = (CGFloat)0;
+
+  // When
+  UIColor *resolvedFirstRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:firstElevation];
+  UIColor *resolvedSecondRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:secondElevation];
+
+  // Then
+  [self assertEqualColorsWithFloatPrecisionFirstColor:resolvedFirstRGBColor
+                                          secondColor:resolvedSecondRGBColor];
+}
+
+- (void)testSmoothJumpBetweenElevationToAlphaForValuesCloseToOne {
+  // Given
+  CGFloat firstElevation = (CGFloat)0.99;
+  CGFloat secondElevation = (CGFloat)1;
 
   // When
   UIColor *resolvedFirstRGBColor = [self.rgbColor mdc_resolvedColorWithElevation:firstElevation];


### PR DESCRIPTION
In the UIColor+MaterialElevation category the formula to convert elevation to alpha has a jump for elevations that are 0 to anything bigger than 0.

This means that elevation 0 returns an alpha that is 0, but any elevation that is above 0, even 0.000000001 will return an alpha of 2 or bigger. This causes 2 problems:

1. Some of our components return elevations that are very close to 0, like 0.0000000000005 (AppBar in particular). If we don't fix this, it will cause constant flickering of the background color of the AppBar as it transitions between 0 and something closer to 0.
2. There is a big jump when component elevations between 0 and anything larger than 0 occurs which makes it seem like a jump and not smooth to the observer.

The change provide a smooth function that occurs between values of 0 and 1. This formula has been thought out in collaboration with design.

Closes: #8213 