### PR TITLE
[Buttons] Delete deprecated customTitleColor property

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -336,13 +336,6 @@
 
 #pragma mark - Deprecated
 
-/**
- This property sets/gets the title color for UIControlStateNormal.
- */
-@property(nonatomic, strong, nullable)
-    UIColor *customTitleColor UI_APPEARANCE_SELECTOR __deprecated_msg(
-        "Use setTitleColor:forState: instead");
-
 @property(nonatomic)
     BOOL shouldRaiseOnTouch __deprecated_msg("Use MDCFlatButton instead of shouldRaiseOnTouch = NO")
         ;

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -995,14 +995,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Deprecations
 
-- (void)setCustomTitleColor:(UIColor *)customTitleColor {
-  [self setTitleColor:customTitleColor forState:UIControlStateNormal];
-}
-
-- (UIColor *)customTitleColor {
-  return [self titleColorForState:UIControlStateNormal];
-}
-
 - (BOOL)shouldCapitalizeTitle {
   return [self isUppercaseTitle];
 }

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -995,14 +995,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Deprecations
 
-- (void)setCustomTitleColor:(UIColor *)customTitleColor {
-  [self setTitleColor:customTitleColor forState:UIControlStateNormal];
-}
-
-- (UIColor *)customTitleColor {
-  return [self titleColorForState:UIControlStateNormal];
-}
-
 - (UIColor *)underlyingColor {
   return [self underlyingColorHint];
 }


### PR DESCRIPTION
All internal use of this property has been deleted. 

Closes #8400 