### PR TITLE
[List] Fix typo in README

### DIFF
--- a/components/List/README.md
+++ b/components/List/README.md
@@ -310,7 +310,7 @@ and save where the touches were so we can then start the ripple animation from
 that point:
 
 <!--<div class="material-code-render" markdown="1">-->
-#### Objevctive-C
+#### Objective-C
 
 ```objc
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {

--- a/components/List/docs/create-your-own.md
+++ b/components/List/docs/create-your-own.md
@@ -61,7 +61,7 @@ and save where the touches were so we can then start the ripple animation from
 that point:
 
 <!--<div class="material-code-render" markdown="1">-->
-#### Objevctive-C
+#### Objective-C
 
 ```objc
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
"Objective-C" was misspelled.

Part of #8293