### PR TITLE
[ActionSheet] Allow clients to customize the title color of actions

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -264,6 +264,13 @@ typedef void (^MDCActionSheetHandler)(MDCActionSheetAction *_Nonnull action);
  */
 @property(nonatomic, nullable, copy) NSString *accessibilityIdentifier;
 
+/**
+ The color of the action title.
+ 
+ @note If no @c titleColor is provided then the @c actionTextColor from the controller will be used.
+ */
+@property(nonatomic, copy, nullable) UIColor *titleColor;
+
 @end
 
 @interface MDCActionSheetController (ToBeDeprecated)

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -276,7 +276,7 @@ typedef void (^MDCActionSheetHandler)(MDCActionSheetAction *_Nonnull action);
 
 /**
  The color of the action title.
- 
+
  @note If no @c titleColor is provided then the @c actionTextColor from the controller will be used.
  */
 @property(nonatomic, copy, nullable) UIColor *titleColor;

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -60,10 +60,6 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   return action;
 }
 
-- (void)setTitleColor:(UIColor *)titleColor {
-  _titleColor = [titleColor copy];
-}
-
 @end
 
 @interface MDCActionSheetController () <MDCBottomSheetPresentationControllerDelegate,

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -55,7 +55,12 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
                                                        handler:self.completionHandler];
   action.accessibilityIdentifier = self.accessibilityIdentifier;
   action.accessibilityLabel = self.accessibilityLabel;
+  action.titleColor = self.titleColor;
   return action;
+}
+
+- (void)setTitleColor:(UIColor *)titleColor {
+  _titleColor = [titleColor copy];
 }
 
 @end
@@ -309,7 +314,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   cell.tintColor = self.actionTintColor;
   cell.imageRenderingMode = self.imageRenderingMode;
   cell.addLeadingPadding = self.addLeadingPaddingToCell;
-  cell.actionTextColor = self.actionTextColor;
+  cell.actionTextColor = action.titleColor ?: self.actionTextColor;
   return cell;
 }
 

--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -700,4 +700,63 @@ static NSString *const kLongTitle5Arabic =
   [self generateSnapshotAndVerifyForView:controller.view];
 }
 
+- (void)testActionSheetWithCustomActionSheetControllerTitleColorAndOneActionCustomTitleColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+  // When
+  controller.actionTextColor = UIColor.blueColor;
+  action2.titleColor = UIColor.orangeColor;
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+- (void)testActionSheetWhenEveryActionHasCustomTitleColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+  // When
+  action1.titleColor = UIColor.blueColor;
+  action2.titleColor = UIColor.redColor;
+  action3.titleColor = UIColor.greenColor;
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -181,17 +181,70 @@
 - (void)testSetActionItemColor {
   // Given
   UIColor *fakeColor = UIColor.orangeColor;
-  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo" image:nil handler:nil];
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
   [self.actionSheet addAction:action];
-  
+
   // When
   action.titleColor = fakeColor;
-  [self.actionSheet.view setNeedsLayout];
-  [self.actionSheet.view layoutIfNeeded];
-  
+
   // Then
-  MDCActionSheetItemTableViewCell *cell = [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
-  XCTAssertEqualObjects(cell.textLabel.textColor, fakeColor);
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionLabel.textColor, fakeColor);
+}
+
+- (void)testSetActionItemColorForOnlyOneCell {
+  // Given
+  UIColor *fakeCellColor = UIColor.orangeColor;
+  UIColor *fakeControllerColor = UIColor.blueColor;
+  MDCActionSheetAction *actionOne = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionTwo = [MDCActionSheetAction actionWithTitle:@"Bar"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionThree = [MDCActionSheetAction actionWithTitle:@"Baz"
+                                                                      image:nil
+                                                                    handler:nil];
+  [self.actionSheet addAction:actionOne];
+  [self.actionSheet addAction:actionTwo];
+  [self.actionSheet addAction:actionThree];
+
+  // When
+  actionTwo.titleColor = fakeCellColor;
+  self.actionSheet.actionTextColor = fakeControllerColor;
+
+  // Then
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+  for (NSUInteger index = 0; index < cells.count; ++index) {
+    MDCActionSheetItemTableViewCell *cell = cells[index];
+    if (index == 1) {
+      XCTAssertEqualObjects(cell.actionLabel.textColor, fakeCellColor);
+    } else {
+      XCTAssertEqualObjects(cell.actionLabel.textColor, fakeControllerColor);
+    }
+  }
+}
+
+- (void)testSetActionItemColorThenResetToNilFallsBackToControllerColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
+  action.titleColor = UIColor.blueColor;
+  [self.actionSheet addAction:action];
+
+  // When
+  self.actionSheet.actionTextColor = fakeColor;
+  action.titleColor = nil;
+
+  // Then
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionLabel.textColor, fakeColor);
 }
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -178,4 +178,20 @@
   XCTAssertEqual(cell.actionLabel.accessibilityLabel, action.accessibilityLabel);
 }
 
+- (void)testSetActionItemColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo" image:nil handler:nil];
+  [self.actionSheet addAction:action];
+  
+  // When
+  action.titleColor = fakeColor;
+  [self.actionSheet.view setNeedsLayout];
+  [self.actionSheet.view layoutIfNeeded];
+  
+  // Then
+  MDCActionSheetItemTableViewCell *cell = [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.textLabel.textColor, fakeColor);
+}
+
 @end

--- a/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWhenEveryActionHasCustomTitleColor_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWhenEveryActionHasCustomTitleColor_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:795613a889ad446e2dc25e036ab59282ef94839a724333f12a980e2212b58503
+size 12846

--- a/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWithCustomActionSheetControllerTitleColorAndOneActionCustomTitleColor_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWithCustomActionSheetControllerTitleColorAndOneActionCustomTitleColor_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba87d4771c565f3279a670a83932debbdabe50cad8b043a03409792005b4b20d
+size 12917


### PR DESCRIPTION
Allows clients to customize the title of individual actions. Currently MDCActionSheetController allows clients to customize the title color on the controller itself but this allows for each action to have its own color. The controller will maintain its API so that clients can have a convenience of coloring all actions but also the ability to customize each individual action if that is what their design asks for.

Related to #7549 