### PR TITLE
[Shapes] Update border color to support dynamic color

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1625,6 +1625,7 @@ Pod::Spec.new do |mdc|
     component.source_files = "components/#{component.base_name}/src/*.{h,m}", "components/#{component.base_name}/src/private/*.{h,m}"
 
     component.dependency "MaterialComponents/ShadowLayer"
+    component.dependency "MaterialComponents/private/Color"
     component.dependency "MaterialComponents/private/Math"
 
     component.test_spec 'UnitTests' do |unit_tests|

--- a/components/Shapes/BUILD
+++ b/components/Shapes/BUILD
@@ -33,6 +33,7 @@ mdc_public_objc_library(
     ],
     deps = [
         "//components/ShadowLayer",
+        "//components/private/Color",
         "//components/private/Math",
     ],
 )

--- a/components/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/Shapes/src/MDCShapedShadowLayer.m
@@ -114,10 +114,6 @@
 - (void)setShapedBackgroundColor:(UIColor *)shapedBackgroundColor {
   _shapedBackgroundColor = shapedBackgroundColor;
 
-  if ([self.delegate isKindOfClass:[UIView class]]) {
-    UIView *view = (UIView *)self.delegate;
-    _shapedBackgroundColor = [_shapedBackgroundColor mdc_resolvedColorWithTraitCollection:view.traitCollection];
-  }
   if (CGPathIsEmpty(self.path)) {
     self.backgroundColor = _shapedBackgroundColor.CGColor;
     _colorLayer.fillColor = nil;

--- a/components/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/Shapes/src/MDCShapedShadowLayer.m
@@ -128,7 +128,8 @@
 
   if ([self.delegate isKindOfClass:[UIView class]]) {
     UIView *view = (UIView *)self.delegate;
-    _shapedBorderColor = [_shapedBorderColor mdc_resolvedColorWithTraitCollection:view.traitCollection];
+    _shapedBorderColor =
+        [_shapedBorderColor mdc_resolvedColorWithTraitCollection:view.traitCollection];
   }
   if (CGPathIsEmpty(self.path)) {
     self.borderColor = _shapedBorderColor.CGColor;

--- a/components/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/Shapes/src/MDCShapedShadowLayer.m
@@ -15,6 +15,7 @@
 #import "MDCShapedShadowLayer.h"
 
 #import "MDCShapeGenerating.h"
+#import "MaterialColor.h"
 
 @implementation MDCShapedShadowLayer
 
@@ -125,6 +126,10 @@
 - (void)setShapedBorderColor:(UIColor *)shapedBorderColor {
   _shapedBorderColor = shapedBorderColor;
 
+  if ([self.delegate isKindOfClass:[UIView class]]) {
+    UIView *view = (UIView *)self.delegate;
+//    _shapedBorderColor = [_shapedBorderColor mdc]
+  }
   if (CGPathIsEmpty(self.path)) {
     self.borderColor = _shapedBorderColor.CGColor;
     _colorLayer.strokeColor = nil;

--- a/components/Shapes/src/MDCShapedShadowLayer.m
+++ b/components/Shapes/src/MDCShapedShadowLayer.m
@@ -114,6 +114,10 @@
 - (void)setShapedBackgroundColor:(UIColor *)shapedBackgroundColor {
   _shapedBackgroundColor = shapedBackgroundColor;
 
+  if ([self.delegate isKindOfClass:[UIView class]]) {
+    UIView *view = (UIView *)self.delegate;
+    _shapedBackgroundColor = [_shapedBackgroundColor mdc_resolvedColorWithTraitCollection:view.traitCollection];
+  }
   if (CGPathIsEmpty(self.path)) {
     self.backgroundColor = _shapedBackgroundColor.CGColor;
     _colorLayer.fillColor = nil;
@@ -128,7 +132,7 @@
 
   if ([self.delegate isKindOfClass:[UIView class]]) {
     UIView *view = (UIView *)self.delegate;
-//    _shapedBorderColor = [_shapedBorderColor mdc]
+    _shapedBorderColor = [_shapedBorderColor mdc_resolvedColorWithTraitCollection:view.traitCollection];
   }
   if (CGPathIsEmpty(self.path)) {
     self.borderColor = _shapedBorderColor.CGColor;


### PR DESCRIPTION
### Context

Currently the `setBorderColor` method of MDCShapedShadowLayer can receive a dynamic color but will use the light mode color because it doesn't not know about traitCollections since it is a CALayer subclass. This causes a problem for any component that subclasses `UIControl` and updates its visuals based on state. For instance MDCCard within `setHighlighted` calls `updateBorderColor` which then would call `setBorderColor` on the shapedShadowLayer. Since traitCollection was never involved here the border gets render as it's in a light mode even if it happens to be in a dark mode. Additionally, we may need this for other CGColor things but this will unblock card for now.

### Screenshots

| Before | After |
| - | - |
|![before](https://user-images.githubusercontent.com/7131294/62970425-73d0da00-bddd-11e9-8643-6ae5b039a3a2.gif)|![after](https://user-images.githubusercontent.com/7131294/62970438-7d5a4200-bddd-11e9-9a38-45b7e8bb8328.gif)|
