### PR TITLE
[TextFields] Don't list MDFI18N as dependency twice.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1859,7 +1859,6 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/AnimationTiming"
     component.dependency "MaterialComponents/Palettes"
     component.dependency "MaterialComponents/Typography"
-    component.dependency "MDFInternationalization"
     component.dependency "MaterialComponents/private/Math"
     component.dependency "MDFInternationalization"
 


### PR DESCRIPTION
Removes a duplicated dependency from the podspec for Text Fields.