### PR TITLE
[Typography] add doc to clarify useCurrentContentSizeCategoryWhenApplied.

### DIFF
--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -94,7 +94,8 @@
  @warning This API will eventually be deprecated. Please use
  @c useCurrentContentSizeCategoryWhenApplied instead.
 
- @note  The value of @c useCurrentContentSizeCategoryWhenApplied (if implemented) and @c mdc_adjustsFontForContentSizeCategory must always be the same.
+ @note  The value of @c useCurrentContentSizeCategoryWhenApplied (if implemented) and @c
+ mdc_adjustsFontForContentSizeCategory must always be the same.
 
 */
 @property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory __deprecated;

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -107,7 +107,8 @@
  the component.
 
  @note This flag will become required in the future as a replacement for
- @c mdc_adjustsFontForContentSizeCategory. The value of this flag needs to be the same as @c mdc_adjustsFontForContentSizeCategory.
+ @c mdc_adjustsFontForContentSizeCategory. The value of this flag needs to be the same as @c
+ mdc_adjustsFontForContentSizeCategory.
  */
 @property(nonatomic, assign, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -92,7 +92,8 @@
  functionality and embedded frameworks that also render UI.
 
  @warning This API will eventually be deprecated. Please use
- @c useCurrentContentSizeCategoryWhenApplied instead.
+ @c useCurrentContentSizeCategoryWhenApplied instead. It is recommended to use
+ @c useCurrentContentSizeCategoryWhenApplied as the backing value during deprecation.
 */
 @property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory __deprecated;
 

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -92,8 +92,10 @@
  functionality and embedded frameworks that also render UI.
 
  @warning This API will eventually be deprecated. Please use
- @c useCurrentContentSizeCategoryWhenApplied instead. It is recommended to use
- @c useCurrentContentSizeCategoryWhenApplied as the backing value during deprecation.
+ @c useCurrentContentSizeCategoryWhenApplied instead.
+
+ @note  The value of @c useCurrentContentSizeCategoryWhenApplied (if implemented) and @c mdc_adjustsFontForContentSizeCategory must always be the same.
+
 */
 @property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory __deprecated;
 

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -94,7 +94,7 @@
  @warning This API will eventually be deprecated. Please use
  @c useCurrentContentSizeCategoryWhenApplied instead.
 */
-@property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory;
+@property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory __deprecated;
 
 @optional
 
@@ -106,7 +106,7 @@
  the component.
 
  @note This flag will become required in the future as a replacement for
- @c mdc_adjustsFontForContentSizeCategory.
+ @c mdc_adjustsFontForContentSizeCategory. The value of this flag needs to be the same as @c mdc_adjustsFontForContentSizeCategory.
  */
 @property(nonatomic, assign, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 


### PR DESCRIPTION
Related to discussion in https://github.com/material-components/material-components-ios/pull/8285#discussion_r313948120.

For clients who conform to `useCurrentContentSizeCategoryWhenApplied` property, it is implicit that its value needs to be the same as `mdc_adjustsFontForContentSizeCategory`. Adding instruction to clarify the migration path would remove the confusion.