### PR TITLE
[ButtonBar] Deprecate Theming and TypographyThemer.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -604,6 +604,8 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/Themes"
   end
 
+  # ButtonBar is not intended to be themed as a standalone component.
+  # Please theme it via the AppBar component's Theming extension instead.
   mdc.subspec "ButtonBar+TypographyThemer" do |extension|
     extension.ios.deployment_target = '9.0'
     extension.public_header_files = [

--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -69,6 +69,8 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  # ButtonBar is not intended to be themed as a standalone component.
+  # Please theme it via the AppBar component's Theming extension instead.
   mdc.subspec "ButtonBar+Theming" do |extension|
     extension.ios.deployment_target = '9.0'
     extension.public_header_files = "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -51,29 +51,10 @@ mdc_extension_objc_library(
     ],
 )
 
-mdc_extension_objc_library(
-    name = "TypographyThemer",
-    deps = [
-        ":ButtonBar",
-        "//components/schemes/Typography",
-    ],
-)
-
-mdc_extension_objc_library(
-    name = "Theming",
-    deps = [
-        ":ButtonBar",
-        ":ColorThemer",
-        ":TypographyThemer",
-        "//components/schemes/Container",
-    ],
-)
-
 mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":ButtonBar",
-        ":Theming",
         "//components/private/Icons/icons/ic_check_circle",
         "//components/private/Icons/icons/ic_info",
         "//components/schemes/Container",
@@ -84,7 +65,6 @@ mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [
         ":ButtonBar",
-        ":Theming",
         "//components/schemes/Container",
     ],
 )
