### PR TITLE
[MDCNavigationBar] Delete unused MDCNavigationBar textAlignment property

### DIFF
--- a/components/NavigationBar/src/MDCNavigationBar.h
+++ b/components/NavigationBar/src/MDCNavigationBar.h
@@ -365,11 +365,6 @@ IB_DESIGNABLE
 @property(nonatomic, copy, nullable)
     NSDictionary<NSAttributedStringKey, id> *titleTextAttributes UI_APPEARANCE_SELECTOR;
 
-#pragma mark - Deprecated
-
-/** The text alignment of the navigation bar title. Defaults to NSTextAlignmentLeft. */
-@property(nonatomic) NSTextAlignment textAlignment __deprecated_msg("Use titleAlignment instead.");
-
 @end
 
 @interface MDCNavigationBar (ToBeDeprecated)

--- a/components/NavigationBar/src/MDCNavigationBar.m
+++ b/components/NavigationBar/src/MDCNavigationBar.m
@@ -841,14 +841,4 @@ static NSArray<NSString *> *MDCNavigationBarNavigationItemKVOPaths(void) {
   self.leadingItemsSupplementBackButton = leftItemsSupplementBackButton;
 }
 
-#pragma mark deprecated
-
-- (void)setTextAlignment:(NSTextAlignment)textAlignment {
-  [self setTitleAlignment:[MDCNavigationBar titleAlignmentFromTextAlignment:textAlignment]];
-}
-
-- (NSTextAlignment)textAlignment {
-  return [MDCNavigationBar textAlignmentFromTitleAlignment:self.titleAlignment];
-}
-
 @end


### PR DESCRIPTION
This property has no internal usage.

Closes #8409 