### PR TITLE
[Banner] Add a missing button title in example.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -285,7 +285,7 @@ static NSString *const exampleExtraLongText =
 
   MDCButton *dismissButton = bannerView.leadingButton;
   [dismissButton applyTextThemeWithScheme:self.containerScheme];
-  [dismissButton sizeToFit];
+  [dismissButton setTitle:@"Dismiss" forState:UIControlStateNormal];
   [dismissButton addTarget:self
                     action:@selector(dismissBanner)
           forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8368.

A button is missing from the example. Note: these two buttons are not aligned well. To be fixed in https://github.com/material-components/material-components-ios/pull/8370.

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone Xʀ - 2019-08-26 at 15 18 32](https://user-images.githubusercontent.com/8836258/63716809-de8a0880-c814-11e9-867d-eee2179fdd15.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-08-26 at 15 24 05](https://user-images.githubusercontent.com/8836258/63717141-8dc6df80-c815-11e9-9109-8be5f91cfe8d.png) |


