### PR TITLE
Correct gh authentication instruction in release script

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -341,7 +341,7 @@ publish_release() {
     echo
     echo "And then get an auth token by running:"
     echo
-    echo "    gh user $(whoami)"
+    echo "    gh user"
     echo
     exit 1
   fi

--- a/scripts/release
+++ b/scripts/release
@@ -341,7 +341,7 @@ publish_release() {
     echo
     echo "And then get an auth token by running:"
     echo
-    echo "    gh user --whoami"
+    echo "    gh user $(whoami)"
     echo
     exit 1
   fi


### PR DESCRIPTION
Update the instructions regarding how to authenticate with the command line `gh` tool.