### PR TITLE
[BottomNavigation] Don't assign `accessibilityIdentifier` to the item view

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -417,7 +417,7 @@ static NSString *const kOfAnnouncement = @"of";
     } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
       itemView.title = newValue;
     } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityIdentifier))]) {
-      itemView.accessibilityIdentifier = newValue;
+      itemView.accessibilityElementIdentifier = newValue;
     } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityLabel))]) {
       itemView.accessibilityLabel = newValue;
     } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityHint))]) {
@@ -527,7 +527,7 @@ static NSString *const kOfAnnouncement = @"of";
     itemView.titleVisibility = self.titleVisibility;
     itemView.titleBelowIcon = self.isTitleBelowIcon;
     itemView.accessibilityValue = item.accessibilityValue;
-    itemView.accessibilityIdentifier = item.accessibilityIdentifier;
+    itemView.accessibilityElementIdentifier = item.accessibilityIdentifier;
     itemView.accessibilityLabel = item.accessibilityLabel;
     itemView.accessibilityHint = item.accessibilityHint;
     itemView.isAccessibilityElement = item.isAccessibilityElement;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -51,6 +51,8 @@
 
 @property(nonatomic, assign) CGFloat contentVerticalMargin;
 @property(nonatomic, assign) CGFloat contentHorizontalMargin;
+/** The @c accessibilityIdentifier of the accessibility element for this view. */
+@property(nonatomic, copy, nullable) NSString *accessibilityElementIdentifier;
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.h
@@ -23,13 +23,13 @@
 @property(nonatomic, assign) BOOL titleBelowIcon;
 @property(nonatomic, assign) BOOL selected;
 @property(nonatomic, assign) MDCBottomNavigationBarTitleVisibility titleVisibility;
-@property(nonatomic, strong) MDCInkView *inkView;
-@property(nonatomic, strong) MDCRippleTouchController *rippleTouchController;
+@property(nonatomic, strong, nonnull) MDCInkView *inkView;
+@property(nonatomic, strong, nonnull) MDCRippleTouchController *rippleTouchController;
 @property(nonatomic, assign) UIOffset titlePositionAdjustment;
 
-@property(nonatomic, copy) NSString *badgeValue;
-@property(nonatomic, copy) NSString *title;
-@property(nonatomic, strong) UIFont *itemTitleFont UI_APPEARANCE_SELECTOR;
+@property(nonatomic, copy, nullable) NSString *badgeValue;
+@property(nonatomic, copy, nullable) NSString *title;
+@property(nonatomic, strong, nullable) UIFont *itemTitleFont UI_APPEARANCE_SELECTOR;
 
 /**
  The number of lines available for rendering the title of this item.  Defaults to 1.
@@ -40,14 +40,14 @@
 // Default = YES
 @property(nonatomic, assign) BOOL truncatesTitle;
 
-@property(nonatomic, strong) UIButton *button;
-@property(nonatomic, strong) UIImage *image;
-@property(nonatomic, strong) UIImage *selectedImage;
+@property(nonatomic, strong, nonnull) UIButton *button;
+@property(nonatomic, strong, nullable) UIImage *image;
+@property(nonatomic, strong, nullable) UIImage *selectedImage;
 
-@property(nonatomic, strong) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
-@property(nonatomic, strong) UIColor *selectedItemTitleColor;
+@property(nonatomic, strong, nullable) UIColor *badgeColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *selectedItemTintColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *unselectedItemTintColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, nullable) UIColor *selectedItemTitleColor;
 
 @property(nonatomic, assign) CGFloat contentVerticalMargin;
 @property(nonatomic, assign) CGFloat contentHorizontalMargin;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -578,11 +578,11 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   return self.button.accessibilityValue;
 }
 
-- (void)setAccessibilityIdentifier:(NSString *)accessibilityIdentifier {
-  self.button.accessibilityIdentifier = accessibilityIdentifier;
+- (void)setAccessibilityElementIdentifier:(NSString *)accessibilityElementIdentifier {
+  self.button.accessibilityIdentifier = accessibilityElementIdentifier;
 }
 
-- (NSString *)accessibilityIdentifier {
+- (NSString *)accessibilityElementIdentifier {
   return self.button.accessibilityIdentifier;
 }
 

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
@@ -267,7 +267,9 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertEqualObjects(itemView.accessibilityIdentifier, self.barItem.accessibilityIdentifier);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityIdentifier,
+                        self.barItem.accessibilityIdentifier);
 }
 
 - (void)testChangeAccessibilityIdentifierToEmptyString {
@@ -276,7 +278,9 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertEqualObjects(itemView.accessibilityIdentifier, self.barItem.accessibilityIdentifier);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityIdentifier,
+                        self.barItem.accessibilityIdentifier);
 }
 
 - (void)testChangeAccessibilityIdentifierToNil {
@@ -285,7 +289,8 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertNil(itemView.accessibilityIdentifier);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertNil(itemViewButton.accessibilityIdentifier);
 }
 
 - (void)testChangeIsAccessibilityElementNoToYes {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -540,6 +540,30 @@
   XCTAssertNil(result);
 }
 
+- (NSInteger)countOfViewsWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+                                        fromRootView:(UIView *)view {
+  NSInteger sum = [view.accessibilityIdentifier isEqualToString:accessibilityIdentifier] ? 1 : 0;
+  for (UIView *subview in view.subviews) {
+    sum += [self countOfViewsWithAccessibilityIdentifier:accessibilityIdentifier
+                                            fromRootView:subview];
+  }
+  return sum;
+}
+
+- (void)testSettingAccessibilityIdentifierAffectsExactlyOneSubview {
+  // Given
+  UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:@"Title" image:nil tag:1];
+  item.accessibilityIdentifier = @"__i_d__";
+
+  // When
+  self.bottomNavBar.items = @[ item ];
+
+  // Then
+  XCTAssertEqual([self countOfViewsWithAccessibilityIdentifier:item.accessibilityIdentifier
+                                                  fromRootView:self.bottomNavBar],
+                 1);
+}
+
 #pragma mark - traitCollectionDidChangeBlock
 
 - (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -156,16 +156,28 @@
   XCTAssertNil(self.bottomNavBar.selectedItem);
 }
 
-- (void)testAccessibilityIdentifier {
-  NSString *oldIdentifier = @"oldIdentifier";
-  NSString *newIdentifier = @"newIdentifier";
-  UITabBarItem *tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Home" image:nil tag:0];
-  tabBarItem.accessibilityIdentifier = oldIdentifier;
-  MDCBottomNavigationBar *bar = [[MDCBottomNavigationBar alloc] init];
-  bar.items = @[ tabBarItem ];
-  XCTAssertEqualObjects(bar.itemViews.firstObject.accessibilityIdentifier, oldIdentifier);
-  tabBarItem.accessibilityIdentifier = newIdentifier;
-  XCTAssertEqualObjects(bar.itemViews.firstObject.accessibilityIdentifier, newIdentifier);
+- (NSInteger)countOfViewsWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+                                        fromRootView:(UIView *)view {
+  NSInteger sum = [view.accessibilityIdentifier isEqualToString:accessibilityIdentifier] ? 1 : 0;
+  for (UIView *subview in view.subviews) {
+    sum += [self countOfViewsWithAccessibilityIdentifier:accessibilityIdentifier
+                                            fromRootView:subview];
+  }
+  return sum;
+}
+
+- (void)testSettingAccessibilityIdentifierAffectsExactlyOneSubview {
+  // Given
+  UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:@"Title" image:nil tag:1];
+  item.accessibilityIdentifier = @"__i_d__";
+
+  // When
+  self.bottomNavBar.items = @[ item ];
+
+  // Then
+  XCTAssertEqual([self countOfViewsWithAccessibilityIdentifier:item.accessibilityIdentifier
+                                                  fromRootView:self.bottomNavBar],
+                 1);
 }
 
 - (void)testAccessibilityLabelInitialValue {
@@ -538,30 +550,6 @@
 
   // Then
   XCTAssertNil(result);
-}
-
-- (NSInteger)countOfViewsWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
-                                        fromRootView:(UIView *)view {
-  NSInteger sum = [view.accessibilityIdentifier isEqualToString:accessibilityIdentifier] ? 1 : 0;
-  for (UIView *subview in view.subviews) {
-    sum += [self countOfViewsWithAccessibilityIdentifier:accessibilityIdentifier
-                                            fromRootView:subview];
-  }
-  return sum;
-}
-
-- (void)testSettingAccessibilityIdentifierAffectsExactlyOneSubview {
-  // Given
-  UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:@"Title" image:nil tag:1];
-  item.accessibilityIdentifier = @"__i_d__";
-
-  // When
-  self.bottomNavBar.items = @[ item ];
-
-  // Then
-  XCTAssertEqual([self countOfViewsWithAccessibilityIdentifier:item.accessibilityIdentifier
-                                                  fromRootView:self.bottomNavBar],
-                 1);
 }
 
 #pragma mark - traitCollectionDidChangeBlock


### PR DESCRIPTION
Creates an explicit assignment of `UITabBarItem`'s `accessibilityIdentifier`
to the actual accessibility element of the item view.

The item views should not have accessibility identifiers because they are not
accessibility elements. Reusing the same identifier for both the button and
the view makes it harder to perform automated UI tests.

Closes #8137
