### PR TITLE
[NavDrawer] Allow animations alongside movement in MDCBottomNavigatio…

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -50,6 +50,67 @@
             (nonnull MDCBottomDrawerPresentationController *)presentationController
                        transitionRatio:(CGFloat)transitionRatio;
 
+/**
+ This method is called when the y-offset of the visible contents of the drawer have changed. This
+ is triggered when the drawer is presented and dismissed as well as when the content is being
+ dragged interactively.
+
+ @param presentationController presentation controller of the bottom drawer
+ @param yOffset yOffset of the top of the drawer
+ */
+- (void)bottomDrawerTopDidChangeYOffset:
+            (nonnull MDCBottomDrawerPresentationController *)presentationController
+                                yOffset:(CGFloat)yOffset;
+
+/**
+ This method is called when the bottom drawer will begin animating to an open state. This is
+ triggered when the VC is being presented.
+
+ @param presentationController presentation controller of the bottom drawer
+ @param transitionCoordinator coordinator being used to animate the transition
+ @param targetYOffset y-Offset that the drawer will animate to
+
+ @discussion The target y-offset is calculated based upon the @c maximumInitialDrawerHeight and
+ @c preferredContentSize of the @c contentViewController. This value may not be the final offset
+ since that may change once the initial layout pass has completed. If the offset changes again then
+ @c bottomDrawerTopDidChangeYOffset:yOffset will be called with the updated value.
+ */
+- (void)bottomDrawerPresentTransitionWillBegin:
+            (nonnull MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator
+                                 targetYOffset:(CGFloat)targetYOffset;
+
+/**
+ This method is called when the bottom drawer has completed animating to an open state. This is
+ triggered when the VC is being presented.
+
+ @param presentationController presentation controller of the bottom drawer
+ */
+- (void)bottomDrawerPresentTransitionDidEnd:
+    (nonnull MDCBottomDrawerPresentationController *)presentationController;
+
+/**
+ This method is called when the bottom drawer will begin animating to a closed state. This is
+ triggered when the VC is being dismissed.
+
+ @param presentationController presentation controller of the bottom drawer
+ @param transitionCoordinator coordinator being used to animate the transition
+ */
+- (void)bottomDrawerDismissTransitionWillBegin:
+            (nonnull MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator;
+
+/**
+ This method is called when the bottom drawer has completed animating to a closed state. This is
+ triggered when the VC is being dismissed.
+
+ @param presentationController presentation controller of the bottom drawer
+ */
+- (void)bottomDrawerDismissTransitionDidEnd:
+    (nonnull MDCBottomDrawerPresentationController *)presentationController;
+
 @end
 
 /**

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -173,6 +173,13 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
         self.scrimView.alpha = 1.0;
       }
                       completion:nil];
+
+  // Need to calculate the initial position of the drawer since the layout pass will
+  // not be complete before the animation begins.
+  CGRect frame = [self frameOfPresentedViewInContainerView];
+  [self.delegate bottomDrawerPresentTransitionWillBegin:self
+                                        withCoordinator:transitionCoordinator
+                                          targetYOffset:frame.origin.y];
 }
 
 - (void)presentationTransitionDidEnd:(BOOL)completed {
@@ -188,6 +195,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }
+
+  [self.delegate bottomDrawerPresentTransitionDidEnd:self];
 }
 
 - (void)dismissalTransitionWillBegin {
@@ -198,6 +207,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
         self.scrimView.alpha = 0.0;
       }
                       completion:nil];
+
+  [self.delegate bottomDrawerDismissTransitionWillBegin:self withCoordinator:transitionCoordinator];
 }
 
 - (void)dismissalTransitionDidEnd:(BOOL)completed {
@@ -212,12 +223,25 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
     [self.scrimView removeFromSuperview];
     [self.topHandle removeFromSuperview];
   }
+  [self.delegate bottomDrawerDismissTransitionDidEnd:self];
 }
 
 - (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
   [super preferredContentSizeDidChangeForChildContentContainer:container];
-
   [self.bottomDrawerContainerViewController.view layoutIfNeeded];
+}
+
+- (CGRect)frameOfPresentedViewInContainerView {
+  CGSize containerSize = self.containerView.frame.size;
+  CGSize preferredSize = self.presentedViewController.preferredContentSize;
+
+  // Layout has yet to be completed so let's calculate the preferred height
+  if (CGSizeEqualToSize(preferredSize, CGSizeZero)) {
+    preferredSize.height = self.bottomDrawerContainerViewController.maximumInitialDrawerHeight;
+    preferredSize.width = containerSize.width;
+  }
+  return CGRectMake(0, containerSize.height - preferredSize.height, preferredSize.height,
+                    preferredSize.width);
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size
@@ -308,6 +332,15 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                             completion:(void (^__nullable)(BOOL finished))completion {
   [self.bottomDrawerContainerViewController expandToFullscreenWithDuration:duration
                                                                 completion:completion];
+}
+
+- (void)bottomDrawerContainerViewControllerDidChangeYOffset:
+            (MDCBottomDrawerContainerViewController *)containerViewController
+                                                    yOffset:(CGFloat)yOffset {
+  id<MDCBottomDrawerPresentationControllerDelegate> strongDelegate = self.delegate;
+  if ([strongDelegate respondsToSelector:@selector(bottomDrawerTopDidChangeYOffset:yOffset:)]) {
+    [strongDelegate bottomDrawerTopDidChangeYOffset:self yOffset:yOffset];
+  }
 }
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -168,6 +168,7 @@
  */
 @protocol MDCBottomDrawerViewControllerDelegate <NSObject>
 
+@optional
 /**
  Called when the top inset of the drawer changes due to size changes when moving into full screen
  to cover the status bar and safe area inset. Also if there is a top handle, the top inset will
@@ -179,5 +180,60 @@
  */
 - (void)bottomDrawerControllerDidChangeTopInset:(nonnull MDCBottomDrawerViewController *)controller
                                        topInset:(CGFloat)topInset;
+
+/**
+ Called when the y-offset of the visible contents of the drawer (excluding shadow & scrim) have
+ changed. This is triggered when the drawer is presented and dismissed as well as when the content
+ is being dragged interactively.
+
+ @param controller The MDCBottomDrawerViewController.
+ @param yOffset The y-Offset of the top of the visible contents of the drawer.
+ */
+- (void)bottomDrawerControllerDidChangeTopYOffset:
+            (nonnull MDCBottomDrawerViewController *)controller
+                                          yOffset:(CGFloat)yOffset;
+
+/**
+ Called when the bottom drawer will begin animating to an open state. This is triggered when the VC
+ is being presented. Add animations and/or completion to the transitionCoordinator to cause them to
+ animate/complete alongside the drawer animation.
+
+ @param controller The MDCBottomDrawerViewController.
+ @param transitionCoordinator The transitionCoordinator handling the presentation transition.
+ */
+- (void)bottomDrawerControllerWillTransitionOpen:(nonnull MDCBottomDrawerViewController *)controller
+                                 withCoordinator:
+                                     (nullable id<UIViewControllerTransitionCoordinator>)
+                                         transitionCoordinator
+                                   targetYOffset:(CGFloat)targetYOffset;
+
+/**
+ Called when the bottom drawer has completed animating to the open state.
+
+ @param controller The MDCBottomDrawerViewController.
+ */
+- (void)bottomDrawerControllerDidEndOpenTransition:
+    (nonnull MDCBottomDrawerViewController *)controller;
+
+/**
+ Called when the bottom drawer will begin animating to a closed state. This is triggered when the VC
+ is being dismissed. Add animations and/or completion to the transitionCoordinator to cause them to
+ animate/complete alongside the drawer animation.
+
+ @param controller The MDCBottomDrawerViewController.
+ @param transitionCoordinator The transitionCoordinator handling the presentation transition.
+ */
+- (void)
+    bottomDrawerControllerWillTransitionClosed:(nonnull MDCBottomDrawerViewController *)controller
+                               withCoordinator:(nullable id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator;
+
+/**
+ Called when the bottom drawer has completed animating to the closed state.
+
+ @param controller The MDCBottomDrawerViewController.
+ */
+- (void)bottomDrawerControllerDidEndCloseTransition:
+    (nonnull MDCBottomDrawerViewController *)controller;
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -30,6 +30,10 @@
 @implementation MDCBottomDrawerViewController {
   NSMutableDictionary<NSNumber *, NSNumber *> *_topCornersRadius;
   BOOL _isMaskAppliedFirstTime;
+
+  // Used for tracking the presentation/dismissal animations.
+  BOOL _isDrawerClosed;
+  CGFloat _lastOffset;
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
@@ -61,6 +65,8 @@
   _drawerShadowColor = [UIColor.blackColor colorWithAlphaComponent:(CGFloat)0.2];
   _elevation = MDCShadowElevationNavDrawer;
   _mdc_overrideBaseElevation = -1;
+  _isDrawerClosed = YES;
+  _lastOffset = NSNotFound;
 }
 
 - (void)viewWillLayoutSubviews {
@@ -249,6 +255,61 @@
   }
 }
 
+- (void)bottomDrawerPresentTransitionDidEnd:
+    (MDCBottomDrawerPresentationController *)presentationController {
+  if ([self.delegate respondsToSelector:@selector(bottomDrawerControllerDidEndOpenTransition:)]) {
+    [self.delegate bottomDrawerControllerDidEndOpenTransition:self];
+  }
+}
+
+- (void)bottomDrawerDismissTransitionDidEnd:
+    (MDCBottomDrawerPresentationController *)presentationController {
+  _isDrawerClosed = YES;
+  if ([self.delegate respondsToSelector:@selector(bottomDrawerControllerDidEndCloseTransition:)]) {
+    [self.delegate bottomDrawerControllerDidEndCloseTransition:self];
+  }
+}
+
+- (void)bottomDrawerPresentTransitionWillBegin:
+            (MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:
+                                   (id<UIViewControllerTransitionCoordinator>)transitionCoordinator
+                                 targetYOffset:(CGFloat)targetYOffset {
+  _isDrawerClosed = NO;
+  _lastOffset = targetYOffset;
+  if ([self.delegate respondsToSelector:@selector
+                     (bottomDrawerControllerWillTransitionOpen:withCoordinator:targetYOffset:)]) {
+    [self.delegate bottomDrawerControllerWillTransitionOpen:self
+                                            withCoordinator:transitionCoordinator
+                                              targetYOffset:targetYOffset];
+  }
+}
+
+- (void)bottomDrawerDismissTransitionWillBegin:
+            (MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:(id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator {
+  if ([self.delegate respondsToSelector:@selector(bottomDrawerControllerWillTransitionClosed:
+                                                                             withCoordinator:)]) {
+    [self.delegate bottomDrawerControllerWillTransitionClosed:self
+                                              withCoordinator:transitionCoordinator];
+  }
+}
+
+- (void)bottomDrawerTopDidChangeYOffset:
+            (MDCBottomDrawerPresentationController *)presentationController
+                                yOffset:(CGFloat)yOffset {
+  // Only forward changes along if the drawer is actually still on screen and the offset has
+  // changed. This will avoid sending thru duplicated offset changes or changes where the
+  // real value will be calculated soon (aka set to zero for prep, then layout pass happens).
+  if (!_isDrawerClosed && _lastOffset != yOffset &&
+      [self.delegate respondsToSelector:@selector(bottomDrawerControllerDidChangeTopYOffset:
+                                                                                    yOffset:)]) {
+    [self.delegate bottomDrawerControllerDidChangeTopYOffset:self yOffset:yOffset];
+  }
+  _lastOffset = yOffset;
+}
+
 - (void)bottomDrawerWillChangeState:
             (nonnull MDCBottomDrawerPresentationController *)presentationController
                         drawerState:(MDCBottomDrawerState)drawerState {
@@ -270,7 +331,11 @@
   if (!self.topHandleHidden) {
     topInset = MAX(topInset, (CGFloat)7.0);
   }
-  [self.delegate bottomDrawerControllerDidChangeTopInset:self topInset:topInset];
+
+  if ([self.delegate respondsToSelector:@selector(bottomDrawerControllerDidChangeTopInset:
+                                                                                 topInset:)]) {
+    [self.delegate bottomDrawerControllerDidChangeTopInset:self topInset:topInset];
+  }
 }
 
 - (void)setContentOffsetY:(CGFloat)contentOffsetY animated:(BOOL)animated {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -36,6 +36,15 @@
                                                drawerState:(MDCBottomDrawerState)drawerState;
 
 /**
+ This method is called when the bottom drawer will change the y-offset of its contents.
+
+ @param containerViewController the container view controller of the bottom drawer.
+ @param yOffset current yOffset of the bottom drawer contents
+ */
+- (void)bottomDrawerContainerViewControllerDidChangeYOffset:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                    yOffset:(CGFloat)yOffset;
+/**
  This method is called when the drawer is scrolled/dragged and provides a transition ratio value
  between 0-100% (0-1) that indicates the percentage in which the drawer is close to reaching the end
  of its scrolling. If the drawer is about to reach fullscreen, its percentage moves between 0-100%

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -638,6 +638,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
       contentOffset.y >= self.transitionCompleteContentOffset ? 1 : transitionPercentage;
   [self.delegate bottomDrawerContainerViewControllerTopTransitionRatio:self
                                                        transitionRatio:transitionPercentage];
+
   [self updateDrawerState:transitionPercentage];
   self.currentlyFullscreen = self.contentReachesFullscreen && headerTransitionToTop >= 1;
   CGFloat fullscreenHeaderHeight =
@@ -647,6 +648,17 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
                         fullscreenHeaderHeight:fullscreenHeaderHeight];
   [self updateTopHeaderBottomShadowWithContentOffset:contentOffset];
   [self updateContentWithHeight:contentOffset.y];
+
+  // Calculate the current yOffset of the header and content.
+  CGFloat yOffset = self.contentViewController.view.frame.origin.y -
+                    self.headerViewController.view.frame.size.height - contentOffset.y;
+
+  // While animation open, always send back the final target Y offset.
+  if (self.animatingPresentation) {
+    yOffset = self.contentHeaderTopInset;
+  }
+  [self.delegate bottomDrawerContainerViewControllerDidChangeYOffset:self
+                                                             yOffset:MAX(0.0f, yOffset)];
 }
 
 - (void)updateContentHeaderWithTransitionToTop:(CGFloat)headerTransitionToTop

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -17,8 +17,8 @@
 #import "../../src/private/MDCBottomDrawerContainerViewController.h"
 #import "../../src/private/MDCBottomDrawerHeaderMask.h"
 #import "../../src/private/MDCBottomDrawerShadowedView.h"
-#import "third_party/objective_c/material_components_ios/components/NavigationDrawer/tests/unit/MDCNavigationDrawerFakes.h"
-#import "third_party/objective_c/material_components_ios/components/ShadowLayer/src/MaterialShadowLayer.h"
+#import "MDCNavigationDrawerFakes.h"
+#import "MaterialShadowLayer.h"
 
 @interface MDCBottomDrawerDelegateTest
     : UIViewController <MDCBottomDrawerPresentationControllerDelegate,

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerScrollViewTests.m
@@ -17,12 +17,15 @@
 #import "../../src/private/MDCBottomDrawerContainerViewController.h"
 #import "../../src/private/MDCBottomDrawerHeaderMask.h"
 #import "../../src/private/MDCBottomDrawerShadowedView.h"
-#import "MDCNavigationDrawerFakes.h"
-#import "MaterialShadowLayer.h"
+#import "third_party/objective_c/material_components_ios/components/NavigationDrawer/tests/unit/MDCNavigationDrawerFakes.h"
+#import "third_party/objective_c/material_components_ios/components/ShadowLayer/src/MaterialShadowLayer.h"
 
 @interface MDCBottomDrawerDelegateTest
-    : UIViewController <MDCBottomDrawerPresentationControllerDelegate>
-@property(nonatomic, assign) BOOL delegateWasCalled;
+    : UIViewController <MDCBottomDrawerPresentationControllerDelegate,
+                        MDCBottomDrawerViewControllerDelegate>
+
+@property(nonatomic, strong) NSMutableArray *commands;
+
 @end
 
 @implementation MDCBottomDrawerDelegateTest
@@ -30,18 +33,92 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _delegateWasCalled = NO;
+    _commands = [NSMutableArray array];
   }
   return self;
 }
 - (void)bottomDrawerWillChangeState:(MDCBottomDrawerPresentationController *)presentationController
                         drawerState:(MDCBottomDrawerState)drawerState {
-  _delegateWasCalled = YES;
+  [_commands addObject:NSStringFromSelector(_cmd)];
 }
 
 - (void)bottomDrawerTopTransitionRatio:
             (nonnull MDCBottomDrawerPresentationController *)presentationController
                        transitionRatio:(CGFloat)transitionRatio {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerDismissTransitionDidEnd:
+    (MDCBottomDrawerPresentationController *)presentationController {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerPresentTransitionDidEnd:
+    (MDCBottomDrawerPresentationController *)presentationController {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerTopDidChangeYOffset:
+            (MDCBottomDrawerPresentationController *)presentationController
+                                yOffset:(CGFloat)yOffset {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerDismissTransitionWillBegin:
+            (MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:(id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerPresentTransitionWillBegin:
+            (MDCBottomDrawerPresentationController *)presentationController
+                               withCoordinator:
+                                   (id<UIViewControllerTransitionCoordinator>)transitionCoordinator
+                                 targetYOffset:(CGFloat)targetYOffset {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerControllerDidEndOpenTransition:(MDCBottomDrawerViewController *)controller {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerControllerDidEndCloseTransition:(MDCBottomDrawerViewController *)controller {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerControllerDidChangeTopInset:(nonnull MDCBottomDrawerViewController *)controller
+                                       topInset:(CGFloat)topInset {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerControllerDidChangeTopYOffset:
+            (nonnull MDCBottomDrawerViewController *)controller
+                                          yOffset:(CGFloat)yOffset {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)bottomDrawerControllerWillTransitionOpen:(nonnull MDCBottomDrawerViewController *)controller
+                                 withCoordinator:
+                                     (nullable id<UIViewControllerTransitionCoordinator>)
+                                         transitionCoordinator
+                                   targetYOffset:(CGFloat)targetYOffset {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)
+    bottomDrawerControllerWillTransitionClosed:(nonnull MDCBottomDrawerViewController *)controller
+                               withCoordinator:(nullable id<UIViewControllerTransitionCoordinator>)
+                                                   transitionCoordinator {
+  [_commands addObject:NSStringFromSelector(_cmd)];
+}
+
+- (void)clear {
+  _commands = [NSMutableArray array];
+}
+
+- (BOOL)verifyCallback:(SEL)cmd {
+  return [_commands containsObject:NSStringFromSelector(cmd)];
 }
 
 @end
@@ -418,7 +495,88 @@
   self.fakeBottomDrawer.drawerState = MDCBottomDrawerStateExpanded;
 
   // Then
-  XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
+  XCTAssertTrue([self.delegateTest verifyCallback:@selector(bottomDrawerWillChangeState:
+                                                                            drawerState:)]);
+}
+
+- (void)testBottomDrawerControllerWillOpenCallback {
+  self.drawerViewController.delegate = self.delegateTest;
+  self.presentationController.delegate = self.drawerViewController;
+  [self.presentationController presentationTransitionWillBegin];
+  XCTAssertTrue([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerWillTransitionOpen:
+                                                        withCoordinator:targetYOffset:)]);
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+}
+
+- (void)testBottomDrawerControllerDidOpenCallback {
+  self.drawerViewController.delegate = self.delegateTest;
+  self.presentationController.delegate = self.drawerViewController;
+  [self.presentationController presentationTransitionDidEnd:YES];
+  XCTAssertTrue(
+      [self.delegateTest verifyCallback:@selector(bottomDrawerControllerDidEndOpenTransition:)]);
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+}
+
+- (void)testBottomDrawerControllerWillCloseCallback {
+  self.drawerViewController.delegate = self.delegateTest;
+  self.presentationController.delegate = self.drawerViewController;
+  [self.presentationController dismissalTransitionWillBegin];
+  XCTAssertTrue([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerWillTransitionClosed:withCoordinator:)]);
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+}
+
+- (void)testBottomDrawerControllerDidCloseCallback {
+  self.drawerViewController.delegate = self.delegateTest;
+  self.presentationController.delegate = self.drawerViewController;
+  [self.presentationController dismissalTransitionDidEnd:YES];
+  XCTAssertTrue(
+      [self.delegateTest verifyCallback:@selector(bottomDrawerControllerDidEndCloseTransition:)]);
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+}
+
+- (void)testBottomDrawerControllerToYOffsetChangesCallback {
+  self.fakeBottomDrawer.delegate = self.presentationController;
+  self.drawerViewController.delegate = self.delegateTest;
+  self.presentationController.delegate = self.drawerViewController;
+
+  CGSize fakePreferredContentSize = CGSizeMake(200, 100);
+  [self setupHeaderWithPreferredContentSize:fakePreferredContentSize];
+  self.fakeBottomDrawer.contentViewController =
+      [[MDCNavigationDrawerFakeTableViewController alloc] init];
+  // fake out a layout pass...
+  self.fakeBottomDrawer.contentViewController.preferredContentSize = CGSizeMake(200, 100);
+  self.fakeBottomDrawer.contentViewController.view.frame = CGRectMake(0, 500, 200, 100);
+
+  // fake presenting the drawer
+  [self.presentationController presentationTransitionWillBegin];
+  [self.presentationController presentationTransitionDidEnd:YES];
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+
+  // fake a content inset change -- aka a user scrolled
+  [self.fakeBottomDrawer updateViewWithContentOffset:CGPointMake(0, 100)];
+  XCTAssertTrue([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+
+  // clear recorded cmds
+  [self.delegateTest clear];
+
+  // fake close the drawer
+  [self.presentationController dismissalTransitionWillBegin];
+  [self.presentationController dismissalTransitionDidEnd:YES];
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
+
+  // fake a content inset change -- aka a reset
+  [self.fakeBottomDrawer updateViewWithContentOffset:CGPointMake(0, 50)];
+  XCTAssertFalse([self.delegateTest
+      verifyCallback:@selector(bottomDrawerControllerDidChangeTopYOffset:yOffset:)]);
 }
 
 - (void)testBottomDrawerCornersAPICollapsed {


### PR DESCRIPTION
Add delegate methods to allow the presenting VC to gain access to the transitionCoordinator used during the present/dismiss transitions. Also provide callbacks for y-offset changes so that the presenting VC can animate content along with the y-offset changes.

Fixed requests from previous PR and added some tests for the callbacks.

Screen recording of the usage:

[navdrawer.mov.zip](https://github.com/material-components/material-components-ios/files/3633638/navdrawer.mov.zip)
