### PR TITLE
[AppBar] Rewrite tests in ObjC to prevent the failing unit tests on iOS 13.

### DIFF
--- a/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.m
@@ -1,0 +1,135 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialAppBar.h"
+
+@interface MDCAppBarNavigationControllerTests : XCTestCase
+
+@property(nonatomic, strong) MDCAppBarNavigationController *navigationController;
+
+@end
+
+@implementation MDCAppBarNavigationControllerTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.navigationController = [[MDCAppBarNavigationController alloc] init];
+}
+
+- (void)tearDown {
+  self.navigationController = nil;
+
+  [super tearDown];
+}
+
+- (void)testSettingAViewControllerInjectsAnAppBar {
+  // Given
+  UIViewController *viewController = [[UIViewController alloc] init];
+
+  // When
+  self.navigationController.viewControllers = @[ viewController ];
+
+  // Then
+  XCTAssertEqual(
+      viewController.childViewControllers.count, 1,
+      @"Expected there to be exactly one child view controller added to the view controller.");
+  XCTAssertEqual(self.navigationController.topViewController, viewController,
+                 @"The navigation controller's top view controller is supposed to be the pushed "
+                 @"view controller, but it is %@.",
+                 viewController);
+  XCTAssertTrue(
+      [viewController.childViewControllers.firstObject
+          isKindOfClass:[MDCFlexibleHeaderViewController class]],
+      "The injected view controller is not a flexible header view controller, it is %@ instead.",
+      NSStringFromClass([viewController.childViewControllers.firstObject class]));
+
+  if ([viewController.childViewControllers.firstObject
+          isKindOfClass:[MDCFlexibleHeaderViewController class]]) {
+    MDCFlexibleHeaderViewController *headerViewController =
+        viewController.childViewControllers.firstObject;
+    XCTAssertEqual(headerViewController.headerView.frame.size.height,
+                   headerViewController.headerView.maximumHeight);
+  }
+}
+
+- (void)testSettingAViewControllerAnimatedInjectsAnAppBar {
+  // Given
+  UIViewController *viewController = [[UIViewController alloc] init];
+
+  // When
+  [self.navigationController setViewControllers:@[ viewController ] animated:NO];
+
+  // Then
+  XCTAssertEqual(
+      viewController.childViewControllers.count, 1,
+      @"Expected there to be exactly one child view controller added to the view controller.");
+  XCTAssertEqual(self.navigationController.topViewController, viewController,
+                 @"The navigation controller's top view controller is supposed to be the pushed "
+                 @"view controller, but it is %@.",
+                 viewController);
+  XCTAssertTrue(
+      [viewController.childViewControllers.firstObject
+          isKindOfClass:[MDCFlexibleHeaderViewController class]],
+      "The injected view controller is not a flexible header view controller, it is %@ instead.",
+      NSStringFromClass([viewController.childViewControllers.firstObject class]));
+
+  if ([viewController.childViewControllers.firstObject
+          isKindOfClass:[MDCFlexibleHeaderViewController class]]) {
+    MDCFlexibleHeaderViewController *headerViewController =
+        viewController.childViewControllers.firstObject;
+    XCTAssertEqual(headerViewController.headerView.frame.size.height,
+                   headerViewController.headerView.maximumHeight);
+  }
+}
+
+- (void)testSettingAViewControllerAssignsTraitCollectionDidChangeBlock {
+  // Given
+  UIViewController *viewController = [[UIViewController alloc] init];
+  self.navigationController.traitCollectionDidChangeBlockForAppBarController =
+      ^(MDCFlexibleHeaderViewController *_Nonnull flexibleHeaderViewController,
+        UITraitCollection *_Nullable previousTraitCollection) {
+      };
+
+  // When
+  self.navigationController.viewControllers = @[ viewController ];
+
+  // Then
+  MDCAppBarViewController *injectedAppBarViewController =
+      viewController.childViewControllers.firstObject;
+  XCTAssertNotNil(injectedAppBarViewController);
+  XCTAssertNotNil(injectedAppBarViewController.traitCollectionDidChangeBlock);
+}
+
+- (void)testSettingAViewControllerAnimatedAssignsTraitCollectionDidChangeBlock {
+  // Given
+  UIViewController *viewController = [[UIViewController alloc] init];
+  self.navigationController.traitCollectionDidChangeBlockForAppBarController =
+      ^(MDCFlexibleHeaderViewController *_Nonnull flexibleHeaderViewController,
+        UITraitCollection *_Nullable previousTraitCollection) {
+      };
+
+  // When
+  [self.navigationController setViewControllers:@[ viewController ] animated:NO];
+
+  // Then
+  MDCAppBarViewController *injectedAppBarViewController =
+      viewController.childViewControllers.firstObject;
+  XCTAssertNotNil(injectedAppBarViewController);
+  XCTAssertNotNil(injectedAppBarViewController.traitCollectionDidChangeBlock);
+}
+
+@end

