### PR TITLE
[MaskedTransition] Deprecate MDCMaskedTransitionController.

### DIFF
--- a/components/MaskedTransition/BUILD
+++ b/components/MaskedTransition/BUILD
@@ -26,6 +26,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "MaskedTransition",
+    deprecation = "There is no replacemennt for this component. Please use a standard presentViewController invocation instead.",
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -35,7 +35,7 @@
  */
 __deprecated_msg("There is no replacemennt for this API."
                  " Please use a standard presentViewController invocation instead.")
-@interface MDCMaskedTransitionController : NSObject <UIViewControllerTransitioningDelegate>
+    @interface MDCMaskedTransitionController : NSObject<UIViewControllerTransitioningDelegate>
 
 /**
  Initializes the transition controller with a given source view.

--- a/components/MaskedTransition/src/MDCMaskedTransitionController.h
+++ b/components/MaskedTransition/src/MDCMaskedTransitionController.h
@@ -33,6 +33,8 @@
  Once the view controller to be presented has been fully configured, you can present the view
  controller using any of the available view controller presentation APIs.
  */
+__deprecated_msg("There is no replacemennt for this API."
+                 " Please use a standard presentViewController invocation instead.")
 @interface MDCMaskedTransitionController : NSObject <UIViewControllerTransitioningDelegate>
 
 /**


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8228

The API has no internal usage.