### PR TITLE
[ActionSheet] Minor style cleanup of import statements.

### DIFF
--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MDCActionSheetController+MaterialTheming.h"
+
 #import "MaterialColor.h"
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;


### PR DESCRIPTION
There should be a newline between the `.m`'s companion `.h` file and the rest of the imports required by the `.m` file.