### PR TITLE
[Catalog] Remove a layer of indirection in AppTheme.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
   }
 
   @objc func themeDidChange(notification: NSNotification) {
-    let colorScheme = AppTheme.globalTheme.colorScheme
+    let colorScheme = AppTheme.containerScheme.colorScheme
     for viewController in navigationController.children {
       guard let appBar = navigationController.appBar(for: viewController) else {
         continue
@@ -82,9 +82,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
   func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
                                   willAdd appBarViewController: MDCAppBarViewController,
                                   asChildOf viewController: UIViewController) {
-    MDCAppBarColorThemer.applyColorScheme(AppTheme.globalTheme.colorScheme,
+    MDCAppBarColorThemer.applyColorScheme(AppTheme.containerScheme.colorScheme,
                                                         to: appBarViewController)
-    MDCAppBarTypographyThemer.applyTypographyScheme(AppTheme.globalTheme.typographyScheme,
+    MDCAppBarTypographyThemer.applyTypographyScheme(AppTheme.containerScheme.typographyScheme,
                                                     to: appBarViewController)
 
     if let injectee = viewController as? CatalogAppBarInjectee {

--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -20,21 +20,7 @@ import MaterialComponents.MaterialShapeScheme
 import MaterialComponents.MaterialTypographyScheme
 
 final class AppTheme {
-  let containerScheme: MDCContainerScheming
-
-  var colorScheme: MDCColorScheming {
-    return containerScheme.colorScheme
-  }
-
-  var typographyScheme: MDCTypographyScheming {
-    return containerScheme.typographyScheme
-  }
-
-  init(containerScheme: MDCContainerScheming) {
-    self.containerScheme = containerScheme
-  }
-
-  static var globalTheme = AppTheme(containerScheme: DefaultContainerScheme()) {
+  static var containerScheme: MDCContainerScheming = DefaultContainerScheme() {
     didSet {
       NotificationCenter.default.post(name: AppTheme.didChangeGlobalThemeNotificationName,
                                       object: nil,
@@ -44,6 +30,10 @@ final class AppTheme {
 
   static let didChangeGlobalThemeNotificationName =
     Notification.Name("MDCCatalogDidChangeGlobalTheme")
+
+  private init() {
+    // An AppTheme is not intended to be created; use the static APIs instead.
+  }
 }
 
 func DefaultContainerScheme() -> MDCContainerScheme {

--- a/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
+++ b/catalog/MDCCatalog/MDCCatalogCollectionViewCell.swift
@@ -84,8 +84,8 @@ class MDCCatalogCollectionViewCell: UICollectionViewCell {
   }
 
   func updateTheme() {
-    label.font = AppTheme.globalTheme.typographyScheme.button
-    label.textColor = AppTheme.globalTheme.colorScheme.onBackgroundColor
+    label.font = AppTheme.containerScheme.typographyScheme.button
+    label.textColor = AppTheme.containerScheme.colorScheme.onBackgroundColor
   }
 
   @objc func themeDidChange(notification: NSNotification) {

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -104,7 +104,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
 
     collectionView?.register(MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
-    collectionView?.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    collectionView?.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
 
     MDCIcons.ic_arrow_backUseNewStyle(true)
 
@@ -116,7 +116,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
   }
 
   @objc func themeDidChange(notification: NSNotification) {
-    let colorScheme = AppTheme.globalTheme.colorScheme
+    let colorScheme = AppTheme.containerScheme.colorScheme
     MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
                                                           to: headerViewController.headerView)
     setNeedsStatusBarAppearanceUpdate()
@@ -144,9 +144,9 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
     containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
     titleLabel.text = title!
-    titleLabel.textColor = AppTheme.globalTheme.colorScheme.onPrimaryColor
+    titleLabel.textColor = AppTheme.containerScheme.colorScheme.onPrimaryColor
     titleLabel.textAlignment = .center
-    titleLabel.font = AppTheme.globalTheme.typographyScheme.headline1
+    titleLabel.font = AppTheme.containerScheme.typographyScheme.headline1
     titleLabel.sizeToFit()
 
     let titleInsets = UIEdgeInsets(top: 0,
@@ -162,7 +162,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
 
     containerView.addSubview(logo)
 
-    let colorScheme = AppTheme.globalTheme.colorScheme
+    let colorScheme = AppTheme.containerScheme.colorScheme
 
     let image = MDCDrawImage(CGRect(x:0,
                                     y:0,
@@ -341,7 +341,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
     let cell =
         collectionView.dequeueReusableCell(withReuseIdentifier: "MDCCatalogCollectionViewCell",
                                            for: indexPath)
-    cell.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    cell.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
 
     let componentName = node.children[indexPath.row].title
     if let catalogCell = cell as? MDCCatalogCollectionViewCell {

--- a/catalog/MDCCatalog/MDCCatalogTileView.swift
+++ b/catalog/MDCCatalog/MDCCatalogTileView.swift
@@ -93,7 +93,7 @@ class MDCCatalogTileView: UIView {
   func createImage() -> UIImage {
     var newImage: UIImage?
 
-    let colorScheme = AppTheme.globalTheme.colorScheme
+    let colorScheme = AppTheme.containerScheme.colorScheme
 
     switch componentNameString {
     case "Activity Indicator":

--- a/catalog/MDCCatalog/MDCMenuViewController.swift
+++ b/catalog/MDCCatalog/MDCMenuViewController.swift
@@ -53,7 +53,7 @@ class MDCMenuViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView,
                           cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let iconColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.61)
+    let iconColor = AppTheme.containerScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.61)
     let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
     let cellData = tableData[indexPath.item]
     cell.textLabel?.text = cellData.title

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -211,7 +211,7 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
     mainSectionHeader = MainSectionHeader()
     additionalExamplesSectionHeader = createAdditionalExamplesSectionHeader()
-    self.tableView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    self.tableView.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
     self.tableView.separatorStyle = .none
     self.tableView.sectionHeaderHeight = UITableView.automaticDimension
 
@@ -284,7 +284,7 @@ extension MDCNodeListViewController {
 
   func createAdditionalExamplesSectionHeader() -> UIView {
     let sectionView = UIView()
-    sectionView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    sectionView.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
     let lineDivider = UIView()
     lineDivider.backgroundColor = UIColor(white: 0.85, alpha: 1)
     lineDivider.translatesAutoresizingMaskIntoConstraints = false
@@ -390,7 +390,7 @@ extension MDCNodeListViewController {
 
   func MainSectionHeader() -> UIView {
     let sectionView = UIView()
-    sectionView.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    sectionView.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
 
     let sectionTitleLabel = UILabel()
     sectionTitleLabel.font = MDCTypography.body2Font()
@@ -513,7 +513,7 @@ extension MDCNodeListViewController {
       cell?.selectionStyle = .none
       let primaryDemoCell = cell as! NodeViewTableViewPrimaryDemoCell
       let button = primaryDemoCell.containedButton
-      button.applyContainedTheme(withScheme: AppTheme.globalTheme.containerScheme)
+      button.applyContainedTheme(withScheme: AppTheme.containerScheme)
       button.addTarget(self, action: #selector(primaryDemoButtonClicked), for: .touchUpInside)
     } else {
       cell = tableView.dequeueReusableCell(withIdentifier: "NodeViewTableViewDemoCell")
@@ -534,7 +534,7 @@ extension MDCNodeListViewController {
       cell!.accessibilityIdentifier = "Cell" + cell!.textLabel!.text!
       cell!.accessoryType = .disclosureIndicator
     }
-    cell?.backgroundColor = AppTheme.globalTheme.colorScheme.backgroundColor
+    cell?.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
     return cell!
   }
 
@@ -577,15 +577,15 @@ extension MDCNodeListViewController {
   func themeExample(vc: UIViewController) {
     let colorSel = NSSelectorFromString("setColorScheme:");
     if vc.responds(to: colorSel) {
-      vc.perform(colorSel, with: AppTheme.globalTheme.colorScheme)
+      vc.perform(colorSel, with: AppTheme.containerScheme.colorScheme)
     }
     let typoSel = NSSelectorFromString("setTypographyScheme:");
     if vc.responds(to: typoSel) {
-      vc.perform(typoSel, with: AppTheme.globalTheme.typographyScheme)
+      vc.perform(typoSel, with: AppTheme.containerScheme.typographyScheme)
     }
     let containerSel = NSSelectorFromString("setContainerScheme:")
     if vc.responds(to: containerSel) {
-      vc.perform(containerSel, with: AppTheme.globalTheme.containerScheme)
+      vc.perform(containerSel, with: AppTheme.containerScheme)
     }
   }
 }

--- a/catalog/MDCCatalog/MDCThemePickerViewController.swift
+++ b/catalog/MDCCatalog/MDCThemePickerViewController.swift
@@ -69,12 +69,12 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
     return palettesCollectionView.collectionViewLayout as! UICollectionViewFlowLayout
   }
 
-  let titleColor = AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.5)
-  let titleFont = AppTheme.globalTheme.typographyScheme.button
+  let titleColor = AppTheme.containerScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.5)
+  let titleFont = AppTheme.containerScheme.typographyScheme.button
   private let cellReuseIdentifier = "cell"
   private let colorSchemeConfigurations = [
     MDCColorThemeCellConfiguration(name: "Default",
-                                   mainColor: AppTheme.globalTheme.colorScheme.primaryColor,
+                                   mainColor: AppTheme.containerScheme.colorScheme.primaryColor,
                                    scheme: DefaultContainerScheme()),
     MDCColorThemeCellConfiguration(name: "Blue",
                                    mainColor: MDCPalette.blue.tint500,
@@ -153,8 +153,8 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
     cell.contentView.layer.cornerRadius = cellSize / 2
     cell.contentView.layer.borderWidth = 1
     cell.contentView.layer.borderColor =
-      AppTheme.globalTheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
-    if AppTheme.globalTheme.colorScheme.primaryColor
+      AppTheme.containerScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.05).cgColor
+    if AppTheme.containerScheme.colorScheme.primaryColor
       == colorSchemeConfigurations[indexPath.item].mainColor {
       cell.imageView.isHidden = false
       cell.isSelected = true
@@ -207,7 +207,7 @@ class MDCThemePickerViewController: UIViewController, UICollectionViewDataSource
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     navigationController?.popViewController(animated: true)
     let scheme = colorSchemeConfigurations[indexPath.item].scheme
-    AppTheme.globalTheme = AppTheme(containerScheme: scheme)
+    AppTheme.containerScheme = scheme
   }
 
 }


### PR DESCRIPTION
AppTheme was originally created to store each of the Scheme types (Typography, Color, etc...). We've since introduced a container scheme type which can be used for the same purpose, so this PR removes the overlapping functionality in favor of simply exposing a global static container scheme on the AppTheme type.

Closes https://github.com/material-components/material-components-ios/issues/8260