### PR TITLE
[ActivityIndicator] Deprecate ColorThemer.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -132,6 +132,9 @@ Pod::Spec.new do |mdc|
       "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
     ]
 
+    # Please theme MDCActivityIndicator's colors directly instead.
+    extension.deprecated = true
+
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"
   end

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -123,6 +123,8 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  # This subspec is deprecated.
+  # Please theme MDCActivityIndicator's colors directly instead.
   mdc.subspec "ActivityIndicator+ColorThemer" do |extension|
     extension.ios.deployment_target = '9.0'
     extension.public_header_files = [
@@ -131,9 +133,6 @@ Pod::Spec.new do |mdc|
     extension.source_files = [
       "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
     ]
-
-    # Please theme MDCActivityIndicator's colors directly instead.
-    extension.deprecated = true
 
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Color"

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -57,14 +57,6 @@ objc_bundle(
     bundle_imports = [":BundleFiles"],
 )
 
-mdc_extension_objc_library(
-    name = "ColorThemer",
-    deps = [
-        ":ActivityIndicator",
-        "//components/schemes/Color",
-    ],
-)
-
 mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
     deps = [
@@ -119,5 +111,16 @@ mdc_snapshot_test(
     name = "snapshot_tests",
     deps = [
         ":snapshot_test_lib",
+    ],
+)
+
+# Deprecated
+
+mdc_extension_objc_library(
+    name = "ColorThemer",
+    deprecation = "Please theme MDCActivityIndicator's colors directly instead.",
+    deps = [
+        ":ActivityIndicator",
+        "//components/schemes/Color",
     ],
 )

--- a/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorExampleViewController.m
@@ -14,8 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialActivityIndicator+ColorThemer.h"
 #import "MaterialActivityIndicator.h"
+#import "MaterialColorScheme.h"
 #import "MaterialPalettes.h"
 #import "supplemental/ActivityIndicatorExampleViewControllerSupplemental.h"
 
@@ -49,8 +49,7 @@
 
   // Themed determinate activity indicator
   self.activityIndicator1 = [[MDCActivityIndicator alloc] init];
-  [MDCActivityIndicatorColorThemer applySemanticColorScheme:self.colorScheme
-                                        toActivityIndicator:self.activityIndicator1];
+  self.activityIndicator1.cycleColors = @[ self.colorScheme.primaryColor ];
   self.activityIndicator1.delegate = self;
   self.activityIndicator1.indicatorMode = MDCActivityIndicatorModeDeterminate;
   [self.activityIndicator1 sizeToFit];
@@ -59,8 +58,7 @@
   self.activityIndicator2 = [[MDCActivityIndicator alloc] init];
   self.activityIndicator2.delegate = self;
   self.activityIndicator2.indicatorMode = MDCActivityIndicatorModeDeterminate;
-  [MDCActivityIndicatorColorThemer applySemanticColorScheme:self.colorScheme
-                                        toActivityIndicator:self.activityIndicator2];
+  self.activityIndicator2.cycleColors = @[ self.colorScheme.primaryColor ];
   [self.activityIndicator2 sizeToFit];
 
   // Indeterminate activity indicator with custom colors.

--- a/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
+++ b/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
@@ -24,10 +24,8 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
+__deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.")
 @interface MDCActivityIndicatorColorThemer : NSObject
-@end
-
-@interface MDCActivityIndicatorColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCActivityIndicator.
@@ -40,7 +38,8 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-             toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator;
+             toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator
+             __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
 
 /**
  Applies a color scheme's properties to an MDCActivityIndicator.
@@ -53,6 +52,7 @@
  @param activityIndicator A component instance to which the color scheme should be applied.
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-     toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator;
+     toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator
+     __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
 
 @end

--- a/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
+++ b/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.h
@@ -25,7 +25,7 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.")
-@interface MDCActivityIndicatorColorThemer : NSObject
+    @interface MDCActivityIndicatorColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCActivityIndicator.
@@ -39,7 +39,7 @@ __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.")
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
              toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator
-             __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
+    __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
 
 /**
  Applies a color scheme's properties to an MDCActivityIndicator.
@@ -53,6 +53,6 @@ __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.")
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
      toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator
-     __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
+    __deprecated_msg("Please theme MDCActivityIndicator's colors directly instead.");
 
 @end

--- a/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.m
+++ b/components/ActivityIndicator/src/ColorThemer/MDCActivityIndicatorColorThemer.m
@@ -14,7 +14,10 @@
 
 #import "MDCActivityIndicatorColorThemer.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCActivityIndicatorColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
              toActivityIndicator:(nonnull MDCActivityIndicator *)activityIndicator {


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8429

These targets have no internal usage.

Note: CocoaPods is unfortunately not able to annotate subspecs as deprecated. It generates the following when you try:

```
ERROR | [iOS] attributes: Can't set `deprecated` attribute for subspecs (in `MaterialComponents/ActivityIndicator+ColorThemer`).
```