### PR TITLE
 [ActionSheet] Add snapshot tests to ensure the default presentation behavior doesn't change under iOS 13.

### DIFF
--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -69,6 +69,8 @@ static NSString *const kLongTitle5Arabic =
 /** Snapshot tests for MDCActionSheetController's view. */
 @interface MDCActionSheetControllerSnapshotTests : MDCSnapshotTestCase
 
+@property(nonatomic, strong, nullable) MDCActionSheetController *actionSheetController;
+
 @end
 
 @implementation MDCActionSheetControllerSnapshotTests
@@ -79,6 +81,21 @@ static NSString *const kLongTitle5Arabic =
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
   //  self.recordMode = YES;
+}
+
+- (void)tearDown {
+  if (self.actionSheetController.presentingViewController) {
+    XCTestExpectation *expectation =
+    [[XCTestExpectation alloc] initWithDescription:@"Action sheet is dismissed"];
+    [self.actionSheetController dismissViewControllerAnimated:NO
+                                         completion:^{
+                                           [expectation fulfill];
+                                         }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+  }
+  self.actionSheetController = nil;
+
+  [super tearDown];
 }
 
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
@@ -816,6 +833,42 @@ static NSString *const kLongTitle5Arabic =
 
   // Then
   [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+- (void)testThreeActionsSufficientSizeShortTextLTRWithDefaultPresentationStyleOniOS13 {
+  // Given
+  MDCActionSheetAction *action1 =
+  [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                handler:nil];
+  MDCActionSheetAction *action2 =
+  [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                handler:nil];
+  MDCActionSheetAction *action3 =
+  [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                handler:nil];
+  self.actionSheetController = [MDCActionSheetController actionSheetControllerWithTitle:nil];
+  [self.actionSheetController addAction:action1];
+  [self.actionSheetController addAction:action2];
+  [self.actionSheetController addAction:action3];
+  self.actionSheetController.view.bounds = CGRectMake(0, 0, 320, 200);
+
+  // When
+  UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+  UIViewController *currentViewController = window.rootViewController;
+  XCTestExpectation *expectation =
+  [[XCTestExpectation alloc] initWithDescription:@"Action sheet is presented"];
+  [currentViewController presentViewController:self.actionSheetController
+                                      animated:NO
+                                    completion:^{
+                                      [expectation fulfill];
+                                    }];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  [self snapshotVerifyViewForIOS13:window];
 }
 
 @end

--- a/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
+++ b/components/ActionSheet/tests/snapshot/MDCActionSheetControllerSnapshotTests.m
@@ -86,11 +86,11 @@ static NSString *const kLongTitle5Arabic =
 - (void)tearDown {
   if (self.actionSheetController.presentingViewController) {
     XCTestExpectation *expectation =
-    [[XCTestExpectation alloc] initWithDescription:@"Action sheet is dismissed"];
+        [[XCTestExpectation alloc] initWithDescription:@"Action sheet is dismissed"];
     [self.actionSheetController dismissViewControllerAnimated:NO
-                                         completion:^{
-                                           [expectation fulfill];
-                                         }];
+                                                   completion:^{
+                                                     [expectation fulfill];
+                                                   }];
     [self waitForExpectations:@[ expectation ] timeout:5];
   }
   self.actionSheetController = nil;
@@ -838,17 +838,17 @@ static NSString *const kLongTitle5Arabic =
 - (void)testThreeActionsSufficientSizeShortTextLTRWithDefaultPresentationStyleOniOS13 {
   // Given
   MDCActionSheetAction *action1 =
-  [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
-                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
-                                handler:nil];
+      [MDCActionSheetAction actionWithTitle:kShortTitle1Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
   MDCActionSheetAction *action2 =
-  [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
-                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
-                                handler:nil];
+      [MDCActionSheetAction actionWithTitle:kShortTitle2Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
   MDCActionSheetAction *action3 =
-  [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
-                                  image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
-                                handler:nil];
+      [MDCActionSheetAction actionWithTitle:kShortTitle3Latin
+                                      image:[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+                                    handler:nil];
   self.actionSheetController = [MDCActionSheetController actionSheetControllerWithTitle:nil];
   [self.actionSheetController addAction:action1];
   [self.actionSheetController addAction:action2];
@@ -859,7 +859,7 @@ static NSString *const kLongTitle5Arabic =
   UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
   UIViewController *currentViewController = window.rootViewController;
   XCTestExpectation *expectation =
-  [[XCTestExpectation alloc] initWithDescription:@"Action sheet is presented"];
+      [[XCTestExpectation alloc] initWithDescription:@"Action sheet is presented"];
   [currentViewController presentViewController:self.actionSheetController
                                       animated:NO
                                     completion:^{

--- a/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testThreeActionsSufficientSizeShortTextLTRWithDefaultPresentationStyleOniOS13_13_0@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCActionSheetControllerSnapshotTests/testThreeActionsSufficientSizeShortTextLTRWithDefaultPresentationStyleOniOS13_13_0@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6b19d24628203cc22cb8f6482c63249c6b4905cdfb09e63c241f45573992131
+size 29458


### PR DESCRIPTION
Part of b/135017125.

Added a snapshot test to ensure ActionSheet's appearance doesn't change when presented under iOS 13.