### PR TITLE
[TextFields] Added check on textinput.font set to avoid sideeffects

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -397,16 +397,16 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 #pragma mark - TextInput Customization
 
 - (void)updateTextInput {
-	UIFont *font = self.textInputFont;
-	if (self.mdc_adjustsFontForContentSizeCategory) {
-		font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
+  UIFont *font = self.textInputFont;
+    if (self.mdc_adjustsFontForContentSizeCategory) {
+      font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
 								  scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-		// TODO: (#4331) This needs to be converted to the new text scheme.
-	}
+        // TODO: (#4331) This needs to be converted to the new text scheme.
+    }
 	
-	if (![self.textInput.font mdc_isSimplyEqual:font]){
-		self.textInput.font = font;
-	}
+    if (![self.textInput.font mdc_isSimplyEqual:font]){
+      self.textInput.font = font;
+    }
 }
 
 #pragma mark - Placeholder Customization

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -397,13 +397,16 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 #pragma mark - TextInput Customization
 
 - (void)updateTextInput {
-  UIFont *font = self.textInputFont;
-  if (self.mdc_adjustsFontForContentSizeCategory) {
-    font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
-                              scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
-    // TODO: (#4331) This needs to be converted to the new text scheme.
-  }
-  self.textInput.font = font;
+	UIFont *font = self.textInputFont;
+	if (self.mdc_adjustsFontForContentSizeCategory) {
+		font = [font mdc_fontSizedForMaterialTextStyle:MDCFontTextStyleBody1
+								  scaledForDynamicType:_mdc_adjustsFontForContentSizeCategory];
+		// TODO: (#4331) This needs to be converted to the new text scheme.
+	}
+	
+	if (![self.textInput.font mdc_isSimplyEqual:font]){
+		self.textInput.font = font;
+	}
 }
 
 #pragma mark - Placeholder Customization


### PR DESCRIPTION
This PR should be fix this issue: https://github.com/material-components/material-components-ios/issues/8390
#8390 

This PR is part of code of closed PR hadn't merge anymore. #5810

This code only change the font in this method when is different. Doing that we avoid that font size change while the user is typing on textfields.

