### PR TITLE
[BottomNavigation] Propagate `accessibilityHint` to the accessibility element.

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBar.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBar.m
@@ -547,7 +547,13 @@ static NSString *const kOfAnnouncement = @"of";
           key, kMaterialBottomNavigationStringsTableName, [[self class] bundle], kOfString);
       NSString *localizedPosition =
           [NSString localizedStringWithFormat:itemOfTotalString, (i + 1), (int)items.count];
-      itemView.button.accessibilityHint = localizedPosition;
+      // Allow a custom `accessibilityHint` to be assigned even if "faking" a tab bar is enabled.
+      if (itemView.button.accessibilityHint.length) {
+        itemView.button.accessibilityHint =
+            [NSString stringWithFormat:@"%@. %@", localizedPosition, itemView.accessibilityHint];
+      } else {
+        itemView.button.accessibilityHint = localizedPosition;
+      }
     }
     if (item.image) {
       itemView.image = item.image;

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -578,6 +578,15 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
   return self.button.accessibilityValue;
 }
 
+- (void)setAccessibilityHint:(NSString *)accessibilityHint {
+  [super setAccessibilityHint:accessibilityHint];
+  self.button.accessibilityHint = accessibilityHint;
+}
+
+- (NSString *)accessibilityHint {
+  return self.button.accessibilityHint;
+}
+
 - (void)setAccessibilityIdentifier:(NSString *)accessibilityIdentifier {
   self.button.accessibilityIdentifier = accessibilityIdentifier;
 }

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarKVOTests.m
@@ -213,7 +213,8 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertEqualObjects(itemView.accessibilityHint, self.barItem.accessibilityHint);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityHint, self.barItem.accessibilityHint);
 }
 
 - (void)testChangeAccessibilityHintToEmptyString {
@@ -222,7 +223,8 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertEqualObjects(itemView.accessibilityHint, self.barItem.accessibilityHint);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityHint, self.barItem.accessibilityHint);
 }
 
 - (void)testChangeAccessibilityHintToNil {
@@ -231,7 +233,8 @@ static UIImage *fakeImage() {
 
   // Then
   MDCBottomNavigationItemView *itemView = self.bottomNavigationBar.itemViews.firstObject;
-  XCTAssertNil(itemView.accessibilityHint);
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertNil(itemViewButton.accessibilityHint);
 }
 
 - (void)testChangeAccessibilityValueToNonEmptyString {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -203,6 +203,7 @@
   UITabBarItem *tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Home" image:nil tag:0];
   tabBarItem.accessibilityHint = initialHint;
   MDCBottomNavigationBar *bar = [[MDCBottomNavigationBar alloc] init];
+
   // When
   bar.items = @[ tabBarItem ];
 
@@ -225,7 +226,9 @@
   tabBarItem.accessibilityHint = newHint;
 
   // Then
-  XCTAssertEqualObjects(bar.itemViews.firstObject.accessibilityHint, newHint);
+  MDCBottomNavigationItemView *itemView = bar.itemViews.firstObject;
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityHint, newHint);
 }
 
 - (void)testIsAccessibilityElementInitialValue {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -540,6 +540,32 @@
   XCTAssertNil(result);
 }
 
+- (NSInteger)countOfButtonsWithAccessibilityHint:(NSString *)accessibilityHint
+                                    fromRootView:(UIView *)view {
+  NSInteger count = ([view isKindOfClass:[UIButton class]] &&
+                     [view.accessibilityHint isEqualToString:accessibilityHint])
+                        ? 1
+                        : 0;
+  for (UIView *subview in view.subviews) {
+    count += [self countOfButtonsWithAccessibilityHint:accessibilityHint fromRootView:subview];
+  }
+  return count;
+}
+
+- (void)testSettingAccessibilityHintPropagatesToOneUIButtonSubview {
+  // Given
+  UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:@"Title" image:nil tag:9];
+  item.accessibilityHint = @"__h_i_n_t__";
+
+  // When
+  self.bottomNavBar.items = @[ item ];
+
+  // Then
+  XCTAssertEqual([self countOfButtonsWithAccessibilityHint:item.accessibilityHint
+                                              fromRootView:self.bottomNavBar],
+                 1);
+}
+
 #pragma mark - traitCollectionDidChangeBlock
 
 - (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -207,7 +207,9 @@
   bar.items = @[ tabBarItem ];
 
   // Then
-  XCTAssertEqualObjects(bar.itemViews.firstObject.accessibilityHint, initialHint);
+  MDCBottomNavigationItemView *itemView = bar.itemViews.firstObject;
+  UIButton *itemViewButton = itemView.button;
+  XCTAssertEqualObjects(itemViewButton.accessibilityHint, initialHint);
 }
 
 - (void)testAccessibilityHintValueChanged {

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarTests.m
@@ -210,7 +210,13 @@
   // Then
   MDCBottomNavigationItemView *itemView = bar.itemViews.firstObject;
   UIButton *itemViewButton = itemView.button;
-  XCTAssertEqualObjects(itemViewButton.accessibilityHint, initialHint);
+  if (@available(iOS 10.0, *)) {
+    XCTAssertEqualObjects(itemViewButton.accessibilityHint, initialHint);
+  } else {
+    // On iOS 9, the bar "fakes" being a tab bar and modifies the hint.
+    XCTAssertTrue([itemViewButton.accessibilityHint containsString:initialHint],
+                  @"(%@) does not contain (%@)", itemViewButton.accessibilityHint, initialHint);
+  }
 }
 
 - (void)testAccessibilityHintValueChanged {
@@ -547,10 +553,16 @@
 
 - (NSInteger)countOfButtonsWithAccessibilityHint:(NSString *)accessibilityHint
                                     fromRootView:(UIView *)view {
-  NSInteger count = ([view isKindOfClass:[UIButton class]] &&
-                     [view.accessibilityHint isEqualToString:accessibilityHint])
-                        ? 1
-                        : 0;
+  BOOL foundMatchingElement = NO;
+  if (@available(iOS 10.0, *)) {
+    foundMatchingElement = ([view isKindOfClass:[UIButton class]] &&
+                            [view.accessibilityHint isEqualToString:accessibilityHint]);
+  } else {
+    // Accounts for the "fake" tab bar behavior that modifies the `accessibilityHint` on iOS 9.
+    foundMatchingElement = ([view isKindOfClass:[UIButton class]] &&
+                            [view.accessibilityHint containsString:accessibilityHint]);
+  }
+  NSInteger count = foundMatchingElement ? 1 : 0;
   for (UIView *subview in view.subviews) {
     count += [self countOfButtonsWithAccessibilityHint:accessibilityHint fromRootView:subview];
   }


### PR DESCRIPTION
The UIButton subview of the Bottom Navigation bar should be the
one receiving the `accessibilityHint` value from the UITabBarItem. There's no
ill effect if the itemView also receives the hint, and preserving that
behavior is less likely to break clients.
    
In the long term, it's reasonable to remove the `accessibilityHint` from the
item view directly, since it's not an accessibility element and doesn't need
the hint to be set.
    
Closes #7290
