### PR TITLE
[Chips] delete deprecated mdc_legacyFontScaling.

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -157,17 +157,6 @@
     BOOL mdc_adjustsFontForContentSizeCategory UI_APPEARANCE_SELECTOR;
 
 /**
- Enable legacy font scaling curves for Dynamic Type.
-
- Legacy font scaling uses the older [UIFont mdc_fontSizedForMaterialTextStyle:scaledForDynamicType:
- category instead of the MDCFontScaler API.
-
- Default value is YES.
- */
-@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:)
-    BOOL mdc_legacyFontScaling __deprecated;
-
-/**
  Affects the fallback behavior for when a scaled font is not provided.
 
  If enabled, the font size will adjust even if a scaled font has not been provided for

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -319,14 +319,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   [self updateTitleFont];
 }
 
-- (void)mdc_setLegacyFontScaling:(BOOL)legacyScaling {
-  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = legacyScaling;
-}
-
-- (BOOL)mdc_legacyFontScaling {
-  return _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-}
-
 - (void)contentSizeCategoryDidChange:(__unused NSNotification *)notification {
   [self updateTitleFont];
 }
@@ -542,7 +534,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
   // If we are automatically adjusting for Dynamic Type resize the font based on the text style
   if (self.mdc_adjustsFontForContentSizeCategory) {
-    if (titleFont.mdc_scalingCurve && !self.mdc_legacyFontScaling) {
+    if (titleFont.mdc_scalingCurve) {
       titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
     } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       titleFont =


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8304