### PR TITLE
[Catalog] Use the typography scheme defaults.

### DIFF
--- a/catalog/MDCCatalog/AppTheme.swift
+++ b/catalog/MDCCatalog/AppTheme.swift
@@ -39,17 +39,9 @@ final class AppTheme {
 func DefaultContainerScheme() -> MDCContainerScheme {
   let containerScheme = MDCContainerScheme()
 
-  let colorScheme = MDCSemanticColorScheme(defaults: .material201907)
-  containerScheme.colorScheme = colorScheme
-
-  let typographyScheme = MDCTypographyScheme()
-  typographyScheme.headline1 = UIFont.systemFont(ofSize: 20)
-  typographyScheme.headline2 = UIFont.systemFont(ofSize: 18)
-  typographyScheme.headline3 = UIFont.systemFont(ofSize: 15)
-  containerScheme.typographyScheme = typographyScheme
-
-  let shapeScheme = MDCShapeScheme()
-  containerScheme.shapeScheme = shapeScheme
+  containerScheme.colorScheme = MDCSemanticColorScheme(defaults: .material201907)
+  containerScheme.typographyScheme = MDCTypographyScheme(defaults: .material201902)
+  containerScheme.shapeScheme = MDCShapeScheme()
 
   return containerScheme
 }

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -146,7 +146,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
     titleLabel.text = title!
     titleLabel.textColor = AppTheme.containerScheme.colorScheme.onPrimaryColor
     titleLabel.textAlignment = .center
-    titleLabel.font = AppTheme.containerScheme.typographyScheme.headline1
+    titleLabel.font = AppTheme.containerScheme.typographyScheme.headline6
     titleLabel.sizeToFit()
 
     let titleInsets = UIEdgeInsets(top: 0,


### PR DESCRIPTION
Prior to this change we were arbitrarily customizing headlines 1-3 with new font instances. This has the dual effect of being a confusing documentation experience and throwing away the default dynamic type settings that come for free with the typography scheme.

After this change we are using the typography scheme defaults throughout the app.

Closes https://github.com/material-components/material-components-ios/issues/8279
