### PR TITLE
[TextFields] Add non-experimental MDCBaseTextField example

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -61,7 +61,7 @@ mdc_extension_objc_library(
     name = "ContainedInputView",
     deps = [
         "@material_internationalization_ios//:MDFInternationalization",
-    ]
+    ],
 )
 
 mdc_extension_objc_library(
@@ -104,6 +104,7 @@ mdc_examples_objc_library(
         ":ColorThemer",
         ":TextFields",
         ":TypographyThemer",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -102,6 +102,7 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":ColorThemer",
+        ":ContainedInputView",
         ":TextFields",
         ":TypographyThemer",
         "//components/schemes/Container",

--- a/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
+++ b/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <MaterialComponents/MaterialContainerScheme.h>
+#import "MaterialContainerScheme.h"
 #import "MaterialTextFields+ContainedInputView.h"
 
 static NSString *const kExampleTitle = @"MDCBaseTextField";
@@ -43,13 +43,19 @@ static NSString *const kExampleTitle = @"MDCBaseTextField";
   }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
-  CGRect textFieldFrame = CGRectMake(15, 150, CGRectGetWidth(self.view.frame) - 30, 50);
-  self.textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  self.textField = [[MDCBaseTextField alloc] initWithFrame:self.preferredTextFieldFrame];
   self.textField.borderStyle = UITextBorderStyleRoundedRect;
   [self.view addSubview:self.textField];
 }
 
-#pragma mark - Errata
+- (CGRect)preferredTextFieldFrame {
+  return CGRectMake(15, 100, CGRectGetWidth(self.view.frame) - 30, 50);
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  self.textField.frame = self.preferredTextFieldFrame;
+}
 
 @end
 
@@ -59,7 +65,7 @@ static NSString *const kExampleTitle = @"MDCBaseTextField";
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs" : @[ @"Tab Field", kExampleTitle ],
+    @"breadcrumbs" : @[ @"Text Field", kExampleTitle ],
     @"primaryDemo" : @NO,
     @"presentable" : @NO,
   };

--- a/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
+++ b/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
@@ -1,0 +1,68 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import <MaterialComponents/MaterialContainerScheme.h>
+#import "MaterialTextFields+ContainedInputView.h"
+
+static NSString *const kExampleTitle = @"MDCBaseTextField";
+
+/**
+ Typical use example showing how to place an @c MDCBaseTextField in a UIViewController.
+ */
+@interface MDCBaseTextFieldTypicalExampleViewController : UIViewController
+
+/** The TextField for this example. */
+@property(nonatomic, strong) MDCBaseTextField *textField;
+
+/** The container scheme injected into this example. */
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+
+@end
+
+@implementation MDCBaseTextFieldTypicalExampleViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.title = kExampleTitle;
+
+  if (!self.containerScheme) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  CGRect textFieldFrame = CGRectMake(15, 150, CGRectGetWidth(self.view.frame) - 30, 50);
+  self.textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  self.textField.borderStyle = UITextBorderStyleRoundedRect;
+  [self.view addSubview:self.textField];
+}
+
+#pragma mark - Errata
+
+@end
+
+#pragma mark - CatalogByConvention
+
+@implementation MDCBaseTextFieldTypicalExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Tab Field", kExampleTitle ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
+}
+
+@end


### PR DESCRIPTION
This PR adds a non-experimental MDCBaseTextField example.

Related to #6942.

Here are some screenshots:
![Simulator Screen Shot - iPhone 7 - 2019-08-12 at 13 56 25](https://user-images.githubusercontent.com/8020010/62886361-22efb180-bd09-11e9-97ff-7a82dd1f8af3.png)
![Simulator Screen Shot - iPhone 7 - 2019-08-12 at 13 56 23](https://user-images.githubusercontent.com/8020010/62886362-22efb180-bd09-11e9-9814-d5da6584babf.png)