--- a/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.swift
@@ -95,60 +95,6 @@ class MDCAppBarNavigationControllerTests: XCTestCase {
     }
   }
 
-  func testSettingAViewControllerInjectsAnAppBar() {
-    // Given
-    let viewController = UIViewController()
-
-    // When
-    navigationController.viewControllers = [viewController]
-
-    // Then
-    XCTAssertEqual(viewController.children.count, 1,
-                   "Expected there to be exactly one child view controller added to the view"
-                    + " controller.")
-
-    XCTAssertEqual(navigationController.topViewController, viewController,
-                   "The navigation controller's top view controller is supposed to be the pushed"
-                    + " view controller, but it is \(viewController).")
-
-    XCTAssertTrue(viewController.children.first is MDCFlexibleHeaderViewController,
-                  "The injected view controller is not a flexible header view controller, it is"
-                    + "\(String(describing: viewController.children.first)) instead.")
-
-    if let headerViewController
-      = viewController.children.first as? MDCFlexibleHeaderViewController {
-      XCTAssertEqual(headerViewController.headerView.frame.height,
-                     headerViewController.headerView.maximumHeight)
-    }
-  }
-
-  func testSettingAViewControllerAnimatedInjectsAnAppBar() {
-    // Given
-    let viewController = UIViewController()
-
-    // When
-    navigationController.setViewControllers([viewController], animated: false)
-
-    // Then
-    XCTAssertEqual(viewController.children.count, 1,
-                   "Expected there to be exactly one child view controller added to the view"
-                    + " controller.")
-
-    XCTAssertEqual(navigationController.topViewController, viewController,
-                   "The navigation controller's top view controller is supposed to be the pushed"
-                    + " view controller, but it is \(viewController).")
-
-    XCTAssertTrue(viewController.children.first is MDCFlexibleHeaderViewController,
-                  "The injected view controller is not a flexible header view controller, it is"
-                    + "\(String(describing: viewController.children.first)) instead.")
-
-    if let headerViewController
-      = viewController.children.first as? MDCFlexibleHeaderViewController {
-      XCTAssertEqual(headerViewController.headerView.frame.height,
-                     headerViewController.headerView.maximumHeight)
-    }
-  }
-
   func testPushingAnAppBarContainerViewControllerDoesNotInjectAnAppBar() {
     // Given
     let viewController = UIViewController()
@@ -222,36 +168,6 @@ class MDCAppBarNavigationControllerTests: XCTestCase {
 
     // When
     navigationController.pushViewController(viewController, animated: false)
-
-    // Then
-    let injectedAppBarViewController = viewController.children.first as! MDCAppBarViewController
-    XCTAssertNotNil(injectedAppBarViewController)
-    XCTAssertNotNil(injectedAppBarViewController.traitCollectionDidChangeBlock)
-  }
-
-  func testSettingAViewControllerAssignsTraitCollectionDidChangeBlock() {
-    // Given
-    let viewController = UIViewController()
-    let block: ((MDCFlexibleHeaderViewController, UITraitCollection?) -> Void)? = {_, _ in }
-    navigationController.traitCollectionDidChangeBlockForAppBarController = block
-
-    // When
-    navigationController.viewControllers = [viewController]
-
-    // Then
-    let injectedAppBarViewController = viewController.children.first as! MDCAppBarViewController
-    XCTAssertNotNil(injectedAppBarViewController)
-    XCTAssertNotNil(injectedAppBarViewController.traitCollectionDidChangeBlock)
-  }
-
-  func testSettingAViewControllerAnimatedAssignsTraitCollectionDidChangeBlock() {
-    // Given
-    let viewController = UIViewController()
-    let block: ((MDCFlexibleHeaderViewController, UITraitCollection?) -> Void)? = {_, _ in }
-    navigationController.traitCollectionDidChangeBlockForAppBarController = block
-
-    // When
-    navigationController.setViewControllers([viewController], animated: false)
 
     // Then
     let injectedAppBarViewController = viewController.children.first as! MDCAppBarViewController


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8252

## Context
Error occurs when testing using Bazel.
```
Test Case '-[components_AppBar_unit_test_swift_sources.MDCAppBarNavigationControllerTests testSettingAViewControllerInjectsAnAppBar]' started.
Child process terminated with signal 11: Segmentation fault
```