### PR TITLE
[ActionSheet] Add dark mode support to theming extension

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -83,6 +83,7 @@ Pod::Spec.new do |mdc|
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/Elevation"
+    extension.dependency "MaterialComponents/private/Color"
     extension.dependency "MaterialComponents/schemes/Container"
 
     extension.test_spec 'UnitTests' do |unit_tests|

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -82,6 +82,7 @@ Pod::Spec.new do |mdc|
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
     extension.source_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}", "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
+    extension.dependency "MaterialComponents/Elevation"
     extension.dependency "MaterialComponents/schemes/Container"
 
     extension.test_spec 'UnitTests' do |unit_tests|

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -49,6 +49,7 @@ mdc_extension_objc_library(
     deps = [
         ":ActionSheet",
         "//components/Elevation",
+        "//components/private/Color",
         "//components/schemes/Container",
     ],
 )

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -48,6 +48,7 @@ mdc_extension_objc_library(
     name = "Theming",
     deps = [
         ":ActionSheet",
+        "//components/Elevation",
         "//components/schemes/Container",
     ],
 )

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExampleViewController.m
@@ -100,7 +100,7 @@
   return @{
     @"breadcrumbs" : @[ @"Action Sheet", @"Action Sheet" ],
     @"primaryDemo" : @YES,
-    @"presentable" : @NO
+    @"presentable" : @YES,
   };
 }
 

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -366,7 +366,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.view.backgroundColor = backgroundColor;
   self.tableView.backgroundColor = backgroundColor;
   self.header.backgroundColor = backgroundColor;
-  [self.tableView reloadData];
+  //[self.tableView reloadData];
 }
 
 - (void)setTitleTextColor:(UIColor *)titleTextColor {

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -366,6 +366,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.view.backgroundColor = backgroundColor;
   self.tableView.backgroundColor = backgroundColor;
   self.header.backgroundColor = backgroundColor;
+  [self.tableView reloadData];
 }
 
 - (void)setTitleTextColor:(UIColor *)titleTextColor {

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -366,7 +366,6 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.view.backgroundColor = backgroundColor;
   self.tableView.backgroundColor = backgroundColor;
   self.header.backgroundColor = backgroundColor;
-  //[self.tableView reloadData];
 }
 
 - (void)setTitleTextColor:(UIColor *)titleTextColor {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -59,12 +59,16 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.rippleColor = rippleColor;
   self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
                                          UITraitCollection *_Nullable previousTraitCollection) {
-    if (colorScheme.elevationOverlayEnabledForDarkMode) {
-      actionSheet.backgroundColor = [colorScheme.surfaceColor
-          mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
-                                     elevation:actionSheet.view.mdc_absoluteElevation];
-    } else {
-      actionSheet.backgroundColor = colorScheme.surfaceColor;
+    if (@available(iOS 13.0, *)) {
+      if ([actionSheet.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+        if (colorScheme.elevationOverlayEnabledForDarkMode) {
+          actionSheet.backgroundColor = [colorScheme.surfaceColor
+                                         mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
+                                         elevation:actionSheet.view.mdc_absoluteElevation];
+        } else {
+          actionSheet.backgroundColor = colorScheme.surfaceColor;
+        }
+      }
     }
   };
 }

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -66,15 +66,15 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
         [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
       }
     };
