### PR TITLE
[Snapshot] Add a window into the app delegate of host application.

### DIFF
--- a/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.h
+++ b/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.h
@@ -15,4 +15,7 @@
 
 // No-op delegate sufficient to satisfy UIApplicationMain.
 @interface TestHostMinimalDelegate : UIResponder <UIApplicationDelegate>
+
+@property(strong, nonatomic) UIWindow *window;
+
 @end

--- a/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
+++ b/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
@@ -18,6 +18,7 @@
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+  // Set up the rootViewController to support tests that require root level objects.
   UIViewController *rootViewController = [[UIViewController alloc] init];
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
+++ b/components/private/Snapshot/TestHost/src/TestHostMinimalDelegate.m
@@ -14,4 +14,14 @@
 #import "TestHostMinimalDelegate.h"
 
 @implementation TestHostMinimalDelegate
+
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Right now, the behavior of the host application from CocoaPods and Bazel is different because the host application we built for Bazel didn't have a window and a root view controller. It causes https://github.com/material-components/material-components-ios/pull/8360 's failure on Bazel.