### PR TITLE
[Buttons] Add missing self to traitCollectionDidChangeBlock

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -168,7 +168,7 @@
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
-    (UITraitCollection *_Nullable previousTraitCollection);
+    (MDCButton *_Nonnull button, UITraitCollection *_Nullable previousTraitCollection);
 
 /**
  A color used as the button's @c backgroundColor for @c state.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -333,7 +333,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [super traitCollectionDidChange:previousTraitCollection];
 
   if (self.traitCollectionDidChangeBlock) {
-    self.traitCollectionDidChangeBlock(previousTraitCollection);
+    self.traitCollectionDidChangeBlock(self, previousTraitCollection);
   }
 }
 

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1340,7 +1340,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *button = [[MDCButton alloc] init];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
-  button.traitCollectionDidChangeBlock = ^(UITraitCollection *_Nullable previousTraitCollection) {
+  button.traitCollectionDidChangeBlock = ^(MDCButton *_Nonnull b, UITraitCollection *_Nullable previousTraitCollection) {
     [expectation fulfill];
   };
 

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1340,7 +1340,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *button = [[MDCButton alloc] init];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
-  button.traitCollectionDidChangeBlock = ^(MDCButton *_Nonnull b, UITraitCollection *_Nullable previousTraitCollection) {
+  button.traitCollectionDidChangeBlock = ^(MDCButton *_Nonnull passedButton, UITraitCollection *_Nullable previousTraitCollection) {
     [expectation fulfill];
   };
 

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1340,8 +1340,11 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *button = [[MDCButton alloc] init];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
+
+  __block MDCButton *passedButton;
   button.traitCollectionDidChangeBlock =
-      ^(MDCButton *_Nonnull passedButton, UITraitCollection *_Nullable previousTraitCollection) {
+      ^(MDCButton *_Nonnull buttonInBlock, UITraitCollection *_Nullable previousTraitCollection) {
+        passedButton = buttonInBlock;
         [expectation fulfill];
       };
 
@@ -1350,6 +1353,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
 
   // Then
   [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedButton, button);
 }
 
 #pragma mark - MaterialElevation

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1340,9 +1340,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
   MDCButton *button = [[MDCButton alloc] init];
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Called traitCollectionDidChange"];
-  button.traitCollectionDidChangeBlock = ^(MDCButton *_Nonnull passedButton, UITraitCollection *_Nullable previousTraitCollection) {
-    [expectation fulfill];
-  };
+  button.traitCollectionDidChangeBlock =
+      ^(MDCButton *_Nonnull passedButton, UITraitCollection *_Nullable previousTraitCollection) {
+        [expectation fulfill];
+      };
 
   // When
   [button traitCollectionDidChange:nil];


### PR DESCRIPTION
As part of our work of adding traitCollectionDidChangeBlocks to components, we add self as a parameter to the block, buttons is the only component that seems to be missing it.

This is essentially a breaking change based on our breaking changes conventions.