### PR TITLE
[ButtonBar] Stop running swift tests on Autobot.

### DIFF
--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -122,6 +122,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -122,6 +122,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
     use_autobot_environment_runner = False,
 )
 


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8266.

This change only affects Autobot runner. The work to re-enable this flag for Autobot is tracked in https://github.com/material-components/material-components-ios/issues/8249.

### Context
Error occurs when testing using Bazel.

```
Test Case '-[components_ButtonBar_unit_test_swift_sources.ButtonBarButtonTitleCasingTests testButtonTitlesAreNotUppercasedWhenFlagIsDisabledAfterAssignment]' started.
Child process terminated with signal 11: Segmentation fault
```