### PR TITLE
[Buttons] Delete deprecated mdc_legacyFontScaling API.

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -140,8 +140,6 @@
  Default value is @c YES.
  */
 @property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:)
-    BOOL mdc_legacyFontScaling __deprecated;
 
 /**
  The shape generator used to define the button's shape.

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -989,14 +989,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   [self sizeToFit];
 }
 
-- (BOOL)mdc_legacyFontScaling {
-  return self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-}
-
-- (void)mdc_setLegacyFontScaling:(BOOL)mdc_legacyFontScaling {
-  self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = mdc_legacyFontScaling;
-}
-
 #pragma mark - Deprecations
 
 - (void)setCustomTitleColor:(UIColor *)customTitleColor {


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8304