### PR TITLE
[FeatureHighlight] Add snapshot tests to ensure the default presentation behavior doesn't change under iOS 13.

### DIFF
--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -143,3 +143,16 @@ mdc_unit_test_suite(
         ":unit_test_sources",
     ],
 )
+
+mdc_snapshot_objc_library(
+    name = "snapshot_test_lib",
+    deps = [
+        ":FeatureHighlight",
+        ":private",
+    ],
+)
+
+mdc_snapshot_test(
+    name = "snapshot_tests",
+    deps = [":snapshot_test_lib"],
+)

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -20,6 +20,8 @@ load(
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
+    "mdc_snapshot_objc_library",
+    "mdc_snapshot_test",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )

--- a/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
+++ b/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
@@ -1,0 +1,85 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialFeatureHighlight.h"
+#import "MaterialSnapshot.h"
+
+#import <XCTest/XCTest.h>
+
+/** Snapshot tests for MDCFeatureHighlightViewController and MDCFeatureHighlightView. */
+@interface MDCFeatureHighlightSnapshotTests : MDCSnapshotTestCase
+
+@property(nonatomic, strong) MDCFeatureHighlightViewController *featureHighlightViewController;
+
+@end
+
+@implementation MDCFeatureHighlightSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+  // self.recordMode = YES;
+}
+
+- (void)tearDown {
+  if (self.featureHighlightViewController.presentingViewController) {
+    XCTestExpectation *expectation =
+        [[XCTestExpectation alloc] initWithDescription:@"FeatureHighlight is dismissed"];
+    [self.featureHighlightViewController dismissViewControllerAnimated:NO
+                                                            completion:^{
+                                                              [expectation fulfill];
+                                                            }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+  }
+  self.featureHighlightViewController = nil;
+
+  [super tearDown];
+}
+
+- (void)testFeatureHighlightWithDefaultPresentationStyleOniOS13 {
+  // Given
+  UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+  UIViewController *currentViewController = window.rootViewController;
+  UILabel *highlightLabel = [[UILabel alloc] init];
+  highlightLabel.text = @"Highlight";
+  [highlightLabel sizeToFit];
+  [currentViewController.view addSubview:highlightLabel];
+  highlightLabel.center = currentViewController.view.center;
+  self.featureHighlightViewController =
+      [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:highlightLabel
+                                                              completion:nil];
+  self.featureHighlightViewController.titleText = @"Feature Highlight Title";
+  self.featureHighlightViewController.bodyText = @"Feature Highlight Body";
+  self.featureHighlightViewController.outerHighlightColor = UIColor.blueColor;
+  self.featureHighlightViewController.innerHighlightColor = UIColor.whiteColor;
+
+  // When
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Bottom sheet is presented"];
+  [currentViewController presentViewController:self.featureHighlightViewController
+                                      animated:YES
+                                    completion:^{
+                                      [expectation fulfill];
+                                    }];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  [self snapshotVerifyViewForIOS13:window];
+
+  [highlightLabel removeFromSuperview];
+}
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testFeatureHighlightWithDefaultPresentationStyleOniOS13_13_0@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testFeatureHighlightWithDefaultPresentationStyleOniOS13_13_0@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fd5ebcc2192ee234e4808f6575e021657287ad2a008b5ee1edc43406890923f
+size 44821


### PR DESCRIPTION
Part of b/135017125.

Added a snapshot test to ensure FeatureHighlight's appearance doesn't change when presented under iOS 13.