### PR TITLE
[Color+Elevation] Add a convenience method to resolve dynamic color only when traitCollection's color appearance has changed.

### DIFF
--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -31,10 +31,9 @@
 - (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 
 /**
- Returns a color that takes the specified elevation value and traits into account when there is a color
- appearance difference between current traits and previous traits.
- When userInterfaceStyle is UIUserInterfaceStyleDark in currentTraitCollection, elevation will be used
- to resolve the color.
+ Returns a color that takes the specified elevation value and traits into account when there is a
+ color appearance difference between current traits and previous traits. When userInterfaceStyle is
+ UIUserInterfaceStyleDark in currentTraitCollection, elevation will be used to resolve the color.
  Negative elevation is treated as 0.
  Pattern-based UIColor is not supported.
  UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
@@ -43,9 +42,10 @@
  @param previousTraitCollection The previous traits to use when comparing color appearance.
  @param elevation The @c mdc_absoluteElevation to use when resolving the color.
  */
-- (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:(nonnull UITraitCollection *)currentTraitCollection
-                                  previousTraitCollection:(nonnull UITraitCollection *)previousTraitCollection
-                                                elevation:(CGFloat)elevation;
+- (nonnull UIColor *)
+    mdc_resolvedColorWithTraitCollection:(nonnull UITraitCollection *)currentTraitCollection
+                 previousTraitCollection:(nonnull UITraitCollection *)previousTraitCollection
+                               elevation:(CGFloat)elevation;
 
 /**
  Returns a color that takes the specified elevation value and traits into account.

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -34,16 +34,17 @@
  Returns a color that takes the specified elevation value and traits into account when there is a
  color appearance difference between current traits and previous traits. When userInterfaceStyle is
  UIUserInterfaceStyleDark in currentTraitCollection, elevation will be used to resolve the color.
+
  Negative elevation is treated as 0.
  Pattern-based UIColor is not supported.
  UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
 
- @param currentTraitCollection The traits to use when resolving the color.
+ @param traitCollection The traits to use when resolving the color.
  @param previousTraitCollection The previous traits to use when comparing color appearance.
  @param elevation The @c mdc_absoluteElevation to use when resolving the color.
  */
 - (nonnull UIColor *)
-    mdc_resolvedColorWithTraitCollection:(nonnull UITraitCollection *)currentTraitCollection
+    mdc_resolvedColorWithTraitCollection:(nonnull UITraitCollection *)traitCollection
                  previousTraitCollection:(nonnull UITraitCollection *)previousTraitCollection
                                elevation:(CGFloat)elevation;
 

--- a/components/Elevation/src/UIColor+MaterialElevation.h
+++ b/components/Elevation/src/UIColor+MaterialElevation.h
@@ -31,6 +31,23 @@
 - (nonnull UIColor *)mdc_resolvedColorWithElevation:(CGFloat)elevation;
 
 /**
+ Returns a color that takes the specified elevation value and traits into account when there is a color
+ appearance difference between current traits and previous traits.
+ When userInterfaceStyle is UIUserInterfaceStyleDark in currentTraitCollection, elevation will be used
+ to resolve the color.
+ Negative elevation is treated as 0.
+ Pattern-based UIColor is not supported.
+ UIColor in UIExtendedGrayColorSpace will be resolved to UIExtendedSRGBColorSpace.
+
+ @param currentTraitCollection The traits to use when resolving the color.
+ @param previousTraitCollection The previous traits to use when comparing color appearance.
+ @param elevation The @c mdc_absoluteElevation to use when resolving the color.
+ */
+- (nonnull UIColor *)mdc_resolvedColorWithTraitCollection:(nonnull UITraitCollection *)currentTraitCollection
+                                  previousTraitCollection:(nonnull UITraitCollection *)previousTraitCollection
+                                                elevation:(CGFloat)elevation;
+
+/**
  Returns a color that takes the specified elevation value and traits into account.
  When userInterfaceStyle is UIUserInterfaceStyleDark in traitCollection, elevation will be used
  to resolve the color.

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -21,14 +21,14 @@
 
 @implementation UIColor (MaterialElevation)
 
-- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)currentTraitCollection
+- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
                           previousTraitCollection:(UITraitCollection *)previousTraitCollection
                                         elevation:(CGFloat)elevation {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
-    if ([currentTraitCollection
+    if ([traitCollection
             hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
-      return [self mdc_resolvedColorWithTraitCollection:currentTraitCollection elevation:elevation];
+      return [self mdc_resolvedColorWithTraitCollection:traitCollection elevation:elevation];
     }
   }
 #endif

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -21,6 +21,19 @@
 
 @implementation UIColor (MaterialElevation)
 
+- (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)currentTraitCollection
+                          previousTraitCollection:(UITraitCollection *)previousTraitCollection
+                                        elevation:(CGFloat)elevation {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    if ([currentTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+      return [self mdc_resolvedColorWithTraitCollection:currentTraitCollection elevation:elevation];
+    }
+  }
+#endif
+  return self;
+}
+
 - (UIColor *)mdc_resolvedColorWithTraitCollection:(UITraitCollection *)traitCollection
                                         elevation:(CGFloat)elevation {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)

--- a/components/Elevation/src/UIColor+MaterialElevation.m
+++ b/components/Elevation/src/UIColor+MaterialElevation.m
@@ -26,7 +26,8 @@
                                         elevation:(CGFloat)elevation {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
-    if ([currentTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    if ([currentTraitCollection
+            hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
       return [self mdc_resolvedColorWithTraitCollection:currentTraitCollection elevation:elevation];
     }
   }

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -320,6 +320,7 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 }
 
 - (void)testResolvingColorWithDifferenceCurrentTraitCollectionAndPreviousTraitCollection {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     // Given
     CGFloat elevation = (CGFloat)10;
@@ -339,7 +340,12 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                                  elevation:elevation];
     // Then
     XCTAssertNotEqual(resolvedColor, dynamicColor);
+    UIColor *expectedColor =
+        [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
+                                                 elevation:elevation];
+    XCTAssertEqual(resolvedColor, expectedColor);
   }
+#endif
 }
 
 @end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -296,4 +296,48 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
                                           secondColor:resolvedSecondRGBColor];
 }
 
+- (void)testResolvingColorWithSameCurrentTraitCollectionAndPreviousTraitCollection {
+  if (@available(iOS 13.0, *)) {
+    // Given
+    CGFloat elevation = (CGFloat)10;
+    UIColor *darkColor = UIColor.blackColor;
+    UIColor *lightColor = UIColor.whiteColor;
+    UIColor *dynamicColor = [UIColor colorWithUserInterfaceStyleDarkColor:darkColor
+                                                             defaultColor:lightColor];
+
+    // When
+    UITraitCollection *previousTraitCollection =
+    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UITraitCollection *currentTraitCollection =
+    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UIColor *resolvedColor = [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
+                                                        previousTraitCollection:previousTraitCollection
+                                                                      elevation:elevation];
+    // Then
+    XCTAssertEqualObjects(resolvedColor, dynamicColor);
+  }
+}
+
+- (void)testResolvingColorWithDifferenceCurrentTraitCollectionAndPreviousTraitCollection {
+  if (@available(iOS 13.0, *)) {
+    // Given
+    CGFloat elevation = (CGFloat)10;
+    UIColor *darkColor = UIColor.blackColor;
+    UIColor *lightColor = UIColor.whiteColor;
+    UIColor *dynamicColor = [UIColor colorWithUserInterfaceStyleDarkColor:darkColor
+                                                             defaultColor:lightColor];
+
+    // When
+    UITraitCollection *previousTraitCollection =
+    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UITraitCollection *currentTraitCollection =
+    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
+    UIColor *resolvedColor = [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
+                                                        previousTraitCollection:previousTraitCollection
+                                                                      elevation:elevation];
+    // Then
+    XCTAssertNotEqual(resolvedColor, dynamicColor);
+  }
+}
+
 @end

--- a/components/Elevation/tests/unit/MaterialElevationColorTests.m
+++ b/components/Elevation/tests/unit/MaterialElevationColorTests.m
@@ -307,12 +307,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
     // When
     UITraitCollection *previousTraitCollection =
-    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UITraitCollection *currentTraitCollection =
-    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
-    UIColor *resolvedColor = [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
-                                                        previousTraitCollection:previousTraitCollection
-                                                                      elevation:elevation];
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UIColor *resolvedColor =
+        [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
+                                   previousTraitCollection:previousTraitCollection
+                                                 elevation:elevation];
     // Then
     XCTAssertEqualObjects(resolvedColor, dynamicColor);
   }
@@ -329,12 +330,13 @@ static UIImage *fakeImageWithColorAndSize(UIColor *color, CGRect bounds) {
 
     // When
     UITraitCollection *previousTraitCollection =
-    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
     UITraitCollection *currentTraitCollection =
-    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
-    UIColor *resolvedColor = [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
-                                                        previousTraitCollection:previousTraitCollection
-                                                                      elevation:elevation];
+        [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
+    UIColor *resolvedColor =
+        [dynamicColor mdc_resolvedColorWithTraitCollection:currentTraitCollection
+                                   previousTraitCollection:previousTraitCollection
+                                                 elevation:elevation];
     // Then
     XCTAssertNotEqual(resolvedColor, dynamicColor);
   }


### PR DESCRIPTION
Add this convenience method would help supporting theming extension in an easier way that we don't need to check color difference on traitCollection every time like https://github.com/material-components/material-components-ios/pull/8285/files#diff-48ca693ee2870d02b06a42900a1dc69dR73.