@@ -118,12 +98,12 @@ mdc_unit_test_swift_library(
 
 mdc_unit_test_suite(
     name = "unit_tests",
+    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
+    use_autobot_environment_runner = False,
     deps = [
         ":unit_test_sources",
         ":unit_test_swift_sources",
     ],
-    # TODO (https://github.com/material-components/material-components-ios/issues/8249): Re-enable autobot environment.
-    use_autobot_environment_runner = False,
 )
 
 mdc_snapshot_objc_library(
@@ -140,4 +120,28 @@ mdc_snapshot_objc_library(
 mdc_snapshot_test(
     name = "snapshot_tests",
     deps = [":snapshot_test_lib"],
+)
+
+# Deprecated
+
+mdc_extension_objc_library(
+    name = "TypographyThemer",
+    deprecation = "ButtonBar is not intended to be themed as a standalone component." +
+                  " Please theme it via the AppBar component's Theming extension instead.",
+    deps = [
+        ":ButtonBar",
+        "//components/schemes/Typography",
+    ],
+)
+
+mdc_extension_objc_library(
+    name = "Theming",
+    deprecation = "ButtonBar is not intended to be themed as a standalone component." +
+                  " Please theme it via the AppBar component's Theming extension instead.",
+    deps = [
+        ":ButtonBar",
+        ":ColorThemer",
+        ":TypographyThemer",
+        "//components/schemes/Container",
+    ],
 )

--- a/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
+++ b/components/ButtonBar/examples/ButtonBarCustomizedFontExample.m
@@ -14,7 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtonBar+Theming.h"
 #import "MaterialButtonBar.h"
 #import "MaterialContainerScheme.h"
 
@@ -49,11 +48,10 @@
   [super viewDidLoad];
 
   MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
-
-  MDCContainerScheme *scheme = [self containerScheme];
-  scheme.typographyScheme.button = [UIFont fontWithName:@"American Typewriter" size:10];
-
-  [buttonBar applyPrimaryThemeWithScheme:scheme];
+  buttonBar.backgroundColor = self.colorScheme.primaryColor;
+  buttonBar.tintColor = self.colorScheme.onPrimaryColor;
+  [buttonBar setButtonsTitleFont:[UIFont fontWithName:@"American Typewriter" size:10]
+                        forState:UIControlStateNormal];
 
   // MDCButtonBar ignores the style of UIBarButtonItem.
   UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.m
@@ -14,7 +14,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialButtonBar+Theming.h"
 #import "MaterialButtonBar.h"
 #import "MaterialContainerScheme.h"
 
@@ -48,8 +47,9 @@
   [super viewDidLoad];
 
   MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
-  MDCContainerScheme *scheme = [self containerScheme];
-  [buttonBar applyPrimaryThemeWithScheme:scheme];
+  buttonBar.backgroundColor = self.colorScheme.primaryColor;
+  buttonBar.tintColor = self.colorScheme.onPrimaryColor;
+  [buttonBar setButtonsTitleFont:self.typographyScheme.button forState:UIControlStateNormal];
 
   // MDCButtonBar ignores the style of UIBarButtonItem.
   UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -32,7 +32,9 @@ class ButtonBarTypicalUseSwiftExample: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    buttonBar.applyPrimaryTheme(withScheme: scheme)
+    buttonBar.backgroundColor = colorScheme.primaryColor
+    buttonBar.tintColor = colorScheme.onPrimaryColor
+    buttonBar.setButtonsTitleFont(typographyScheme.button, for: .normal)
 
     // MDCButtonBar ignores the style of UIBarButtonItem.
     let ignored: UIBarButtonItem.Style = .done

--- a/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
+++ b/components/ButtonBar/examples/ButtonBarTypicalUseExample.swift
@@ -15,7 +15,6 @@
 import Foundation
 import MaterialComponents.MaterialButtonBar
 import MaterialComponents.MaterialContainerScheme
-import MaterialComponentsBeta.MaterialButtonBar_Theming
 
 class ButtonBarTypicalUseSwiftExample: UIViewController {
   @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)

--- a/components/ButtonBar/src/Theming/MDCButtonBar+MaterialTheming.h
+++ b/components/ButtonBar/src/Theming/MDCButtonBar+MaterialTheming.h
@@ -17,7 +17,9 @@
 
 // This category applies Material themes that are defined in the Material Guidelines:
 // https://material.io/design/components/app-bars-top.html
-@interface MDCButtonBar (MaterialTheming)
+__deprecated_msg("ButtonBar is not intended to be themed as a standalone component."
+                 " Please theme it via the AppBar component's Theming extension instead.")
+    @interface MDCButtonBar(MaterialTheming)
 
 /**
  Apply the primary theme to this instance.
@@ -25,6 +27,8 @@
  @param scheme A container scheme instance containing any desired customizations to the theming
  system.
  */
-- (void)applyPrimaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+- (void)applyPrimaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme
+    __deprecated_msg("ButtonBar is not intended to be themed as a standalone component."
+                     " Please theme it via the AppBar component's Theming extension instead.");
 
 @end

--- a/components/ButtonBar/src/Theming/MDCButtonBar+MaterialTheming.m
+++ b/components/ButtonBar/src/Theming/MDCButtonBar+MaterialTheming.m
@@ -17,7 +17,10 @@
 #import <MaterialComponents/MaterialButtonBar+ColorThemer.h>
 #import <MaterialComponents/MaterialButtonBar+TypographyThemer.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCButtonBar (MaterialTheming)
+#pragma clang diagnostic pop
 
 - (void)applyPrimaryThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme {
   id<MDCColorScheming> colorScheme = scheme.colorScheme;

--- a/components/ButtonBar/src/TypographyThemer/MDCButtonBarTypographyThemer.h
+++ b/components/ButtonBar/src/TypographyThemer/MDCButtonBarTypographyThemer.h
@@ -22,10 +22,9 @@
  `MDCButtonBar`'s `-applyPrimaryThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCButtonBarTypographyThemer : NSObject
-@end
-
-@interface MDCButtonBarTypographyThemer (ToBeDeprecated)
+__deprecated_msg("ButtonBar is not intended to be themed as a standalone component."
+                 " Please theme it via the AppBar component's Theming extension instead.")
+    @interface MDCButtonBarTypographyThemer : NSObject
 
 /**
  Applies a typography scheme's properties to an MDCButtonBar.
@@ -38,6 +37,8 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
-                  toButtonBar:(nonnull MDCButtonBar *)buttonBar;
+                  toButtonBar:(nonnull MDCButtonBar *)buttonBar
+    __deprecated_msg("ButtonBar is not intended to be themed as a standalone component."
+                     " Please theme it via the AppBar component's Theming extension instead.");
 
 @end


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8429

These targets have no internal usage.