### PR TITLE
[Buttons] overwrite intrinsicContentSize method.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -329,6 +329,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return superSize;
 }
 
+- (CGSize)intrinsicContentSize {
+  return [self sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+}
+
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
 

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1291,11 +1291,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
 - (void)testIntrinsicContentSizeWithMaximum {
   // Given
   CGSize originalSize = self.button.intrinsicContentSize;
-  CGSize expectedSize = CGSizeMake(originalSize.width + 5, originalSize.height - 5);
+  CGSize expectedSize = CGSizeMake(originalSize.width - 5, originalSize.height - 5);
 
   // When
-  self.button.maximumSize = CGSizeMake(0, expectedSize.height);
-  self.button.minimumSize = CGSizeMake(expectedSize.width, 0);
+  self.button.maximumSize = expectedSize;
 
   // Then
   XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
@@ -1304,10 +1303,11 @@ static NSString *controlStateDescription(UIControlState controlState) {
 - (void)testIntrinsicContentSizeWithMaximumAndMinimum {
   // Given
   CGSize originalSize = self.button.intrinsicContentSize;
-  CGSize expectedSize = CGSizeMake(originalSize.width - 5, originalSize.height - 5);
+  CGSize expectedSize = CGSizeMake(originalSize.width + 5, originalSize.height - 5);
 
   // When
-  self.button.maximumSize = expectedSize;
+  self.button.maximumSize = CGSizeMake(0, expectedSize.height);
+  self.button.minimumSize = CGSizeMake(expectedSize.width, 0);
 
   // Then
   XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1276,6 +1276,43 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 NSStringFromCGRect(expectedFrame), NSStringFromCGRect(self.button.frame));
 }
 
+- (void)testIntrinsicContentSizeWithMinimum {
+  // Given
+  CGSize originalSize = self.button.intrinsicContentSize;
+  CGSize expectedSize = CGSizeMake(originalSize.width + 10, originalSize.height + 10);
+
+  // When
+  self.button.minimumSize = expectedSize;
+
+  // Then
+  XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
+}
+
+- (void)testIntrinsicContentSizeWithMaximum {
+  // Given
+  CGSize originalSize = self.button.intrinsicContentSize;
+  CGSize expectedSize = CGSizeMake(originalSize.width + 5, originalSize.height - 5);
+
+  // When
+  self.button.maximumSize = CGSizeMake(0, expectedSize.height);
+  self.button.minimumSize = CGSizeMake(expectedSize.width, 0);
+
+  // Then
+  XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
+}
+
+- (void)testIntrinsicContentSizeWithMaximumAndMinimum {
+  // Given
+  CGSize originalSize = self.button.intrinsicContentSize;
+  CGSize expectedSize = CGSizeMake(originalSize.width - 5, originalSize.height - 5);
+
+  // When
+  self.button.maximumSize = expectedSize;
+
+  // Then
+  XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
+}
+
 #pragma mark - UIAccessibility
 
 - (void)testAccessibilityTraitsDefault {

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -1276,7 +1276,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 NSStringFromCGRect(expectedFrame), NSStringFromCGRect(self.button.frame));
 }
 
-- (void)testIntrinsicContentSizeWithMinimum {
+- (void)testIntrinsicContentSizeWithMinimumSizeIncreasesSize {
   // Given
   CGSize originalSize = self.button.intrinsicContentSize;
   CGSize expectedSize = CGSizeMake(originalSize.width + 10, originalSize.height + 10);
@@ -1288,7 +1288,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
 }
 
-- (void)testIntrinsicContentSizeWithMaximum {
+- (void)testIntrinsicContentSizeWithMaximumDecreasesSize {
   // Given
   CGSize originalSize = self.button.intrinsicContentSize;
   CGSize expectedSize = CGSizeMake(originalSize.width - 5, originalSize.height - 5);
@@ -1300,7 +1300,7 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertTrue(CGSizeEqualToSize(expectedSize, self.button.intrinsicContentSize));
 }
 
-- (void)testIntrinsicContentSizeWithMaximumAndMinimum {
+- (void)testIntrinsicContentSizeWithMaximumAndMinimumSizeBehavior {
   // Given
   CGSize originalSize = self.button.intrinsicContentSize;
   CGSize expectedSize = CGSizeMake(originalSize.width + 5, originalSize.height - 5);


### PR DESCRIPTION
The `instrinsicContentSize` of `MDCButton` was not aware of `minimumSize` property, which is wrong.

Open to use `super.instrinsicContentSize` if reviewer(s) prefer.