### PR TITLE
[Cards, Chips, Tabs] Fix theming docs.

### DIFF
--- a/components/Cards/README.md
+++ b/components/Cards/README.md
@@ -8,7 +8,7 @@ path: /catalog/cards/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme Cards -->
+<!-- This file was auto-generated using ./scripts/generate_readme Cards -->
 
 # Cards
 
@@ -230,7 +230,7 @@ and the outlined theme.
 
  #### Swift
 
- ```swift
+```swift
 // Import the Cards Theming Extensions module
 import MaterialComponents.MaterialCards_MaterialTheming
  ...
@@ -244,7 +244,7 @@ card.applyOutlinedTheme(withScheme: containerScheme)
 
  #### Objective-C
 
- ```objc
+```objc
 // Import the Cards Theming Extensions header
 #import <MaterialComponents/MaterialCards+MaterialTheming.h>
  ...

--- a/components/Cards/docs/theming.md
+++ b/components/Cards/docs/theming.md
@@ -8,7 +8,7 @@ and the outlined theme.
 
  #### Swift
 
- ```swift
+```swift
 // Import the Cards Theming Extensions module
 import MaterialComponents.MaterialCards_MaterialTheming
  ...
@@ -22,7 +22,7 @@ card.applyOutlinedTheme(withScheme: containerScheme)
 
  #### Objective-C
 
- ```objc
+```objc
 // Import the Cards Theming Extensions header
 #import <MaterialComponents/MaterialCards+MaterialTheming.h>
  ...

--- a/components/Chips/README.md
+++ b/components/Chips/README.md
@@ -8,7 +8,7 @@ path: /catalog/chips/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme Chips -->
+<!-- This file was auto-generated using ./scripts/generate_readme Chips -->
 
 # Chips
 
@@ -367,7 +367,7 @@ and the outlined theme.
 
  #### Swift
 
- ```swift
+```swift
 // Import the Chips Theming Extensions module
 import MaterialComponents.MaterialChips_MaterialTheming
  ...
@@ -381,7 +381,7 @@ chip.applyOutlinedTheme(withScheme: containerScheme)
 
  #### Objective-C
 
- ```objc
+```objc
 // Import the Tabs Theming Extensions header
 #import <MaterialComponents/MaterialChips+MaterialTheming.h>
  ...

--- a/components/Chips/docs/theming.md
+++ b/components/Chips/docs/theming.md
@@ -8,7 +8,7 @@ and the outlined theme.
 
  #### Swift
 
- ```swift
+```swift
 // Import the Chips Theming Extensions module
 import MaterialComponents.MaterialChips_MaterialTheming
  ...
@@ -22,7 +22,7 @@ chip.applyOutlinedTheme(withScheme: containerScheme)
 
  #### Objective-C
 
- ```objc
+```objc
 // Import the Tabs Theming Extensions header
 #import <MaterialComponents/MaterialChips+MaterialTheming.h>
  ...

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -301,15 +301,15 @@ id<MDCTypographyScheming> typographyScheme = [[MDCTypographyScheme alloc] init];
 
 ### Theming Extensions
 
- `MDCTabBar` supports Material Theming using a Container Scheme.
+`MDCTabBar` supports Material Theming using a Container Scheme.
 There are two variants for Material Theming of a MDCTabBar, which are the Primary Theme
 and the Surface Theme.
 
- <!--<div class="material-code-render" markdown="1">-->
+<!--<div class="material-code-render" markdown="1">-->
 
- #### Swift
+#### Swift
 
- ```swift
+```swift
 // Import the Tabs Theming Extensions module
 import MaterialComponents.MaterialTabs_MaterialTheming
  ...
@@ -321,9 +321,9 @@ tabBar.applyPrimaryTheme(withScheme: containerScheme)
 tabBar.applySurfaceTheme(withScheme: containerScheme)
 ```
 
- #### Objective-C
+#### Objective-C
 
- ```objc
+```objc
 // Import the Tabs Theming Extensions header
 #import <MaterialComponents/MaterialTabBar+MaterialTheming.h>
  ...

--- a/components/Tabs/docs/theming-extensions.md
+++ b/components/Tabs/docs/theming-extensions.md
@@ -1,14 +1,14 @@
 ### Theming Extensions
 
- `MDCTabBar` supports Material Theming using a Container Scheme.
+`MDCTabBar` supports Material Theming using a Container Scheme.
 There are two variants for Material Theming of a MDCTabBar, which are the Primary Theme
 and the Surface Theme.
 
- <!--<div class="material-code-render" markdown="1">-->
+<!--<div class="material-code-render" markdown="1">-->
 
- #### Swift
+#### Swift
 
- ```swift
+```swift
 // Import the Tabs Theming Extensions module
 import MaterialComponents.MaterialTabs_MaterialTheming
  ...
@@ -20,9 +20,9 @@ tabBar.applyPrimaryTheme(withScheme: containerScheme)
 tabBar.applySurfaceTheme(withScheme: containerScheme)
 ```
 
- #### Objective-C
+#### Objective-C
 
- ```objc
+```objc
 // Import the Tabs Theming Extensions header
 #import <MaterialComponents/MaterialTabBar+MaterialTheming.h>
  ...


### PR DESCRIPTION
Formatting errors in the Theming Extension sections resulted in Markdown
rendering errors.

Part of #7162
Follow-up to #7193
Follow-up to #7194