### PR TITLE
[Slider] Remove use of `NS_ASSUME_NONNULL_BEGIN`.

### DIFF
--- a/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.h
+++ b/components/Slider/tests/unit/MockUIImpactFeedbackGenerator.h
@@ -14,13 +14,9 @@
 
 #import <UIKit/UIKit.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 API_AVAILABLE(ios(10.0))
 @interface MockUIImpactFeedbackGenerator : UIImpactFeedbackGenerator
 
 @property(nonatomic) BOOL impactHasOccurred;
 
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The project overwhelmingly uses explicit nullability annotations. This PR
switches a test class for MDCSlider to explicit annotations.

Part of #8297