### PR TITLE
[Buttons] Replace mdc_legacyFontScaling usage with adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable.

### DIFF
--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -69,7 +69,7 @@ class ButtonsDynamicTypeViewController: UIViewController {
     flatButtonDynamicLegacy.translatesAutoresizingMaskIntoConstraints = false
     flatButtonDynamicLegacy.addTarget(self, action: #selector(tap), for: .touchUpInside)
     flatButtonDynamicLegacy.mdc_adjustsFontForContentSizeCategory = true
-    flatButtonDynamicLegacy.mdc_legacyFontScaling = true
+    flatButtonDynamicLegacy.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = true
     view.addSubview(flatButtonDynamicLegacy)
 
     let views = [

--- a/components/Buttons/tests/snapshot/ButtonCustomTraitCollectionSnapshotTests.m
+++ b/components/Buttons/tests/snapshot/ButtonCustomTraitCollectionSnapshotTests.m
@@ -54,7 +54,7 @@
   self.button = [[ButtonDynamicTypeSnapshotTestFakeButton alloc] init];
   [self.button setTitle:@"Material" forState:UIControlStateNormal];
   self.button.mdc_adjustsFontForContentSizeCategory = YES;
-  self.button.mdc_legacyFontScaling = NO;
+  self.button.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
   MDCFontScaler *fontScaler = [MDCFontScaler scalerForMaterialTextStyle:MDCTextStyleSubtitle1];
   UIFont *buttonFont = [UIFont systemFontOfSize:14];
   buttonFont = [fontScaler scaledFontWithFont:buttonFont];


### PR DESCRIPTION
mdc_legacyFontScaling is deprecated and will be deleted once all MDC usage is removed.

Part of https://github.com/material-components/material-components-ios/issues/8243