### PR TITLE
[BottomAppBar] Deprecate the ColorThemer.

### DIFF
--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -51,15 +51,6 @@ mdc_objc_library(
     visibility = ["//visibility:private"],
 )
 
-mdc_extension_objc_library(
-    name = "ColorThemer",
-    deps = [
-        ":BottomAppBar",
-        "//components/Themes",
-        "//components/schemes/Color",
-    ],
-)
-
 mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
@@ -117,4 +108,17 @@ mdc_snapshot_objc_library(
 mdc_snapshot_test(
     name = "snapshot_tests",
     deps = [":snapshot_test_lib"],
+)
+
+# Deprecated
+
+mdc_extension_objc_library(
+    name = "ColorThemer",
+    deprecation = "Please indicate interest in a replacement API at" +
+                  " https://github.com/material-components/material-components-ios/issues/7172",
+    deps = [
+        ":BottomAppBar",
+        "//components/Themes",
+        "//components/schemes/Color",
+    ],
 )

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.m
@@ -82,8 +82,18 @@
   [self commonBottomBarSetup];
 
   [self.bottomBarView.floatingButton applySecondaryThemeWithScheme:[self containerScheme]];
-  [MDCBottomAppBarColorThemer applySurfaceVariantWithSemanticColorScheme:self.colorScheme
-                                                      toBottomAppBarView:self.bottomBarView];
+
+  self.bottomBarView.barTintColor = self.colorScheme.surfaceColor;
+  UIColor *barItemTintColor =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.6];
+  self.bottomBarView.leadingBarItemsTintColor = barItemTintColor;
+  self.bottomBarView.trailingBarItemsTintColor = barItemTintColor;
+  [self.bottomBarView.floatingButton setBackgroundColor:self.colorScheme.primaryColor
+                                               forState:UIControlStateNormal];
+  [self.bottomBarView.floatingButton setTitleColor:self.colorScheme.onPrimaryColor
+                                          forState:UIControlStateNormal];
+  [self.bottomBarView.floatingButton setImageTintColor:self.colorScheme.onPrimaryColor
+                                              forState:UIControlStateNormal];
 }
 
 - (void)didTapFloatingButton:(id)sender {

--- a/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
+++ b/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.h
@@ -21,14 +21,14 @@
  A color themer for MDCBottomAppBarView. This API does not fully implement the Material Design color
  system.
 
- @warning This API will eventually be deprecated. There is no replacement yet.
+ @warning This API will eventually be deleted. There is no replacement yet.
  Track progress here: https://github.com/material-components/material-components-ios/issues/7172
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCBottomAppBarColorThemer : NSObject
-@end
-
-@interface MDCBottomAppBarColorThemer (ToBeDeprecated)
+__deprecated_msg("No replacement exists. Please comment on"
+                 " https://github.com/material-components/material-components-ios/issues/7172"
+                 " in order to indicate interest in a replacement API.")
+    @interface MDCBottomAppBarColorThemer : NSObject
 
 /**
  Applies a color scheme to theme an MDCBottomAppBarView using the "surface" variant theming. The
@@ -43,7 +43,10 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySurfaceVariantWithSemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-                                toBottomAppBarView:(nonnull MDCBottomAppBarView *)bottomAppBarView;
+                                toBottomAppBarView:(nonnull MDCBottomAppBarView *)bottomAppBarView
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 /**
  Applies a color scheme to theme a MDCBottomAppBarView.
@@ -56,6 +59,9 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-      toBottomAppBarView:(nonnull MDCBottomAppBarView *)bottomAppBarView;
+      toBottomAppBarView:(nonnull MDCBottomAppBarView *)bottomAppBarView
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 @end

--- a/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.m
+++ b/components/BottomAppBar/src/ColorThemer/MDCBottomAppBarColorThemer.m
@@ -17,7 +17,10 @@
 #import "MaterialBottomAppBar.h"
 #import "MaterialThemes.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCBottomAppBarColorThemer
+#pragma clang diagnostic pop
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
       toBottomAppBarView:(MDCBottomAppBarView *)bottomAppBarView {

--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -38,8 +38,15 @@ class BottomDrawerExpandFullscreenExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -38,8 +38,15 @@ class BottomDrawerInfiniteScrollingExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -37,8 +37,15 @@ class BottomDrawerNoHeaderExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
@@ -40,8 +40,15 @@ class BottomDrawerNoHeaderLessContentExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -38,8 +38,15 @@ class BottomDrawerWithChangingContentSizeExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -38,8 +38,15 @@ class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewContro
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -38,8 +38,15 @@ class BottomDrawerWithScrollableContentExample: UIViewController {
     barButtonLeadingItem.target = self
     barButtonLeadingItem.action = #selector(presentNavigationDrawer)
     bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
-    MDCBottomAppBarColorThemer.applySurfaceVariant(withSemanticColorScheme: colorScheme,
-                                                   to: bottomAppBar)
+
+    bottomAppBar.barTintColor = colorScheme.surfaceColor;
+    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+
     view.addSubview(bottomAppBar)
   }
 


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8429

There is no internal usage of this API.