### PR TITLE
[FeatureHighlight] Add missing test for Dynamic Type and mark mdc_legacyFontScaling deprecated.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1015,6 +1015,7 @@ Pod::Spec.new do |mdc|
       unit_tests.dependency "MaterialComponents/FeatureHighlight+ColorThemer"
       unit_tests.dependency "MaterialComponents/FeatureHighlight+TypographyThemer"
       unit_tests.dependency "MaterialComponents/FeatureHighlight+FeatureHighlightAccessibilityMutator"
+      unit_tests.dependency "MaterialComponents/Typography"
     end
   end
 

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -134,6 +134,7 @@ mdc_unit_test_objc_library(
         ":FontThemer",
         ":TypographyThemer",
         ":private",
+        "//components/Typography",
     ],
 )
 

--- a/components/FeatureHighlight/src/MDCFeatureHighlightView.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightView.h
@@ -41,7 +41,19 @@
  Enable legacy font scaling curves for Dynamic Type
  Default value is NO.
  */
-@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:) BOOL mdc_legacyFontScaling;
+@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:)
+    BOOL mdc_legacyFontScaling __deprecated;
+
+/**
+ Affects the fallback behavior for when a scaled font is not provided.
+ If enabled, the font size will adjust even if a scaled font has not been provided for
+ a given UIFont property on this component.
+ If disabled, the font size will only be adjusted if a scaled font has been provided.
+ This behavior most closely matches UIKit's.
+ Default value is YES, but this flag will eventually default to NO and then be deprecated
+ and deleted.
+ */
+@property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
 /**
  A block that is invoked when the @c MDCFeatureHighlightView receives a call to @c

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.h
@@ -150,7 +150,19 @@ typedef void (^MDCFeatureHighlightCompletion)(BOOL accepted);
  Enable legacy font scaling curves for Dynamic Type.
  Default value is NO.
  */
-@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:) BOOL mdc_legacyFontScaling;
+@property(nonatomic, readwrite, setter=mdc_setLegacyFontScaling:)
+    BOOL mdc_legacyFontScaling __deprecated;
+
+/**
+ Affects the fallback behavior for when a scaled font is not provided.
+ If enabled, the font size will adjust even if a scaled font has not been provided for
+ a given UIFont property on this component.
+ If disabled, the font size will only be adjusted if a scaled font has been provided.
+ This behavior most closely matches UIKit's.
+ Default value is YES, but this flag will eventually default to NO and then be deprecated
+ and deleted.
+ */
+@property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
 /**
  A block that is invoked when the @c MDCFeatureHighlightViewController receives a call to @c

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -52,6 +52,7 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
     _outerHighlightColor =
         [[UIColor blueColor] colorWithAlphaComponent:kMDCFeatureHighlightOuterHighlightAlpha];
     _innerHighlightColor = [UIColor whiteColor];
+    _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
     _displayedView.accessibilityTraits = UIAccessibilityTraitButton;
 
@@ -72,6 +73,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
   self.featureHighlightView.mdc_adjustsFontForContentSizeCategory =
       _mdc_adjustsFontForContentSizeCategory;
   self.featureHighlightView.mdc_legacyFontScaling = _mdc_legacyFontScaling;
+  self.featureHighlightView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
   __weak MDCFeatureHighlightViewController *weakSelf = self;
   self.featureHighlightView.interactionBlock = ^(BOOL accepted) {
@@ -281,6 +284,17 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
 
   if (self.isViewLoaded) {
     self.featureHighlightView.mdc_legacyFontScaling = legacyScaling;
+  }
+}
+
+- (void)setAdjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable:
+    (BOOL)adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable {
+  _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+      adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
+
+  if (self.isViewLoaded) {
+    self.featureHighlightView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
+        adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   }
 }
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -185,8 +185,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   if (_mdc_adjustsFontForContentSizeCategory) {
     if (_titleFont.mdc_scalingCurve && !_mdc_legacyFontScaling) {
       // The font has an associated curve (M2+)
-      _titleLabel.font = [_titleFont mdc_scaledFontForCurrentSizeCategory];
-    } else {
+      _titleLabel.font = [_titleFont mdc_scaledFontForTraitEnvironment:self];
+    } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       // The original (M1) custom font + DT implementation
       _titleLabel.font =
           [_titleFont mdc_fontSizedForMaterialTextStyle:kTitleTextStyle
@@ -215,19 +215,19 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   if (!_bodyFont) {
     _bodyFont = [MDCFeatureHighlightView defaultBodyFont];
   }
+  UIFont *bodyFont = _bodyFont;
   if (_mdc_adjustsFontForContentSizeCategory) {
-    if (_bodyFont.mdc_scalingCurve && !_mdc_legacyFontScaling) {
+    if (bodyFont.mdc_scalingCurve && !_mdc_legacyFontScaling) {
       // The font has an associated curve (M2+)
-      _bodyLabel.font = [_bodyFont mdc_scaledFontForCurrentSizeCategory];
-    } else {
+      bodyFont = [bodyFont mdc_scaledFontForTraitEnvironment:self];
+    } else if (self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable) {
       // The original (M1) custom font + DT implementation
-      _bodyLabel.font =
+      bodyFont =
           [_bodyFont mdc_fontSizedForMaterialTextStyle:kBodyTextStyle
                                   scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
     }
-  } else {
-    _bodyLabel.font = _bodyFont;
   }
+  _bodyLabel.font = bodyFont;
 
   [self setNeedsLayout];
 }


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8304.