### PR TITLE
[ActionSheet] Update cells when the background is set.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -340,6 +340,14 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
 
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+  if (@available(iOS 13.0, *)) {
+    if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+      [self.tableView reloadData];
+    }
+  }
+#endif
+
   if (self.traitCollectionDidChangeBlock) {
     self.traitCollectionDidChangeBlock(self, previousTraitCollection);
   }
@@ -366,7 +374,6 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.view.backgroundColor = backgroundColor;
   self.tableView.backgroundColor = backgroundColor;
   self.header.backgroundColor = backgroundColor;
-  [self.tableView reloadData];
 }
 
 - (void)setTitleTextColor:(UIColor *)titleTextColor {

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -342,7 +342,8 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
 
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
-    if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    if ([self.traitCollection
+            hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
       [self.tableView reloadData];
     }
   }

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -366,6 +366,7 @@ static const CGFloat kActionTextAlpha = (CGFloat)0.87;
   self.view.backgroundColor = backgroundColor;
   self.tableView.backgroundColor = backgroundColor;
   self.header.backgroundColor = backgroundColor;
+  [self.tableView reloadData];
 }
 
 - (void)setTitleTextColor:(UIColor *)titleTextColor {


### PR DESCRIPTION
In certain instances when the traitCollection changes on an MDCActionSheet from light/dark the table doesn't update its cells. This causes the cells to be white while the rest of the action sheet is dark. By reloading the cells when the traitCollection changes we can make sure the color are always in sync.

Steps to reproduce.
1. Open MDCCatalog Action Sheet example
2. Present the ActionSheet
3. Toggle light/dark in Xcode settings
4. Dismiss the action sheet
5. Repeat steps 2-3.

| Before | After |
| --- | --- |
|![before](https://user-images.githubusercontent.com/7131294/63269999-3e0c7500-c265-11e9-8083-60a27894829d.gif)|![after](https://user-images.githubusercontent.com/7131294/63270008-419ffc00-c265-11e9-8da0-5ce1d3a23848.gif)|



Closes #8340 