### PR TITLE
{Git LFS} Correct `.gitattributes` to use path and not glob.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # DO NOT CHANGE THIS FILE
 # DO NOT EDIT THE LINE BELOW.
-.gitattributes merge=gitattributes
+/.gitattributes merge=gitattributes
 # DO NOT EDIT THE LINE ABOVE.
 #
 # You can of course edit this file, but make sure you understand what you are


### PR DESCRIPTION
The `.gitattributes` path to match the `.gitattributes` file itself should use
an explicit path and not a globbed matcher. The new value was tested by
merging `develop` into `stable` and confirming that the `.gitattributes` file
in `stable` is unchanged.

## Testing steps
1. Clone material-components-ios
2. Configure merge driver `git config merge.gitattributes.driver true`
3. Checkout `stable`
4. Merge `develop` into `stable`
5. Verify that the contents of `.gitattributes` have not changed

Part of #8233