### PR TITLE
[TextFields] Remove use of `NS_ASSUME_NONNULL_BEGIN`.

### DIFF
--- a/components/TextFields/examples/experimental/supplemental/InputChipView.h
+++ b/components/TextFields/examples/experimental/supplemental/InputChipView.h
@@ -18,18 +18,14 @@
 
 #import "MDCContainedInputView.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface InputChipView : UIControl <MDCContainedInputView>
-@property(strong, nonatomic, readonly) UITextField *textField;
+@property(nonnull, strong, nonatomic, readonly) UITextField *textField;
 
 @property(nonatomic, assign) BOOL chipsWrap;
 
 @property(nonatomic, assign) CGFloat chipRowHeight;
 @property(nonatomic, assign) CGFloat chipRowSpacing;
 
-- (void)addChip:(UIView *)chip;
+- (void)addChip:(nonnull UIView *)chip;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/TextFields/examples/experimental/supplemental/InputChipViewLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/InputChipViewLayout.h
@@ -17,8 +17,6 @@
 #import "MDCContainedInputView.h"
 #import "MaterialChips.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 // typedef NS_ENUM(NSUInteger, InputChipViewOrien) {
 //};
 
@@ -28,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign) CGFloat globalChipRowMinX;
 @property(nonatomic, assign) CGFloat globalChipRowMaxX;
 
-@property(nonatomic, strong) NSArray<NSValue *> *chipFrames;
+@property(nonnull, nonatomic, strong) NSArray<NSValue *> *chipFrames;
 
 @property(nonatomic, assign) CGRect floatingLabelFrameFloating;
 @property(nonatomic, assign) CGRect floatingLabelFrameNormal;
@@ -49,22 +47,22 @@ NS_ASSUME_NONNULL_BEGIN
 //@property(nonatomic, readonly) CGFloat minimumHeight;
 @property(nonatomic, readonly) CGFloat contentAreaMaxY;
 
-- (instancetype)initWithSize:(CGSize)size
-                      containerStyler:(id<MDCContainedInputViewStyler>)containerStyler
-                                 text:(NSString *)text
-                          placeholder:(NSString *)placeholder
-                                 font:(UIFont *)font
-                         floatingFont:(UIFont *)floatingFont
+- (nonnull instancetype)initWithSize:(CGSize)size
+                      containerStyler:(nonnull id<MDCContainedInputViewStyler>)containerStyler
+                                 text:(nonnull NSString *)text
+                          placeholder:(nonnull NSString *)placeholder
+                                 font:(nonnull UIFont *)font
+                         floatingFont:(nonnull UIFont *)floatingFont
                    floatingLabelState:(MDCContainedInputViewFloatingLabelState)floatingLabelState
-                                chips:(NSArray<UIView *> *)chips
-                       staleChipViews:(NSArray<UIView *> *)staleChipViews
+                                chips:(nonnull NSArray<UIView *> *)chips
+                       staleChipViews:(nonnull NSArray<UIView *> *)staleChipViews
                             chipsWrap:(BOOL)chipsWrap
                         chipRowHeight:(CGFloat)chipRowHeight
                      interChipSpacing:(CGFloat)interChipSpacing
-                          clearButton:(UIButton *)clearButton
+                          clearButton:(nonnull UIButton *)clearButton
                   clearButtonViewMode:(UITextFieldViewMode)clearButtonViewMode
-                   leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                  rightUnderlineLabel:(UILabel *)rightUnderlineLabel
+                   leftUnderlineLabel:(nonnull UILabel *)leftUnderlineLabel
+                  rightUnderlineLabel:(nonnull UILabel *)rightUnderlineLabel
            underlineLabelDrawPriority:
                (MDCContainedInputViewUnderlineLabelDrawPriority)underlineLabelDrawPriority
      customUnderlineLabelDrawPriority:(CGFloat)normalizedCustomUnderlineLabelDrawPriority
@@ -73,5 +71,3 @@ NS_ASSUME_NONNULL_BEGIN
                                 isRTL:(BOOL)isRTL
                             isEditing:(BOOL)isEditing;
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/TextFields/examples/experimental/supplemental/MDCContainedInputUnderlineLabelView.h
+++ b/components/TextFields/examples/experimental/supplemental/MDCContainedInputUnderlineLabelView.h
@@ -18,14 +18,10 @@
 
 #import "MDCContainedInputUnderlineLabelViewLayout.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface MDCContainedInputUnderlineLabelView : UIView
 
-@property(nonatomic, strong, readonly) UILabel *leftUnderlineLabel;
-@property(nonatomic, strong, readonly) UILabel *rightUnderlineLabel;
-@property(nonatomic, strong) MDCContainedInputUnderlineLabelViewLayout *layout;
+@property(nonnull, nonatomic, strong, readonly) UILabel *leftUnderlineLabel;
+@property(nonnull, nonatomic, strong, readonly) UILabel *rightUnderlineLabel;
+@property(nonnull, nonatomic, strong) MDCContainedInputUnderlineLabelViewLayout *layout;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/TextFields/examples/experimental/supplemental/MDCContainedInputUnderlineLabelViewLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/MDCContainedInputUnderlineLabelViewLayout.h
@@ -17,24 +17,20 @@
 
 #import "MDCContainedInputView.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface MDCContainedInputUnderlineLabelViewLayout : NSObject
 
 @property(nonatomic, assign, readonly) CGRect leftUnderlineLabelFrame;
 @property(nonatomic, assign, readonly) CGRect rightUnderlineLabelFrame;
 @property(nonatomic, assign, readonly) CGFloat calculatedHeight;
 
