### PR TITLE
[Ripple] Performance Improvements on initialization

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -67,10 +67,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   });
   _rippleColor = defaultRippleColor;
   _rippleStyle = MDCRippleStyleBounded;
-
-  // Use mask layer when the superview has a shadowPath.
-  _maskLayer = [CAShapeLayer layer];
-  _maskLayer.delegate = self;
 }
 
 - (void)layoutSubviews {
@@ -104,6 +100,11 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   self.layer.masksToBounds = (self.rippleStyle == MDCRippleStyleBounded);
   if (self.rippleStyle == MDCRippleStyleBounded) {
     if (self.superview.layer.shadowPath) {
+      if (!self.maskLayer) {
+        // Use mask layer when the superview has a shadowPath.
+        self.maskLayer = [CAShapeLayer layer];
+        self.maskLayer.delegate = self;
+      }
       self.maskLayer.path = self.superview.layer.shadowPath;
       self.layer.mask = _maskLayer;
     }

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -58,7 +58,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)commonMDCRippleViewInit {
   self.userInteractionEnabled = NO;
-  self.backgroundColor = [UIColor clearColor];
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 
   static UIColor *defaultRippleColor;
@@ -67,9 +66,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
     defaultRippleColor = [[UIColor alloc] initWithWhite:0 alpha:kRippleDefaultAlpha];
   });
   _rippleColor = defaultRippleColor;
-
   _rippleStyle = MDCRippleStyleBounded;
-  self.layer.masksToBounds = YES;
 
   // Use mask layer when the superview has a shadowPath.
   _maskLayer = [CAShapeLayer layer];
@@ -79,7 +76,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  [self updateRippleStyle];
   self.activeRippleLayer.fillColor = self.activeRippleColor.CGColor;
 }
 
@@ -178,6 +174,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
                          completion:(nullable MDCRippleCompletionBlock)completion {
   MDCRippleLayer *rippleLayer = [MDCRippleLayer layer];
   rippleLayer.rippleLayerDelegate = self;
+  [self updateRippleStyle];
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     [self.traitCollection performAsCurrentTraitCollection:^{


### PR DESCRIPTION
To improve performance when Ripple is being initialized, I have tried to look at what things are not needed, or can be delayed to a later stage, like the ripple invocation and not init.

1. self.backgroundColor is initially nil, which defaults to clearColor, hence we can remove that setting.

2. self.layer.maskToBounds = YES is redundant because maskToBounds is dependent on the rippleStyle which is set anyway in the method `updateRippleStyle` that is invoked.

3. `updateRippleStyle` does not need to be called in every layout of the view/subviews, because the masking of the ripple based on the shadowPath (if exists) is only important if there is an actual ripple layer being created, otherwise it is masking the "empty case"

4. The initialization of the maskLayer and setting the delegate only needs to be set when the maskLayer is actually used, so it is then set up if needed only if the ripple is bounded and there is a shadowPath, and the maskLayer is going to be used.

I've run instrumentation of Counters using an iPhone 5c 8GB which uses an A6 chip.
During instrumentation on high frequency, I had gathered that updateRippleStyle takes 0.1ms, and setting backgroundColor 0.2ms every time. 