### PR TITLE
[Snackbar] Adding traitCollection and elevationDidChange blocks of the messageView in the manager.

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -15,6 +15,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MDCSnackbarAlignment.h"
+#import "MaterialElevation.h"
 #import "MaterialShadowElevations.h"
 
 @class MDCSnackbarMessage;
@@ -47,7 +48,7 @@
  Snackbars prefer an application's main window is a subclass of @c MDCOverlayWindow. When a standard
  UIWindow is used an attempt is made to find the top-most view controller in the view hierarchy.
  */
-@interface MDCSnackbarManager : NSObject
+@interface MDCSnackbarManager : NSObject <MDCElevationOverriding>
 
 /**
  An instance of MDCSnackbarManager.
@@ -268,6 +269,19 @@
  */
 @property(nonatomic, weak, nullable) id<MDCSnackbarManagerDelegate> delegate;
 
+/**
+ A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView receives a call to @c
+ traitCollectionDidChange:.
+ */
+@property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlockForMessageView)
+    (MDCSnackbarMessageView *_Nonnull messageView,
+     UITraitCollection *_Nullable previousTraitCollection);
+
+/**
+ A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView elevation changes, and its mdc_elevationDidChangeBlock is called.
+ */
+@property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlockForMessageView)
+    (id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation);
 @end
 
 /**

--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -270,15 +270,16 @@
 @property(nonatomic, weak, nullable) id<MDCSnackbarManagerDelegate> delegate;
 
 /**
- A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView receives a call to @c
- traitCollectionDidChange:.
+ A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView receives a
+ call to @c traitCollectionDidChange:.
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlockForMessageView)
     (MDCSnackbarMessageView *_Nonnull messageView,
      UITraitCollection *_Nullable previousTraitCollection);
 
 /**
- A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView elevation changes, and its mdc_elevationDidChangeBlock is called.
+ A block that is invoked when the manager's current snackbar's MDCSnackbarMessageView elevation
+ changes, and its mdc_elevationDidChangeBlock is called.
  */
 @property(nonatomic, copy, nullable) void (^mdc_elevationDidChangeBlockForMessageView)
     (id<MDCElevatable> _Nonnull object, CGFloat absoluteElevation);

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -536,6 +536,8 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
   BOOL _shouldApplyStyleChangesToVisibleSnackbars;
 }
 
+@synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
+
 + (instancetype)defaultManager {
   static MDCSnackbarManager *defaultManager;
   static dispatch_once_t onceToken;
@@ -553,6 +555,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
     _disabledButtonAlpha = (CGFloat)0.12;
     _messageElevation = MDCShadowElevationSnackbar;
     _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+    _mdc_overrideBaseElevation = -1;
   }
   return self;
 }
@@ -823,6 +826,25 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
 - (BOOL)shouldApplyStyleChangesToVisibleSnackbars {
   return _shouldApplyStyleChangesToVisibleSnackbars;
+}
+
+#pragma mark - Elevation
+
+- (void)setMdc_overrideBaseElevation:(CGFloat)mdc_overrideBaseElevation {
+  if (_mdc_overrideBaseElevation != mdc_overrideBaseElevation) {
+     _mdc_overrideBaseElevation = mdc_overrideBaseElevation;
+      self.internalManager.currentSnackbar.mdc_overrideBaseElevation = mdc_overrideBaseElevation;
+   }
+}
+
+- (void)setTraitCollectionDidChangeBlockForMessageView:(void (^)(MDCSnackbarMessageView *, UITraitCollection *))traitCollectionDidChangeBlockForMessageView {
+  _traitCollectionDidChangeBlockForMessageView = traitCollectionDidChangeBlockForMessageView;
+  self.internalManager.currentSnackbar.traitCollectionDidChangeBlock = traitCollectionDidChangeBlockForMessageView;
+}
+
+- (void)setMdc_elevationDidChangeBlockForMessageView:(void (^)(id<MDCElevatable> _Nonnull, CGFloat))mdc_elevationDidChangeBlockForMessageView {
+  _mdc_elevationDidChangeBlockForMessageView = mdc_elevationDidChangeBlockForMessageView;
+  self.internalManager.currentSnackbar.mdc_elevationDidChangeBlock = mdc_elevationDidChangeBlockForMessageView;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -832,19 +832,24 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
 
 - (void)setMdc_overrideBaseElevation:(CGFloat)mdc_overrideBaseElevation {
   if (_mdc_overrideBaseElevation != mdc_overrideBaseElevation) {
-     _mdc_overrideBaseElevation = mdc_overrideBaseElevation;
-      self.internalManager.currentSnackbar.mdc_overrideBaseElevation = mdc_overrideBaseElevation;
-   }
+    _mdc_overrideBaseElevation = mdc_overrideBaseElevation;
+    self.internalManager.currentSnackbar.mdc_overrideBaseElevation = mdc_overrideBaseElevation;
+  }
 }
 
