### PR TITLE
[Color] Remove use of `NS_ASSUME_NONNULL_BEGIN`.

### DIFF
--- a/components/private/Color/src/UIColor+MaterialBlending.h
+++ b/components/private/Color/src/UIColor+MaterialBlending.h
@@ -14,8 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface UIColor (MaterialBlending)
 
 /**
@@ -29,5 +27,3 @@ NS_ASSUME_NONNULL_BEGIN
                 withBackgroundColor:(nonnull UIColor *)backgroundColor;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/private/Color/src/UIColor+MaterialDynamic.h
+++ b/components/private/Color/src/UIColor+MaterialDynamic.h
@@ -14,8 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface UIColor (MaterialDynamic)
 
 /// Returns a color object that picks its value from given color objects dynamically
@@ -25,9 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param darkColor A color object returned when @c userInterfaceStyle is @c
 /// UIUserInterfaceStyleDark based on currently active traits.
 /// @param defaultColor A default color object.
-+ (UIColor *)colorWithUserInterfaceStyleDarkColor:(UIColor *)darkColor
-                                     defaultColor:(UIColor *)defaultColor;
++ (nonnull UIColor *)colorWithUserInterfaceStyleDarkColor:(nonnull UIColor *)darkColor
+                                             defaultColor:(nonnull UIColor *)defaultColor;
 
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The project overwhelmingly uses explicit nullability annotations. This PR
switches the Color component to use the same convention.

Part of #8297