### PR TITLE
[BottomSheet] replace UIWebView usage with WKWebView.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -411,6 +411,7 @@ Pod::Spec.new do |mdc|
       "components/#{component.base_name}/src/*.{h,m}",
       "components/#{component.base_name}/src/private/*.{h,m}"
     ]
+    component.framework = "WebKit"
 
     component.dependency "MaterialComponents/Elevation"
     component.dependency "MaterialComponents/ShapeLibrary"

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -33,6 +33,7 @@ mdc_public_objc_library(
     name = "BottomSheet",
     sdk_frameworks = [
         "QuartzCore",
+        "WebKit",
     ],
     deps = [
         "//components/Elevation",

--- a/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
+++ b/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
@@ -1,4 +1,4 @@
-// Copyright 201-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
+++ b/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
@@ -1,0 +1,62 @@
+// Copyright 201-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#import "MaterialBottomSheet.h"
+#import "supplemental/BottomSheetSupplemental.h"
+
+@interface PresentedWebViewController : UIViewController
+
+@property(nonatomic) WKWebView *webView;
+
+@end
+
+@implementation PresentedWebViewController {
+  NSObject<UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
+      *_transitionController;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    _transitionController = [[MDCBottomSheetTransitionController alloc] init];
+    self.transitioningDelegate = _transitionController;
+    self.modalPresentationStyle = UIModalPresentationCustom;
+  }
+  return self;
+}
+
+- (void)loadView {
+  WKWebView *webView = [[WKWebView alloc] init];
+  NSURL *url = [NSURL URLWithString:@"https://nytimes.com/"];
+  NSURLRequest *request = [NSURLRequest requestWithURL:url];
+  [webView loadRequest:request];
+  self.view = webView;
+}
+
+@end
+
+@implementation BottomSheetWebViewPresentationExample
+
+- (void)presentBottomSheet {
+  PresentedWebViewController *viewController = [[PresentedWebViewController alloc] init];
+
+  MDCBottomSheetController *bottomSheet =
+      [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+  [self presentViewController:bottomSheet animated:YES completion:nil];
+}
+
+@end

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.h
@@ -20,6 +20,9 @@
 @interface BottomSheetPresentationExample : BottomSheetPresenterViewController
 @end
 
+@interface BottomSheetWebViewPresentationExample : BottomSheetPresenterViewController
+@end
+
 @interface BottomSheetAutolayoutSafeAreaExample : BottomSheetPresenterViewController
 @end
 

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
@@ -54,6 +54,22 @@
 
 @end
 
+@implementation BottomSheetWebViewPresentationExample (CatalogByConvention)
+
++ (NSArray *)catalogBreadcrumbs {
+  return @[ @"Bottom Sheet", @"Presentation from Modal (WebView)" ];
+}
+
++ (BOOL)catalogIsPrimaryDemo {
+  return NO;
+}
+
++ (BOOL)catalogIsPresentable {
+  return NO;
+}
+
+@end
+
 @implementation BottomSheetShortCollectionExample (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #import "MDCBottomSheetPresentationController.h"
+
+#import <WebKit/WebKit.h>
+
 #import "MaterialMath.h"
 #import "private/MDCSheetContainerView.h"
 
@@ -31,10 +34,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   if ([viewController.view isKindOfClass:[UIScrollView class]]) {
     scrollView = (UIScrollView *)viewController.view;
-#if !TARGET_OS_UIKITFORMAC
-  } else if ([viewController.view isKindOfClass:[UIWebView class]]) {
-    scrollView = ((UIWebView *)viewController.view).scrollView;
-#endif
+  } else if ([viewController.view isKindOfClass:[WKWebView class]]) {
+    scrollView = ((WKWebView *)viewController.view).scrollView;
   } else if ([viewController isKindOfClass:[UICollectionViewController class]]) {
     scrollView = ((UICollectionViewController *)viewController).collectionView;
   }

--- a/components/schemes/Typography/src/MaterialTypographyScheme.h
+++ b/components/schemes/Typography/src/MaterialTypographyScheme.h
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 #import <MaterialComponents/MaterialTypographyScheme+BasicFontScheme.h>
+
 #import "MDCTypographyScheme.h"

--- a/components/schemes/Typography/src/MaterialTypographyScheme.h
+++ b/components/schemes/Typography/src/MaterialTypographyScheme.h
@@ -13,5 +13,4 @@
 // limitations under the License.
 
 #import <MaterialComponents/MaterialTypographyScheme+BasicFontScheme.h>
-
 #import "MDCTypographyScheme.h"


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8381.

This PR removed the references to deprecated UIWebView, and used WKWebView (available on iOS8+) in place to keep the original behavior. 

As WKWebView is available on Mac Catalyst, the TARGET_OS_UIKITFORMAC flag is also removed.

An Example is created for this WebView change.
Screenshot:

![webview](https://user-images.githubusercontent.com/8836258/64892736-42993300-d643-11e9-8dfa-a686506de015.gif)
