### PR TITLE
[FlexibleHeader] Stop running swift tests on Autobot.

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -116,6 +116,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -116,6 +116,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
     use_autobot_environment_runner = False,
 )
 


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8268

This change only affects Autobot runner. The work to re-enable this flag for Autobot is tracked in #8249.

### Context
Error occurs when testing using Bazel.

```
Test Case '-[components_FlexibleHeader_unit_test_swift_sources.FlexibleHeaderContainerViewControllerTests testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges]' started.
Child process terminated with signal 11: Segmentation fault
```