-- (instancetype)initWithSuperviewWidth:(CGFloat)superviewWidth
-                    leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                   rightUnderlineLabel:(UILabel *)rightUnderlineLabel
-            underlineLabelDrawPriority:
-                (MDCContainedInputViewUnderlineLabelDrawPriority)underlineLabelDrawPriority
-      customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
-                     horizontalPadding:(CGFloat)horizontalPadding
-                       verticalPadding:(CGFloat)verticalPadding
-                                 isRTL:(BOOL)isRTL;
+- (nonnull instancetype)initWithSuperviewWidth:(CGFloat)superviewWidth
+                            leftUnderlineLabel:(nonnull UILabel *)leftUnderlineLabel
+                           rightUnderlineLabel:(nonnull UILabel *)rightUnderlineLabel
+                    underlineLabelDrawPriority:
+                        (MDCContainedInputViewUnderlineLabelDrawPriority)underlineLabelDrawPriority
+              customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+                             horizontalPadding:(CGFloat)horizontalPadding
+                               verticalPadding:(CGFloat)verticalPadding
+                                         isRTL:(BOOL)isRTL;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/components/TextFields/examples/experimental/supplemental/MDCInputTextFieldLayout.h
+++ b/components/TextFields/examples/experimental/supplemental/MDCInputTextFieldLayout.h
@@ -21,8 +21,6 @@
 
 @protocol MDCContainedInputViewStyler;
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface MDCInputTextFieldLayout : NSObject
 
 @property(nonatomic, readonly, class) CGFloat clearButtonSideLength;
@@ -42,35 +40,35 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign) CGRect leftViewFrame;
 @property(nonatomic, assign) CGRect rightViewFrame;
 @property(nonatomic, assign) CGRect underlineLabelViewFrame;
-@property(nonatomic, strong) MDCContainedInputUnderlineLabelViewLayout *underlineLabelViewLayout;
+@property(nonnull, nonatomic, strong)
+    MDCContainedInputUnderlineLabelViewLayout *underlineLabelViewLayout;
 
 @property(nonatomic, readonly) CGFloat calculatedHeight;
 @property(nonatomic, assign) CGFloat topRowBottomRowDividerY;
 
-- (instancetype)initWithTextFieldSize:(CGSize)textFieldSize
-                      containerStyler:(id<MDCContainedInputViewStyler>)containerStyler
-                                 text:(NSString *)text
-                          placeholder:(NSString *)placeholder
-                                 font:(UIFont *)font
-                         floatingFont:(UIFont *)floatingFont
-                        floatingLabel:(UILabel *)floatingLabel
-                canFloatingLabelFloat:(BOOL)canFloatingLabelFloat
-                             leftView:(UIView *)leftView
-                         leftViewMode:(UITextFieldViewMode)leftViewMode
-                            rightView:(UIView *)rightView
-                        rightViewMode:(UITextFieldViewMode)rightViewMode
-                          clearButton:(UIButton *)clearButton
-                      clearButtonMode:(UITextFieldViewMode)clearButtonMode
-                   leftUnderlineLabel:(UILabel *)leftUnderlineLabel
-                  rightUnderlineLabel:(UILabel *)rightUnderlineLabel
-           underlineLabelDrawPriority:
-               (MDCContainedInputViewUnderlineLabelDrawPriority)underlineLabelDrawPriority
-     customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
-       preferredMainContentAreaHeight:(CGFloat)preferredMainContentAreaHeight
-    preferredUnderlineLabelAreaHeight:(CGFloat)preferredUnderlineLabelAreaHeight
-                                isRTL:(BOOL)isRTL
-                            isEditing:(BOOL)isEditing;
+- (nonnull instancetype)initWithTextFieldSize:(CGSize)textFieldSize
+                              containerStyler:
+                                  (nonnull id<MDCContainedInputViewStyler>)containerStyler
+                                         text:(nonnull NSString *)text
+                                  placeholder:(nonnull NSString *)placeholder
+                                         font:(nonnull UIFont *)font
+                                 floatingFont:(nonnull UIFont *)floatingFont
+                                floatingLabel:(nonnull UILabel *)floatingLabel
+                        canFloatingLabelFloat:(BOOL)canFloatingLabelFloat
+                                     leftView:(nonnull UIView *)leftView
+                                 leftViewMode:(UITextFieldViewMode)leftViewMode
+                                    rightView:(nonnull UIView *)rightView
+                                rightViewMode:(UITextFieldViewMode)rightViewMode
+                                  clearButton:(nonnull UIButton *)clearButton
+                              clearButtonMode:(UITextFieldViewMode)clearButtonMode
+                           leftUnderlineLabel:(nonnull UILabel *)leftUnderlineLabel
+                          rightUnderlineLabel:(nonnull UILabel *)rightUnderlineLabel
+                   underlineLabelDrawPriority:
+                       (MDCContainedInputViewUnderlineLabelDrawPriority)underlineLabelDrawPriority
+             customUnderlineLabelDrawPriority:(CGFloat)customUnderlineLabelDrawPriority
+               preferredMainContentAreaHeight:(CGFloat)preferredMainContentAreaHeight
+            preferredUnderlineLabelAreaHeight:(CGFloat)preferredUnderlineLabelAreaHeight
+                                        isRTL:(BOOL)isRTL
+                                    isEditing:(BOOL)isEditing;
 
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The project overwhelmingly uses explicit nullability annotations. This PR
switches experimental code to using explicit nullability.

Part of #8297