### PR TITLE
[NavigationDrawer] Respect the rotation preferences of presenting controller

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -88,6 +88,10 @@
   return UIModalPresentationCustom;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+  return self.presentingViewController.supportedInterfaceOrientations;
+}
+
 - (void)setTrackingScrollView:(UIScrollView *)trackingScrollView {
   _trackingScrollView = trackingScrollView;
   if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {


### PR DESCRIPTION
This pull request changes the behaviour of the NavigationDrawer, so it respects the rotation preference of the presenting controller. 

Currently, if the NavigationDrawer is presented, rotation of the device can change the orientation of the NavigationDrawer and the presentation controller, even if the presenting controller does not support it. Dismissing the NavigationDrawer in the rotated position will not revert the orientation of the presenting controller (potentially resulting in unexpected behaviours for the presenting controller). 

This behaviour is not observed in other components which pop onto the screen (e.g. MDCBottomSheetController will not override the rotation preference of the presenting controller)

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
