### PR TITLE
[TextFields] Stop running swift tests on Autobot.

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -213,4 +213,5 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    use_autobot_environment_runner = False,
 )

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -213,5 +213,6 @@ mdc_unit_test_suite(
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
+    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
     use_autobot_environment_runner = False,
 )


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8270

This change only affects Autobot runner. The work to re-enable this flag for Autobot is tracked in #8249.

### Context
Error occurs when testing using Bazel.

```
Test Case '-[components_TextFields_unit_test_swift_sources.MultilineTextFieldTests testTraitCollectionDidChangeBlockCalledWithExpectedParameters]' started.
Child process terminated with signal 11: Segmentation fault
```