### PR TITLE
[ActionSheet] Stop running swift tests on Autobot.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -144,6 +144,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
     use_autobot_environment_runner = False,
 )
 

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -144,6 +144,7 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8273.

This change only affects Autobot runner. The work to re-enable this flag for Autobot is tracked in #8249.

### Context
Error occurs when testing using Bazel.

```
Test Case '-[components_ActionSheet_unit_test_swift_sources.ActionSheetTest testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges]' started.
Child process terminated with signal 11: Segmentation fault
```