### PR TITLE
[AppBar] Hide the navigation bar in MDCAppBarNavigationController's initWithRootViewController API.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -48,8 +48,7 @@
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    // We always want the navigation bar to be hidden.
-    [self setNavigationBarHidden:YES animated:NO];
+    [self MDCAppBarNavigationController_commonInit];
   }
   return self;
 }
@@ -57,9 +56,16 @@
 - (instancetype)initWithRootViewController:(UIViewController *)rootViewController {
   self = [super initWithRootViewController:rootViewController];
   if (self) {
+    [self MDCAppBarNavigationController_commonInit];
+
     [self injectAppBarIntoViewController:rootViewController];
   }
   return self;
+}
+
+- (void)MDCAppBarNavigationController_commonInit {
+  // We always want the navigation bar to be hidden.
+  [self setNavigationBarHidden:YES animated:NO];
 }
 
 #pragma mark - UINavigationController overrides

--- a/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarNavigationControllerTests.m
@@ -36,6 +36,30 @@
   [super tearDown];
 }
 
+- (void)testInitHidesTheNavigationBar {
+  // Then
+  XCTAssertTrue(self.navigationController.navigationBarHidden);
+}
+
+- (void)testInitWithNibNameHidesTheNavigationBar {
+  // Given
+  MDCAppBarNavigationController *navigationController =
+      [[MDCAppBarNavigationController alloc] initWithNibName:nil bundle:nil];
+
+  // Then
+  XCTAssertTrue(navigationController.navigationBarHidden);
+}
+
+- (void)testInitWithRootViewControllerHidesTheNavigationBar {
+  // Given
+  UIViewController *viewController = [[UIViewController alloc] init];
+  MDCAppBarNavigationController *navigationController =
+      [[MDCAppBarNavigationController alloc] initWithRootViewController:viewController];
+
+  // Then
+  XCTAssertTrue(navigationController.navigationBarHidden);
+}
+
 - (void)testSettingAViewControllerInjectsAnAppBar {
   // Given
   UIViewController *viewController = [[UIViewController alloc] init];


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8462
