### PR TITLE
[Chips] Remove deprecated inkColor property

### DIFF
--- a/components/Chips/src/MDCChipView.h
+++ b/components/Chips/src/MDCChipView.h
@@ -132,12 +132,6 @@
 @property(nonatomic) BOOL rippleAllowsSelection;
 
 /*
- The color of the ink ripple.
- */
-@property(nonatomic, strong, null_resettable)
-    UIColor *inkColor UI_APPEARANCE_SELECTOR __deprecated_msg("Use setInkColor:forState:");
-
-/*
  The shape generator used to define the chip's shape.
  */
 @property(nullable, nonatomic, strong) id<MDCShapeGenerating> shapeGenerator UI_APPEARANCE_SELECTOR;

--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -267,14 +267,6 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   return self.layer.shapeGenerator;
 }
 
-- (void)setInkColor:(UIColor *)inkColor {
-  [self setInkColor:inkColor forState:UIControlStateNormal];
-}
-
-- (UIColor *)inkColor {
-  return [self inkColorForState:UIControlStateNormal];
-}
-
 - (void)setEnableRippleBehavior:(BOOL)enableRippleBehavior {
   _enableRippleBehavior = enableRippleBehavior;
 


### PR DESCRIPTION
I have verified that there is no internal use of this property.

Closes #8398
