### PR TITLE
[Ripple] Add the layer masking in layoutSublayers if there are sublayers present.

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -85,7 +85,12 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)layoutSublayersOfLayer:(CALayer *)layer {
   [super layoutSublayersOfLayer:layer];
-  for (CALayer *sublayer in self.layer.sublayers) {
+
+  NSArray *sublayers = self.layer.sublayers;
+  if (sublayers.count > 0) {
+      [self updateRippleStyle];
+    }
+  for (CALayer *sublayer in sublayers) {
     sublayer.frame = CGRectStandardize(self.bounds);
     [sublayer setNeedsLayout];
   }

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -88,8 +88,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
   NSArray *sublayers = self.layer.sublayers;
   if (sublayers.count > 0) {
-      [self updateRippleStyle];
-    }
+    [self updateRippleStyle];
+  }
   for (CALayer *sublayer in sublayers) {
     sublayer.frame = CGRectStandardize(self.bounds);
     [sublayer setNeedsLayout];


### PR DESCRIPTION
This call is needed in cases where the ripple is added and stays, but then a re-layout occurs. This was found to be needed in internal testing, and seems to resolve those issues.