### PR TITLE
[Dialogs] Add snapshot tests to ensure Dialog's default presentation behavior doesn't change under iOS 13.

### DIFF
--- a/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
@@ -82,6 +82,15 @@ static NSString *const kMessageLongArabic =
 }
 
 - (void)tearDown {
+  if (self.alertController.presentingViewController) {
+    XCTestExpectation *expectation =
+        [[XCTestExpectation alloc] initWithDescription:@"Alert controller is dismissed"];
+    [self.alertController dismissViewControllerAnimated:NO
+                                             completion:^{
+                                               [expectation fulfill];
+                                             }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+  }
   self.alertController = nil;
   self.actionLow = nil;
   self.actionMedium = nil;
@@ -251,6 +260,25 @@ static NSString *const kMessageLongArabic =
 
   // Then
   [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+- (void)testDefaultPresentationStyleWithShortTitleShortMessageLatinOniOS13 {
+  // When
+  UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+  UIViewController *currentViewController = window.rootViewController;
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageShortLatin;
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Alert controller is presented"];
+  [currentViewController presentViewController:self.alertController
+                                      animated:NO
+                                    completion:^{
+                                      [expectation fulfill];
+                                    }];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  [self snapshotVerifyViewForIOS13:window];
 }
 
 @end

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testDefaultPresentationStyleWithShortTitleShortMessageLatinOniOS13_13_0@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testDefaultPresentationStyleWithShortTitleShortMessageLatinOniOS13_13_0@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cdb9f54f7dbbb3fe8829be9f7156564744b465c6726cef4eaddc4ca89a4f364
+size 59310


### PR DESCRIPTION
Part of b/135017125.

Added a snapshot test to ensure Dialog's appearance doesn't change when presented under iOS 13.