### PR TITLE
[Elevation] Update mdc_resolvedColorWithTraitCollection:elevation: to support pre-iOS 13

### DIFF
--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -43,7 +43,5 @@
  */
 - (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:
                          (nonnull UITraitCollection *)traitCollection
-                                                elevation:(CGFloat)elevation
-    API_AVAILABLE(ios(13.0));
-
+                                                elevation:(CGFloat)elevation;
 @end

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -33,9 +33,7 @@
     }
   }
 #endif
-  [NSException raise:NSGenericException
-              format:@"%@ is only supported on iOS 13 and above", NSStringFromSelector(_cmd)];
-  return nil;
+  return self;
 }
 
 - (UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation {

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -232,13 +232,11 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
     UIColor *staticColor = UIColor.blackColor;
     UITraitCollection *traitCollection = [[UITraitCollection alloc] init];
 
-    // When/Then
-    XCTAssertThrowsSpecificNamed(
-        [staticColor performSelector:@selector(mdc_resolvedColorWithTraitCollection:elevation:)
-                          withObject:traitCollection
-                          withObject:@(elevation)],
-        NSException, NSGenericException, @"Expected exception when %@ is called on pre iOS13",
-        NSStringFromSelector(@selector(mdc_resolvedColorWithTraitCollection:elevation:)));
+    // When
+    UIColor *color = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection elevation:elevation];
+
+    // Then
+    [self assertEqualColorsWithFloatPrecisionFirstColor:color secondColor:staticColor];
   }
 }
 

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -233,7 +233,8 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
     UITraitCollection *traitCollection = [[UITraitCollection alloc] init];
 
     // When
-    UIColor *color = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection elevation:elevation];
+    UIColor *color = [staticColor mdc_resolvedColorWithTraitCollection:traitCollection
+                                                             elevation:elevation];
 
     // Then
     [self assertEqualColorsWithFloatPrecisionFirstColor:color secondColor:staticColor];


### PR DESCRIPTION
By having mdc_resolvedColorWithTraitCollection:elevation be an iOS13 only API, it forces the client using this API to have iOS13 checks surrounding this method, when in fact we are already adding those checks inside the method itself, making clients have to do additional work that is unneeded.

Secondly, having the method return nil if it isn't iOS13 and not just return the original color causes clients (and our theming extensions) to add additional checks if its nil and apply the original color otherwise:
```
self.backgroundColor = [self.backgroundColor resolvedColorForTraitCollection:self.traitCollection elevation:elevation] ?: self.backgroundColor;
```

Instead of just doing:
```
self.backgroundColor = [self.backgroundColor resolvedColorForTraitCollection:self.traitCollection elevation:elevation];
```

Lastly, I don't believe it makes sense to make the method an iOS13 API only as in fact UITraitCollections exist since iOS8, and is legitimate to pass it to the function even though userInterfaceStyle is not there yet.

Closes: #8216