### PR TITLE
[ActionSheet] Allow clients to customize the tint color of actions 

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -274,6 +274,13 @@ typedef void (^MDCActionSheetHandler)(MDCActionSheetAction *_Nonnull action);
  */
 @property(nonatomic, nullable, copy) NSString *accessibilityIdentifier;
 
+/**
+ The tint color of the action.
+
+ @note If no @c tintColor is provided then the @c actionTintColor from the controller will be used.
+ */
+@property(nonatomic, copy, nullable) UIColor *tintColor;
+
 @end
 
 @interface MDCActionSheetController (ToBeDeprecated)

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -276,7 +276,7 @@ typedef void (^MDCActionSheetHandler)(MDCActionSheetAction *_Nonnull action);
 
 /**
  The color of the action title.
- 
+
  @note If no @c titleColor is provided then the @c actionTextColor from the controller will be used.
  */
 @property(nonatomic, copy, nullable) UIColor *titleColor;

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -56,7 +56,12 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
                                                        handler:self.completionHandler];
   action.accessibilityIdentifier = self.accessibilityIdentifier;
   action.accessibilityLabel = self.accessibilityLabel;
+  action.tintColor = self.tintColor;
   return action;
+}
+
+- (void)setTintColor:(UIColor *)tintColor {
+  _tintColor = [tintColor copy];
 }
 
 @end
@@ -310,7 +315,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   cell.inkColor = self.inkColor;
   cell.rippleColor = self.rippleColor;
   cell.enableRippleBehavior = self.enableRippleBehavior;
-  cell.tintColor = self.actionTintColor;
+  cell.tintColor = action.tintColor ?: self.actionTintColor;
   cell.imageRenderingMode = self.imageRenderingMode;
   cell.addLeadingPadding = self.addLeadingPaddingToCell;
   cell.actionTextColor = self.actionTextColor;

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -60,10 +60,6 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   return action;
 }
 
-- (void)setTintColor:(UIColor *)tintColor {
-  _tintColor = [tintColor copy];
-}
-
 @end
 
 @interface MDCActionSheetController () <MDCBottomSheetPresentationControllerDelegate,

--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -700,11 +700,7 @@ static NSString *const kLongTitle5Arabic =
   [self generateSnapshotAndVerifyForView:controller.view];
 }
 
