### PR TITLE
[Git LFS] Fix broken LFS handling between branches.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
+# snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
 .gitattributes merge=gitattributes


### PR DESCRIPTION
Fixes Git LFS handling between branches. Specifically resolves the bug
introduced by the recent changes that causes some file to be incorrectly
marked as missing/tracked.

Closes #8233