### PR TITLE
Add an argument to mdc unit test suite to make autobot runner optional.

### DIFF
--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -122,6 +122,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -122,7 +122,6 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
-    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -14,8 +14,8 @@ DEFAULT_IOS_RUNNER_TARGETS = [
     "//components/testing/runners:IPHONE_7_PLUS_IN_10_3",
 ]
 
-KOKORO_EXTENSION_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_X_IN_11_0"
-AUTOBOT_EXTENSION_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_8_IN_13_0"
+KOKORO_ENVIRONMENT_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_X_IN_11_0"
+AUTOBOT_ENVIRONMENT_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_8_IN_13_0"
 
 SNAPSHOT_IOS_RUNNER_TARGET = "//components/testing/runners:IPHONE_7_IN_11_2"
 
@@ -272,9 +272,9 @@ def mdc_unit_test_suite(
     minimum_os_version = IOS_MINIMUM_OS,
     visibility = ["//visibility:private"],
     size = "medium",
-    use_autobot_extension_runner = True,
+    use_autobot_environment_runner = True,
     **kwargs):
-    """Declare a MDC unit_test_suite and a unit_test_extension using the ios_runners matrix.
+    """Declare a MDC unit_test_suite and a unit_test_environment using the ios_runners matrix.
 
     Args:
         name: The name of the target.
@@ -282,26 +282,26 @@ def mdc_unit_test_suite(
         minimum_os_version: The minimum iOS version supported by the target.
         visibility: The visibility of the package.
         size: The size of the test.
-        use_autobot_extension_runner: Indicates whether autobot (a testing machine) extension runner should be used.
+        use_autobot_environment_runner: Indicates whether autobot (a testing machine) environment runner should be used.
         **kwargs: Any arguments accepted by ios_unit_test().
     """
     mdc_ci_config_setting()
     runners = list(DEFAULT_IOS_RUNNER_TARGETS)
-    if use_autobot_extension_runner:
+    if use_autobot_environment_runner:
         ios_unit_test(
-            name = name + '_extension',
+            name = name + '_environment',
             deps = deps,
             minimum_os_version = minimum_os_version,
             runner = select({
-                ":kokoro": KOKORO_EXTENSION_IOS_RUNNER_TARGET,
-                ":autobot": AUTOBOT_EXTENSION_IOS_RUNNER_TARGET,
+                ":kokoro": KOKORO_ENVIRONMENT_IOS_RUNNER_TARGET,
+                ":autobot": AUTOBOT_ENVIRONMENT_IOS_RUNNER_TARGET,
                 "//conditions:default": KOKORO_EXTENSION_IOS_RUNNER_TARGET,
             }),
             visibility = visibility,
             size = size,
             **kwargs)
     else:
-        runners.append(KOKORO_EXTENSION_IOS_RUNNER_TARGET)
+        runners.append(KOKORO_ENVIRONMENT_IOS_RUNNER_TARGET)
     ios_unit_test_suite(
         name = name,
         deps = deps,

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -295,7 +295,7 @@ def mdc_unit_test_suite(
             runner = select({
                 ":kokoro": KOKORO_ENVIRONMENT_IOS_RUNNER_TARGET,
                 ":autobot": AUTOBOT_ENVIRONMENT_IOS_RUNNER_TARGET,
-                "//conditions:default": KOKORO_EXTENSION_IOS_RUNNER_TARGET,
+                "//conditions:default": KOKORO_ENVIRONMENT_IOS_RUNNER_TARGET,
             }),
             visibility = visibility,
             size = size,

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -282,7 +282,7 @@ def mdc_unit_test_suite(
         minimum_os_version: The minimum iOS version supported by the target.
         visibility: The visibility of the package.
         size: The size of the test.
-        use_autobot_extension_runner: Indicates whether autobot extension runner should be used.
+        use_autobot_extension_runner: Indicates whether autobot (a testing machine) extension runner should be used.
         **kwargs: Any arguments accepted by ios_unit_test().
     """
     mdc_ci_config_setting()


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8249.

### Context:
Some of swift unit tests fail on iOS 13. This PR provides a way to make autobot, which is an iOS 13 runner, optional for targets.