### PR TITLE
[Buttons] Remove unused shouldCapitalizeTitle property

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -347,8 +347,6 @@
     BOOL shouldRaiseOnTouch __deprecated_msg("Use MDCFlatButton instead of shouldRaiseOnTouch = NO")
         ;
 
-@property(nonatomic) BOOL shouldCapitalizeTitle __deprecated_msg("Use uppercaseTitle instead.");
-
 @property(nonatomic, strong, nullable)
     UIColor *underlyingColor __deprecated_msg("Use underlyingColorHint instead.");
 

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -1003,14 +1003,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   return [self titleColorForState:UIControlStateNormal];
 }
 
-- (BOOL)shouldCapitalizeTitle {
-  return [self isUppercaseTitle];
-}
-
-- (void)setShouldCapitalizeTitle:(BOOL)shouldCapitalizeTitle {
-  [self setUppercaseTitle:shouldCapitalizeTitle];
-}
-
 - (UIColor *)underlyingColor {
   return [self underlyingColorHint];
 }


### PR DESCRIPTION
This property has no internal usage.

Closes #8401
