### PR TITLE
[Releasing] Allow warnings in `pod lib lint`

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -251,7 +251,7 @@ release candidate.
 
 Send our local podspec through the CocoaPods linter:
 
-    pod lib lint MaterialComponents.podspec --skip-tests
+    pod lib lint MaterialComponents.podspec --skip-tests --allow-warnings
 
 CocoaPods publishes a directory of publicly available pods through its **trunk** service.
 Note: Ensure that you can [push the podspec](#publish-to-cocoapods) later by checking for `MaterialComponents` in your list of available `Pods` when you:


### PR DESCRIPTION
We allow warnings during trunk push, so we should be testing `pod lib lint` with allowed warnings.