-<<<<<<< HEAD
-- (void)testActionSheetWithCustomActionSheetControllerTintColorAndOneActionCustomTintColor {
-=======
 - (void)testActionSheetWithCustomActionSheetControllerTitleColorAndOneActionCustomTitleColor {
->>>>>>> develop
   // Given
   MDCActionSheetAction *action1 =
       [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
@@ -725,24 +721,15 @@ static NSString *const kLongTitle5Arabic =
   [controller addAction:action3];
 
   // When
-<<<<<<< HEAD
-  controller.actionTintColor = UIColor.blueColor;
-  action2.tintColor = UIColor.orangeColor;
-=======
   controller.actionTextColor = UIColor.blueColor;
   action2.titleColor = UIColor.orangeColor;
->>>>>>> develop
   controller.view.bounds = CGRectMake(0, 0, 320, 200);
 
   // Then
   [self generateSnapshotAndVerifyForView:controller.view];
 }
 
-<<<<<<< HEAD
-- (void)testActionSheetWhenEveryActionHasCustomTintColor {
-=======
 - (void)testActionSheetWhenEveryActionHasCustomTitleColor {
->>>>>>> develop
   // Given
   MDCActionSheetAction *action1 =
       [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
@@ -763,15 +750,68 @@ static NSString *const kLongTitle5Arabic =
   [controller addAction:action3];
 
   // When
-<<<<<<< HEAD
-  action1.tintColor = UIColor.blueColor;
-  action2.tintColor = UIColor.redColor;
-  action3.tintColor = UIColor.greenColor;
-=======
   action1.titleColor = UIColor.blueColor;
   action2.titleColor = UIColor.redColor;
   action3.titleColor = UIColor.greenColor;
->>>>>>> develop
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+- (void)testActionSheetWithCustomActionSheetControllerTintColorAndOneActionCustomTintColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+  // When
+  controller.actionTintColor = UIColor.blueColor;
+  action2.tintColor = UIColor.orangeColor;
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+- (void)testActionSheetWhenEveryActionHasCustomTintColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+  // When
+  action1.tintColor = UIColor.blueColor;
+  action2.tintColor = UIColor.redColor;
+  action3.tintColor = UIColor.greenColor;
   controller.view.bounds = CGRectMake(0, 0, 320, 200);
 
   // Then

--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -700,4 +700,64 @@ static NSString *const kLongTitle5Arabic =
   [self generateSnapshotAndVerifyForView:controller.view];
 }
 
+- (void)testActionSheetWithCustomActionSheetControllerTintColorAndOneActionCustomTintColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+   // When
+  controller.actionTintColor = UIColor.blueColor;
+  action2.tintColor = UIColor.orangeColor;
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+   // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+ - (void)testActionSheetWhenEveryActionHasCustomTintColor {
+  // Given
+  MDCActionSheetAction *action1 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action2 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetAction *action3 =
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
+  MDCActionSheetController *controller =
+      [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [controller addAction:action1];
+  [controller addAction:action2];
+  [controller addAction:action3];
+
+   // When
+  action1.tintColor = UIColor.blueColor;
+  action2.tintColor = UIColor.redColor;
+  action3.tintColor = UIColor.greenColor;
+  controller.view.bounds = CGRectMake(0, 0, 320, 200);
+
+   // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+
 @end

--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -720,16 +720,16 @@ static NSString *const kLongTitle5Arabic =
   [controller addAction:action2];
   [controller addAction:action3];
 
-   // When
+  // When
   controller.actionTintColor = UIColor.blueColor;
   action2.tintColor = UIColor.orangeColor;
   controller.view.bounds = CGRectMake(0, 0, 320, 200);
 
-   // Then
+  // Then
   [self generateSnapshotAndVerifyForView:controller.view];
 }
 
- - (void)testActionSheetWhenEveryActionHasCustomTintColor {
+- (void)testActionSheetWhenEveryActionHasCustomTintColor {
   // Given
   MDCActionSheetAction *action1 =
       [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
@@ -749,15 +749,14 @@ static NSString *const kLongTitle5Arabic =
   [controller addAction:action2];
   [controller addAction:action3];
 
-   // When
+  // When
   action1.tintColor = UIColor.blueColor;
   action2.tintColor = UIColor.redColor;
   action3.tintColor = UIColor.greenColor;
   controller.view.bounds = CGRectMake(0, 0, 320, 200);
 
-   // Then
+  // Then
   [self generateSnapshotAndVerifyForView:controller.view];
 }
-
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -234,7 +234,7 @@
   MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
                                                                  image:nil
                                                                handler:nil];
-  action.tintColor = UIColor.blueColor;
+  action.titleColor = UIColor.blueColor;
   [self.actionSheet addAction:action];
 
   // When
@@ -246,5 +246,75 @@
       [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
   XCTAssertEqualObjects(cell.actionLabel.textColor, fakeColor);
 }
+
+- (void)testSetActionItemTintColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
+  [self.actionSheet addAction:action];
+
+  // When
+  action.tintColor = fakeColor;
+
+  // Then
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
+}
+
+- (void)testSetActionItemTintColorForOnlyOneCell {
+  // Given
+  UIColor *fakeCellColor = UIColor.orangeColor;
+  UIColor *fakeControllerColor = UIColor.blueColor;
+  MDCActionSheetAction *actionOne = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionTwo = [MDCActionSheetAction actionWithTitle:@"Bar"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionThree = [MDCActionSheetAction actionWithTitle:@"Baz"
+                                                                      image:nil
+                                                                    handler:nil];
+  [self.actionSheet addAction:actionOne];
+  [self.actionSheet addAction:actionTwo];
+  [self.actionSheet addAction:actionThree];
+
+  // When
+  actionTwo.tintColor = fakeCellColor;
+  self.actionSheet.actionTintColor = fakeControllerColor;
+
+  // Then
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+  for (NSUInteger index = 0; index < cells.count; ++index) {
+    MDCActionSheetItemTableViewCell *cell = cells[index];
+    if (index == 1) {
+      XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeCellColor);
+    } else {
+      XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeControllerColor);
+    }
+  }
+}
+
+- (void)testSetActionItemTintColorThenResetToNilFallsBackToControllerTintColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
+  action.tintColor = UIColor.blueColor;
+  [self.actionSheet addAction:action];
+
+  // When
+  self.actionSheet.actionTintColor = fakeColor;
+  action.tintColor = nil;
+
+  // Then
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
+}
+
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -186,16 +186,16 @@
                                                                handler:nil];
   [self.actionSheet addAction:action];
 
-   // When
+  // When
   action.tintColor = fakeColor;
 
-   // Then
+  // Then
   MDCActionSheetItemTableViewCell *cell =
       [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
   XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
 }
 
- - (void)testSetActionItemColorForOnlyOneCell {
+- (void)testSetActionItemColorForOnlyOneCell {
   // Given
   UIColor *fakeCellColor = UIColor.orangeColor;
   UIColor *fakeControllerColor = UIColor.blueColor;
@@ -212,11 +212,11 @@
   [self.actionSheet addAction:actionTwo];
   [self.actionSheet addAction:actionThree];
 
-   // When
+  // When
   actionTwo.tintColor = fakeCellColor;
   self.actionSheet.actionTintColor = fakeControllerColor;
 
-   // Then
+  // Then
   NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
   for (NSUInteger index = 0; index < cells.count; ++index) {
     MDCActionSheetItemTableViewCell *cell = cells[index];
@@ -228,7 +228,7 @@
   }
 }
 
- - (void)testSetActionItemColorThenResetToNilFallsBackToControllerColor {
+- (void)testSetActionItemColorThenResetToNilFallsBackToControllerColor {
   // Given
   UIColor *fakeColor = UIColor.orangeColor;
   MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
@@ -237,11 +237,11 @@
   action.tintColor = UIColor.blueColor;
   [self.actionSheet addAction:action];
 
-   // When
+  // When
   self.actionSheet.actionTintColor = fakeColor;
   action.tintColor = nil;
 
-   // Then
+  // Then
   MDCActionSheetItemTableViewCell *cell =
       [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
   XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -178,6 +178,73 @@
   XCTAssertEqual(cell.actionLabel.accessibilityLabel, action.accessibilityLabel);
 }
 
+- (void)testSetActionItemColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
+  [self.actionSheet addAction:action];
 
+   // When
+  action.tintColor = fakeColor;
+
+   // Then
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
+}
+
+ - (void)testSetActionItemColorForOnlyOneCell {
+  // Given
+  UIColor *fakeCellColor = UIColor.orangeColor;
+  UIColor *fakeControllerColor = UIColor.blueColor;
+  MDCActionSheetAction *actionOne = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionTwo = [MDCActionSheetAction actionWithTitle:@"Bar"
+                                                                    image:nil
+                                                                  handler:nil];
+  MDCActionSheetAction *actionThree = [MDCActionSheetAction actionWithTitle:@"Baz"
+                                                                      image:nil
+                                                                    handler:nil];
+  [self.actionSheet addAction:actionOne];
+  [self.actionSheet addAction:actionTwo];
+  [self.actionSheet addAction:actionThree];
+
+   // When
+  actionTwo.tintColor = fakeCellColor;
+  self.actionSheet.actionTintColor = fakeControllerColor;
+
+   // Then
+  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+  for (NSUInteger index = 0; index < cells.count; ++index) {
+    MDCActionSheetItemTableViewCell *cell = cells[index];
+    if (index == 1) {
+      XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeCellColor);
+    } else {
+      XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeControllerColor);
+    }
+  }
+}
+
+ - (void)testSetActionItemColorThenResetToNilFallsBackToControllerColor {
+  // Given
+  UIColor *fakeColor = UIColor.orangeColor;
+  MDCActionSheetAction *action = [MDCActionSheetAction actionWithTitle:@"Foo"
+                                                                 image:nil
+                                                               handler:nil];
+  action.tintColor = UIColor.blueColor;
+  [self.actionSheet addAction:action];
+
+   // When
+  self.actionSheet.actionTintColor = fakeColor;
+  action.tintColor = nil;
+
+   // Then
+  MDCActionSheetItemTableViewCell *cell =
+      [MDCActionSheetTestHelper getCellFromActionSheet:self.actionSheet atIndex:0];
+  XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
+}
 
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -316,5 +316,4 @@
   XCTAssertEqualObjects(cell.actionImageView.tintColor, fakeColor);
 }
 
-
 @end

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -178,4 +178,6 @@
   XCTAssertEqual(cell.actionLabel.accessibilityLabel, action.accessibilityLabel);
 }
 
+
+
 @end

--- a/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWhenEveryActionHasCustomTintColor_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWhenEveryActionHasCustomTintColor_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85777b4e4aceb2d3b1a0127094af10db48092ee11cf1a784c4272dcbfd91f620
+size 13316

--- a/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWithCustomActionSheetControllerTintColorAndOneActionCustomTintColor_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testActionSheetWithCustomActionSheetControllerTintColorAndOneActionCustomTintColor_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f32e90529e1cbeb4dde2622b94d818fd661043254008e1fe28fb8b0bd1f23f7
+size 13316


### PR DESCRIPTION
Allows clients to customize the tint of individual actions. Currently MDCActionSheetController allows clients to customize the tint color on the controller itself but this allows for each action to have its own color. The controller will maintain its API so that clients can have a convenience of coloring all actions but also the ability to customize each individual action if that is what their design asks for.

Closes to #7549