### PR TITLE
[MDCButton] Delete underlyingColor property

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -339,7 +339,4 @@
 @property(nonatomic) BOOL shouldRaiseOnTouch __deprecated_msg(
     "Set elevation to MDCShadowElevationNone for all states instead.");
 
-@property(nonatomic, strong, nullable)
-    UIColor *underlyingColor __deprecated_msg("Use underlyingColorHint instead.");
-
 @end

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -995,10 +995,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
 #pragma mark - Deprecations
 
-- (UIColor *)underlyingColor {
-  return [self underlyingColorHint];
-}
-
 - (void)setUnderlyingColor:(UIColor *)underlyingColor {
   [self setUnderlyingColorHint:underlyingColor];
 }


### PR DESCRIPTION
There is no internal usage of this property

Closes #8447 