-- (void)setTraitCollectionDidChangeBlockForMessageView:(void (^)(MDCSnackbarMessageView *, UITraitCollection *))traitCollectionDidChangeBlockForMessageView {
+- (void)setTraitCollectionDidChangeBlockForMessageView:
+    (void (^)(MDCSnackbarMessageView *,
+              UITraitCollection *))traitCollectionDidChangeBlockForMessageView {
   _traitCollectionDidChangeBlockForMessageView = traitCollectionDidChangeBlockForMessageView;
-  self.internalManager.currentSnackbar.traitCollectionDidChangeBlock = traitCollectionDidChangeBlockForMessageView;
+  self.internalManager.currentSnackbar.traitCollectionDidChangeBlock =
+      traitCollectionDidChangeBlockForMessageView;
 }
 
-- (void)setMdc_elevationDidChangeBlockForMessageView:(void (^)(id<MDCElevatable> _Nonnull, CGFloat))mdc_elevationDidChangeBlockForMessageView {
+- (void)setMdc_elevationDidChangeBlockForMessageView:
+    (void (^)(id<MDCElevatable> _Nonnull, CGFloat))mdc_elevationDidChangeBlockForMessageView {
   _mdc_elevationDidChangeBlockForMessageView = mdc_elevationDidChangeBlockForMessageView;
-  self.internalManager.currentSnackbar.mdc_elevationDidChangeBlock = mdc_elevationDidChangeBlockForMessageView;
+  self.internalManager.currentSnackbar.mdc_elevationDidChangeBlock =
+      mdc_elevationDidChangeBlockForMessageView;
 }
 
 @end

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -225,16 +225,17 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
     _buttonFont = manager.buttonFont;
     _message = message;
     _dismissalHandler = [handler copy];
-    _mdc_overrideBaseElevation = -1;
-
+    _mdc_overrideBaseElevation = manager.mdc_overrideBaseElevation;
+    _traitCollectionDidChangeBlock = manager.traitCollectionDidChangeBlockForMessageView;
+    _mdc_elevationDidChangeBlock = manager.mdc_elevationDidChangeBlockForMessageView;
     self.backgroundColor = _snackbarMessageViewBackgroundColor;
     if (MDCSnackbarMessage.usesLegacySnackbar) {
       self.layer.cornerRadius = kLegacyCornerRadius;
     } else {
       self.layer.cornerRadius = kCornerRadius;
     }
-    _elevation = MDCShadowElevationSnackbar;
-    [(MDCShadowLayer *)self.layer setElevation:MDCShadowElevationSnackbar];
+    _elevation = manager.messageElevation;
+    [(MDCShadowLayer *)self.layer setElevation:_elevation];
 
     _anchoredToScreenBottom = YES;
 

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -14,6 +14,15 @@
 
 #import <XCTest/XCTest.h>
 #import "MaterialSnackbar.h"
+#import "../../src/private/MDCSnackbarManagerInternal.h"
+
+@interface MDCSnackbarManagerInternal (SnackbarManagerTesting)
+@property(nonatomic) MDCSnackbarMessageView *currentSnackbar;
+@end
+
+@interface MDCSnackbarManager (SnackbarManagerTesting)
+@property(nonnull, nonatomic, strong) MDCSnackbarManagerInternal *internalManager;
+@end
 
 @interface SnackbarManagerTests : XCTestCase
 
@@ -105,5 +114,143 @@
   // Then
   XCTAssertTrue(manager.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
+
+- (void)testTraitCollectionDidChangeCalledWhenTraitCollectionChanges {
+  // Given
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Called traitCollectionDidChange"];
+  __block UITraitCollection *passedTraitCollection;
+  __block MDCSnackbarMessageView *passedMessageView;
+  MDCSnackbarManager.defaultManager.traitCollectionDidChangeBlockForMessageView =
+      ^(MDCSnackbarMessageView *_Nonnull inMessageView,
+        UITraitCollection *_Nullable previousTraitCollection) {
+        passedMessageView = inMessageView;
+        passedTraitCollection = previousTraitCollection;
+        [expectation fulfill];
+      };
+
+  // When
+  [MDCSnackbarManager showMessage:message];
+  XCTestExpectation *mainQueueExpectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [mainQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[ mainQueueExpectation ] timeout:1];
+
+  UITraitCollection *testCollection = [UITraitCollection traitCollectionWithDisplayScale:77];
+  MDCSnackbarMessageView *messageView =
+      MDCSnackbarManager.defaultManager.internalManager.currentSnackbar;
+  [messageView traitCollectionDidChange:testCollection];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:1];
+  XCTAssertEqual(passedTraitCollection, testCollection);
+  XCTAssertEqual(passedMessageView, messageView);
+}
+
+- (void)testCurrentElevationMatchesElevationWhenElevationChanges {
+  // Given
+   MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+   message.duration = 10;
+  MDCSnackbarManager.defaultManager.messageElevation = 4;
+
+  // When
+  [MDCSnackbarManager showMessage:message];
+  XCTestExpectation *mainQueueExpectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [mainQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[ mainQueueExpectation ] timeout:1];
+
+  // Then
+  MDCSnackbarMessageView *messageView =
+      MDCSnackbarManager.defaultManager.internalManager.currentSnackbar;
+  XCTAssertEqualWithAccuracy(messageView.mdc_currentElevation, 4, 0.001);
+}
+
+- (void)testSettingOverrideBaseElevationReturnsSetValue {
+  // Given
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
+  CGFloat expectedBaseElevation = 99;
+
+  // When
+  [MDCSnackbarManager showMessage:message];
+  XCTestExpectation *mainQueueExpectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [mainQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[ mainQueueExpectation ] timeout:1];
+  MDCSnackbarManager.defaultManager.mdc_overrideBaseElevation = expectedBaseElevation;
+
+  // Then
+  MDCSnackbarMessageView *messageView =
+      MDCSnackbarManager.defaultManager.internalManager.currentSnackbar;
+  XCTAssertEqualWithAccuracy(messageView.mdc_overrideBaseElevation, expectedBaseElevation, 0.001);
+}
+
+- (void)testElevationDidChangeBlockCalledWhenElevationChangesValue {
+  // Given
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
+  MDCSnackbarManager.defaultManager.shouldApplyStyleChangesToVisibleSnackbars = YES;
+
+  // When
+  [MDCSnackbarManager showMessage:message];
+  XCTestExpectation *mainQueueExpectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [mainQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[ mainQueueExpectation ] timeout:1];
+  MDCSnackbarManager.defaultManager.messageElevation = 5;
+
+  __block BOOL blockCalled = NO;
+  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView = ^(MDCSnackbarMessageView *object, CGFloat elevation) {
+    blockCalled = YES;
+  };
+
+  // When
+  MDCSnackbarManager.defaultManager.messageElevation =
+      MDCSnackbarManager.defaultManager.messageElevation + 1;
+
+  // Then
+  XCTAssertTrue(blockCalled);
+}
+
+- (void)testElevationDidChangeBlockNotCalledWhenElevationIsSetWithoutChangingValue {
+  // Given
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
+  MDCSnackbarManager.defaultManager.shouldApplyStyleChangesToVisibleSnackbars = YES;
+
+  // When
+  [MDCSnackbarManager showMessage:message];
+  XCTestExpectation *mainQueueExpectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [mainQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[ mainQueueExpectation ] timeout:1];
+  MDCSnackbarManager.defaultManager.messageElevation = 5;
+
+  __block BOOL blockCalled = NO;
+  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView = ^(MDCSnackbarMessageView *object, CGFloat elevation) {
+    blockCalled = YES;
+  };
+
+  // When
+  MDCSnackbarManager.defaultManager.messageElevation =
+      MDCSnackbarManager.defaultManager.messageElevation;
+
+  // Then
+  XCTAssertFalse(blockCalled);
+}
+
+- (void)testDefaultValueForOverrideBaseElevationIsNegative {
+  // Then
+  XCTAssertLessThan(MDCSnackbarManager.defaultManager.mdc_overrideBaseElevation, 0);
+}
+
 
 @end

--- a/components/Snackbar/tests/unit/SnackbarManagerTests.m
+++ b/components/Snackbar/tests/unit/SnackbarManagerTests.m
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "MaterialSnackbar.h"
 #import "../../src/private/MDCSnackbarManagerInternal.h"
+#import "MaterialSnackbar.h"
 
 @interface MDCSnackbarManagerInternal (SnackbarManagerTesting)
 @property(nonatomic) MDCSnackbarMessageView *currentSnackbar;
@@ -152,8 +152,8 @@
 
 - (void)testCurrentElevationMatchesElevationWhenElevationChanges {
   // Given
-   MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
-   message.duration = 10;
+  MDCSnackbarMessage *message = [MDCSnackbarMessage messageWithText:@"foo1"];
+  message.duration = 10;
   MDCSnackbarManager.defaultManager.messageElevation = 4;
 
   // When
@@ -207,9 +207,10 @@
   MDCSnackbarManager.defaultManager.messageElevation = 5;
 
   __block BOOL blockCalled = NO;
-  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView = ^(MDCSnackbarMessageView *object, CGFloat elevation) {
-    blockCalled = YES;
-  };
+  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView =
+      ^(MDCSnackbarMessageView *object, CGFloat elevation) {
+        blockCalled = YES;
+      };
 
   // When
   MDCSnackbarManager.defaultManager.messageElevation =
@@ -235,9 +236,10 @@
   MDCSnackbarManager.defaultManager.messageElevation = 5;
 
   __block BOOL blockCalled = NO;
-  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView = ^(MDCSnackbarMessageView *object, CGFloat elevation) {
-    blockCalled = YES;
-  };
+  MDCSnackbarManager.defaultManager.mdc_elevationDidChangeBlockForMessageView =
+      ^(MDCSnackbarMessageView *object, CGFloat elevation) {
+        blockCalled = YES;
+      };
 
   // When
   MDCSnackbarManager.defaultManager.messageElevation =
@@ -251,6 +253,5 @@
   // Then
   XCTAssertLessThan(MDCSnackbarManager.defaultManager.mdc_overrideBaseElevation, 0);
 }
-
 
 @end


### PR DESCRIPTION
This PR adds 2 new properties to the manager; traitCollectionDidChangeBlockForMessageView, and mdc_elevationDidChangeBlockForMessageView. This PR also adds conformance to overriding elevation, if the client wants to override the Snackbar's elevation through the manager.

Because the manager is the API surface for the client when initializing a snackbar, and the message view is only apparent through a delegate for each instance that is created, we need to have elevation and trait collection APIs in the manager itself.