-  self.mdc_elevationDidChangeBlock =
-      ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
-        if ([object isKindOfClass:[MDCActionSheetController class]]) {
-          MDCActionSheetController *actionSheet = (MDCActionSheetController *)object;
-          [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-        }
-      };
-    }
-  #endif
+    self.mdc_elevationDidChangeBlock =
+        ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
+          if ([object isKindOfClass:[MDCActionSheetController class]]) {
+            MDCActionSheetController *actionSheet = (MDCActionSheetController *)object;
+            [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+          }
+        };
+  }
+#endif
 }
 
 - (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,18 +57,17 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
-  #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
-    if (@available(iOS 13.0, *)) {
-  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
-                                         UITraitCollection *_Nullable previousTraitCollection) {
-
-    if ([actionSheet.traitCollection
-            hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
-      [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-    }
-  };
-            }
-      #endif
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
+                                           UITraitCollection *_Nullable previousTraitCollection) {
+      if ([actionSheet.traitCollection
+              hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+        [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+      }
+    };
+  }
+#endif
   self.mdc_elevationDidChangeBlock =
       ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
         if ([object isKindOfClass:[MDCActionSheetController class]]) {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -37,13 +37,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    self.backgroundColor =
-        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
-                                                             elevation:self.view.mdc_absoluteElevation];
-  } else {
-    self.backgroundColor = colorScheme.surfaceColor;
-  }
+  [self applyBackgroundColorToActionSheet:self];
   if (self.message && ![self.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
     self.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
@@ -57,6 +51,19 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
+  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController * _Nonnull actionSheet, UITraitCollection * _Nullable previousTraitCollection) {
+    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+  }
+}
+
+- (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet withColorScheme:(id<MDCColorScheming>)colorScheme {
+  if (colorScheme.elevationOverlayEnabledForDarkMode) {
+    self.backgroundColor =
+        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
+                                                             elevation:self.view.mdc_absoluteElevation];
+  } else {
+    self.backgroundColor = colorScheme.surfaceColor;
+  }
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MDCActionSheetController+MaterialTheming.h"
+#import "MaterialElevation.h"
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
@@ -37,7 +38,13 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  self.backgroundColor = colorScheme.surfaceColor;
+  if (colorScheme.elevationOverlayEnabledForDarkMode) {
+    self.backgroundColor =
+        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
+                                                             elevation:self.mdc_absoluteElevation];
+  } else {
+    self.backgroundColor = colorScheme.surfaceColor;
+  }
   if (self.message && ![self.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
     self.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -59,7 +59,9 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.rippleColor = rippleColor;
   self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
                                          UITraitCollection *_Nullable previousTraitCollection) {
-    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+    if ([actionSheet.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+      [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+    }
   };
   self.mdc_elevationDidChangeBlock =
       ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -73,7 +73,9 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 - (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet
                           withColorScheme:(id<MDCColorScheming>)colorScheme {
   if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    actionSheet.backgroundColor = [self dynamicColorWithColor:colorScheme.surfaceColor elevation:actionSheet.view.mdc_absoluteElevation];
+    actionSheet.backgroundColor =
+        [self dynamicColorWithColor:colorScheme.surfaceColor
+                          elevation:actionSheet.view.mdc_absoluteElevation];
   } else {
     actionSheet.backgroundColor = colorScheme.surfaceColor;
   }

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -38,9 +38,9 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
   if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    self.backgroundColor =
-        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
-                                                             elevation:self.view.mdc_absoluteElevation];
+    self.backgroundColor = [colorScheme.surfaceColor
+        mdc_resolvedColorWithTraitCollection:self.traitCollection
+                                   elevation:self.view.mdc_absoluteElevation];
   } else {
     self.backgroundColor = colorScheme.surfaceColor;
   }
@@ -57,11 +57,12 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
-  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController * _Nonnull actionSheet, UITraitCollection * _Nullable previousTraitCollection) {
-      if (colorScheme.elevationOverlayEnabledForDarkMode) {
-      actionSheet.backgroundColor =
-          [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
-                                                               elevation:actionSheet.view.mdc_absoluteElevation];
+  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
+                                         UITraitCollection *_Nullable previousTraitCollection) {
+    if (colorScheme.elevationOverlayEnabledForDarkMode) {
+      actionSheet.backgroundColor = [colorScheme.surfaceColor
+          mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
+                                     elevation:actionSheet.view.mdc_absoluteElevation];
     } else {
       actionSheet.backgroundColor = colorScheme.surfaceColor;
     }

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,19 +57,17 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
-  self.traitCollectionDidChangeBlock =
-      ^(MDCActionSheetController *_Nonnull actionSheet,
-        UITraitCollection *_Nullable previousTraitCollection) {
-        [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-      };
+  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
+                                         UITraitCollection *_Nullable previousTraitCollection) {
+    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+  };
   self.mdc_elevationDidChangeBlock =
-          ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
-            if ([object isKindOfClass:[MDCActionSheetController class]]) {
-              MDCActionSheetController *actionSheet = (MDCActionSheetController *)actionSheet;
-              [actionSheet applyBackgroundColorToActionSheet:actionSheet
-                                             withColorScheme:colorScheme];
-            }
-          };
+      ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
+        if ([object isKindOfClass:[MDCActionSheetController class]]) {
+          MDCActionSheetController *actionSheet = (MDCActionSheetController *)object;
+          [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+        }
+      };
 }
 
 - (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -61,7 +61,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
       ^(MDCActionSheetController *_Nonnull actionSheet,
         UITraitCollection *_Nullable previousTraitCollection) {
         [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-      } self.mdc_elevationDidChangeBlock =
+      };
+  self.mdc_elevationDidChangeBlock =
           ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
             if ([object isKindOfClass:[MDCActionSheetController class]]) {
               MDCActionSheetController *actionSheet = (MDCActionSheetController *)actionSheet;

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,13 +57,18 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
+  #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+    if (@available(iOS 13.0, *)) {
   self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
                                          UITraitCollection *_Nullable previousTraitCollection) {
+
     if ([actionSheet.traitCollection
             hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
       [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
     }
   };
+            }
+      #endif
   self.mdc_elevationDidChangeBlock =
       ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
         if ([object isKindOfClass:[MDCActionSheetController class]]) {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,20 +57,25 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
-  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
-                                         UITraitCollection *_Nullable previousTraitCollection) {
-    if (@available(iOS 13.0, *)) {
-      if ([actionSheet.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
-        if (colorScheme.elevationOverlayEnabledForDarkMode) {
-          actionSheet.backgroundColor = [colorScheme.surfaceColor
-                                         mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
-                                         elevation:actionSheet.view.mdc_absoluteElevation];
-        } else {
-          actionSheet.backgroundColor = colorScheme.surfaceColor;
-        }
-      }
+  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController * _Nonnull actionSheet, UITraitCollection * _Nullable previousTraitCollection) {
+    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+  }
+  self.mdc_elevationDidChangeBlock = ^(id<MDCElevatable>  _Nonnull object, CGFloat absoluteElevation) {
+    if ([object isKindOfClass:[MDCActionSheetController class]]) {
+      MDCActionSheetController *actionSheet = (MDCActionSheetController *)actionSheet;
+      [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
     }
   };
+}
+
+- (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet withColorScheme:(id<MDCColorScheming>)colorScheme {
+  if (colorScheme.elevationOverlayEnabledForDarkMode) {
+    actionSheet.backgroundColor = [colorScheme.surfaceColor
+                                   mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
+                                   elevation:actionSheet.view.mdc_absoluteElevation];
+  } else {
+    actionSheet.backgroundColor = colorScheme.surfaceColor;
+  }
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -59,7 +59,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.rippleColor = rippleColor;
   self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,
                                          UITraitCollection *_Nullable previousTraitCollection) {
-    if ([actionSheet.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    if ([actionSheet.traitCollection
+            hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
       [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
     }
   };

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,21 +57,25 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
-  self.traitCollectionDidChangeBlock = ^(MDCActionSheetController * _Nonnull actionSheet, UITraitCollection * _Nullable previousTraitCollection) {
-    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-  }
-  self.mdc_elevationDidChangeBlock = ^(id<MDCElevatable>  _Nonnull object, CGFloat absoluteElevation) {
-    if ([object isKindOfClass:[MDCActionSheetController class]]) {
-      MDCActionSheetController *actionSheet = (MDCActionSheetController *)actionSheet;
-      [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-    }
-  };
+  self.traitCollectionDidChangeBlock =
+      ^(MDCActionSheetController *_Nonnull actionSheet,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
+      } self.mdc_elevationDidChangeBlock =
+          ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
+            if ([object isKindOfClass:[MDCActionSheetController class]]) {
+              MDCActionSheetController *actionSheet = (MDCActionSheetController *)actionSheet;
+              [actionSheet applyBackgroundColorToActionSheet:actionSheet
+                                             withColorScheme:colorScheme];
+            }
+          };
 }
 
-- (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet withColorScheme:(id<MDCColorScheming>)colorScheme {
+- (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet
+                          withColorScheme:(id<MDCColorScheming>)colorScheme {
   if (colorScheme.elevationOverlayEnabledForDarkMode) {
     actionSheet.backgroundColor = [colorScheme.surfaceColor
-                                   mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
+        mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
                                    elevation:actionSheet.view.mdc_absoluteElevation];
   } else {
     actionSheet.backgroundColor = colorScheme.surfaceColor;

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MDCActionSheetController+MaterialTheming.h"
+#import "MaterialColor.h"
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
@@ -36,14 +37,13 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   [self applyThemeWithTypographyScheme:typographyScheme];
 }
 
+- (UIColor *)dynamicColorWithColor:(UIColor *)color elevation:(CGFloat)elevation {
+  UIColor *darkModeColor = [color mdc_resolvedColorWithElevation:elevation];
+  return [UIColor colorWithUserInterfaceStyleDarkColor:darkModeColor defaultColor:color];
+}
+
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    self.backgroundColor = [colorScheme.surfaceColor
-        mdc_resolvedColorWithTraitCollection:self.traitCollection
-                                   elevation:self.view.mdc_absoluteElevation];
-  } else {
-    self.backgroundColor = colorScheme.surfaceColor;
-  }
+  [self applyBackgroundColorToActionSheet:self withColorScheme:colorScheme];
   if (self.message && ![self.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
     self.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
@@ -73,9 +73,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 - (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet
                           withColorScheme:(id<MDCColorScheming>)colorScheme {
   if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    actionSheet.backgroundColor = [colorScheme.surfaceColor
-        mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
-                                   elevation:actionSheet.view.mdc_absoluteElevation];
+    actionSheet.backgroundColor = [self dynamicColorWithColor:colorScheme.surfaceColor elevation:actionSheet.view.mdc_absoluteElevation];
   } else {
     actionSheet.backgroundColor = colorScheme.surfaceColor;
   }

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -66,8 +66,6 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
         [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
       }
     };
-  }
-#endif
   self.mdc_elevationDidChangeBlock =
       ^(id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation) {
         if ([object isKindOfClass:[MDCActionSheetController class]]) {
@@ -75,6 +73,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
           [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
         }
       };
+    }
+  #endif
 }
 
 - (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MDCActionSheetController+MaterialTheming.h"
-#import "MaterialElevation.h"
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
@@ -41,7 +40,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   if (colorScheme.elevationOverlayEnabledForDarkMode) {
     self.backgroundColor =
         [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
-                                                             elevation:self.mdc_absoluteElevation];
+                                                             elevation:self.view.mdc_absoluteElevation];
   } else {
     self.backgroundColor = colorScheme.surfaceColor;
   }

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -37,7 +37,13 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [self applyBackgroundColorToActionSheet:self];
+  if (colorScheme.elevationOverlayEnabledForDarkMode) {
+    self.backgroundColor =
+        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
+                                                             elevation:self.view.mdc_absoluteElevation];
+  } else {
+    self.backgroundColor = colorScheme.surfaceColor;
+  }
   if (self.message && ![self.message isEqualToString:@""]) {
     // If there is a message then this can be high opacity and won't clash with actions.
     self.titleTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
@@ -52,18 +58,14 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.inkColor = rippleColor;
   self.rippleColor = rippleColor;
   self.traitCollectionDidChangeBlock = ^(MDCActionSheetController * _Nonnull actionSheet, UITraitCollection * _Nullable previousTraitCollection) {
-    [actionSheet applyBackgroundColorToActionSheet:actionSheet withColorScheme:colorScheme];
-  }
-}
-
-- (void)applyBackgroundColorToActionSheet:(MDCActionSheetController *)actionSheet withColorScheme:(id<MDCColorScheming>)colorScheme {
-  if (colorScheme.elevationOverlayEnabledForDarkMode) {
-    self.backgroundColor =
-        [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.traitCollection
-                                                             elevation:self.view.mdc_absoluteElevation];
-  } else {
-    self.backgroundColor = colorScheme.surfaceColor;
-  }
+      if (colorScheme.elevationOverlayEnabledForDarkMode) {
+      actionSheet.backgroundColor =
+          [colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:actionSheet.traitCollection
+                                                               elevation:actionSheet.view.mdc_absoluteElevation];
+    } else {
+      actionSheet.backgroundColor = colorScheme.surfaceColor;
+    }
+  };
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -139,14 +139,21 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 
 - (void)testActionSheetThemingWithDynamicColors {
   // Given
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
   self.containerScheme.colorScheme = colorScheme;
 
   // When
   [self.actionSheet applyThemeWithScheme:self.containerScheme];
 
   // Then
-  XCTAssertEqualObjects(self.actionSheet.backgroundColor, [self.containerScheme.colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.actionSheet.traitCollection elevation:self.actionSheet.view.mdc_absoluteElevation]);
+  XCTAssertEqualObjects(
+      self.actionSheet.backgroundColor,
+      [self.containerScheme.colorScheme.surfaceColor
+          mdc_resolvedColorWithTraitCollection:self.actionSheet.traitCollection
+                                     elevation:self.actionSheet.view.mdc_absoluteElevation]);
+  XCTAssertNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }
 
 @end

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -96,8 +96,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   XCTAssertEqualObjects(actionSheetCell.inkTouchController.defaultInkView.inkColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha]);
   XCTAssertEqualObjects(actionSheetCell.actionLabel.font, typographyScheme.subtitle1);
-  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
-  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
+  [self assertTraitCollectionBlockAndElevationBlockForActionSheet:self.actionSheet];
 }
 
 - (void)testActionSheetThemingTestWithHeaderOnly {
@@ -110,8 +109,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   // Then
   XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
-  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
-  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
+  [self assertTraitCollectionBlockAndElevationBlockForActionSheet:self.actionSheet];
 }
 
 - (void)testActionSheetThemingTestWithMessageOnly {
@@ -124,8 +122,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   // Then
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
-  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
-  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
+  [self assertTraitCollectionBlockAndElevationBlockForActionSheet:self.actionSheet];
 }
 
 - (void)testActionSheetThemingTestWithHeaderAndMessage {
@@ -141,8 +138,23 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
-  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
-  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
+  [self assertTraitCollectionBlockAndElevationBlockForActionSheet:self.actionSheet];
+}
+
+- (void)assertTraitCollectionBlockAndElevationBlockForActionSheet:
+    (MDCActionSheetController *)actionSheet {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
+    XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
+  } else {
+    XCTAssertNil(self.actionSheet.mdc_elevationDidChangeBlock);
+    XCTAssertNil(self.actionSheet.traitCollectionDidChangeBlock);
+  }
+#else
+  XCTAssertNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNil(self.actionSheet.traitCollectionDidChangeBlock);
+#endif
 }
 
 @end

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -137,7 +137,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
 }
 
-- (void)testActionSheetThemingWithDynamicColors {
+- (void)testActionSheetThemingSupportForiOS13 {
   // Given
   MDCSemanticColorScheme *colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
@@ -152,7 +152,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
       [self.containerScheme.colorScheme.surfaceColor
           mdc_resolvedColorWithTraitCollection:self.actionSheet.traitCollection
                                      elevation:self.actionSheet.view.mdc_absoluteElevation]);
-  XCTAssertNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
   XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }
 

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -96,6 +96,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   XCTAssertEqualObjects(actionSheetCell.inkTouchController.defaultInkView.inkColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha]);
   XCTAssertEqualObjects(actionSheetCell.actionLabel.font, typographyScheme.subtitle1);
+  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }
 
 - (void)testActionSheetThemingTestWithHeaderOnly {
@@ -108,6 +110,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   // Then
   XCTAssertEqualObjects(self.actionSheet.header.titleLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
+  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }
 
 - (void)testActionSheetThemingTestWithMessageOnly {
@@ -120,6 +124,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   // Then
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
+  XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
+  XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }
 
 - (void)testActionSheetThemingTestWithHeaderAndMessage {
@@ -135,23 +141,6 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
   XCTAssertEqualObjects(self.actionSheet.header.messageLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
-}
-
-- (void)testActionSheetThemingSupportForiOS13 {
-  // Given
-  MDCSemanticColorScheme *colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
-  self.containerScheme.colorScheme = colorScheme;
-
-  // When
-  [self.actionSheet applyThemeWithScheme:self.containerScheme];
-
-  // Then
-  XCTAssertEqualObjects(
-      self.actionSheet.backgroundColor,
-      [self.containerScheme.colorScheme.surfaceColor
-          mdc_resolvedColorWithTraitCollection:self.actionSheet.traitCollection
-                                     elevation:self.actionSheet.view.mdc_absoluteElevation]);
   XCTAssertNotNil(self.actionSheet.mdc_elevationDidChangeBlock);
   XCTAssertNotNil(self.actionSheet.traitCollectionDidChangeBlock);
 }

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -137,4 +137,16 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
 }
 
+- (void)testActionSheetThemingWithDynamicColors {
+  // Given
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+  self.containerScheme.colorScheme = colorScheme;
+
+  // When
+  [self.actionSheet applyThemeWithScheme:self.containerScheme];
+
+  // Then
+  XCTAssertEqualObjects(self.actionSheet.backgroundColor, [self.containerScheme.colorScheme.surfaceColor mdc_resolvedColorWithTraitCollection:self.actionSheet.traitCollection elevation:self.actionSheet.view.mdc_absoluteElevation]);
+}
+
 @end


### PR DESCRIPTION
This PR adds dark mode support to the theming extension for MDCActionSheetController. In order to support dark mode clients will need to set dynamic colors in their color scheme. 

There is no change to `mdc_elevationDidChangeBlock` because the elevation on an MDCActionSheetController should never change since it is not a settable property. If we later expose a setter then we will need to add that functionality. Additionally unit test were added but since MDCActionSheetController doesn't allow for subclassing I could not test for traitCollection changes. In order to test this more thoroughly do the steps as follows.

1. Launch MDCCatalog on an iOS 13 simulator.
2. Open the ActionSheet example.
3. Switch between light and dark mode in Xcode 11.

Following the steps above, this should be the result.
![actionSheet](https://user-images.githubusercontent.com/7131294/62724608-61bbf980-b9e1-11e9-8979-d586b49d2c58.gif)
