### PR TITLE
[Buttons] Changing logic for MDCButton accessibilityTraitsIncludesButton

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -535,8 +535,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  if (self.accessibilityTraitsIncludesButton) {
-    return [super accessibilityTraits] | UIAccessibilityTraitButton;
+  if (!self.accessibilityTraitsIncludesButton) {
+    return [super accessibilityTraits] & ~UIAccessibilityTraitButton;
   }
   return [super accessibilityTraits];
 }


### PR DESCRIPTION
`MDCButton` contains a property (`accessibilityTraitsIncludesButton`), which if true, is supposed to include `UIAccessibilityTraitButton` as part of the elements `accessibilityTraits`. However, as documented by Apple, "The default value for this property is `UIAccessibilityTraitNone` unless the receiver is a UIKit control, in which case the value is the standard set of traits associated with the control."

Additionally, it is noted by Apple that "Buttons are accessible by default. The default accessibility traits for a button are Button and User Interaction Enabled."

As a result, `MDCButton` already has `UIAccessibilityTraitButton` (since it subclasses `UIButton`). Instead, if users would like the element to not be identified as a button, we have to remove the trait.

**Apple documentation**
https://developer.apple.com/documentation/objectivec/nsobject/1615202-accessibilitytraits?language=objc
https://developer.apple.com/documentation/uikit/uibutton?language=objc

