### PR TITLE
[TypographyScheme] Replace `mdc_adjustsFontForContentSizeCategory` with `useCurrentContentSizeCategoryWhenApplied`

### DIFF
--- a/components/Banner/src/Theming/MDCBannerView+MaterialTheming.m
+++ b/components/Banner/src/Theming/MDCBannerView+MaterialTheming.m
@@ -77,16 +77,8 @@ static CGFloat const kDividerOpacity = (CGFloat)0.12;
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
   UIFont *textFont = typographyScheme.body2;
-  BOOL useCurrentContentSizeCategoryWhenApplied = NO;
-  if ([typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]) {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.useCurrentContentSizeCategoryWhenApplied;
-  } else {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.mdc_adjustsFontForContentSizeCategory;
-  }
 
-  if (useCurrentContentSizeCategoryWhenApplied) {
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
     textFont = [textFont mdc_scaledFontForTraitEnvironment:self];
   }
   self.textView.font = textFont;

--- a/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.m
+++ b/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.m
@@ -21,16 +21,8 @@
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
                    toChipView:(nonnull MDCChipView *)chipView {
   UIFont *titleFont = typographyScheme.body2;
-  BOOL useCurrentContentSizeCategoryWhenApplied = NO;
-  if ([typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]) {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.useCurrentContentSizeCategoryWhenApplied;
-  } else {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.mdc_adjustsFontForContentSizeCategory;
-  }
 
-  if (useCurrentContentSizeCategoryWhenApplied) {
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
     titleFont = [titleFont mdc_scaledFontForTraitEnvironment:chipView];
   }
   chipView.titleFont = titleFont;

--- a/components/Chips/tests/unit/ChipViewTypographyThemerTests.m
+++ b/components/Chips/tests/unit/ChipViewTypographyThemerTests.m
@@ -40,16 +40,6 @@
 
 @implementation ChipViewTypographyThemerTests
 
-- (void)testFontThemerWithNoDynamicTypeSupport {
-  MDCChipView *chip = [[MDCChipView alloc] init];
-  MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
-  typographyScheme.mdc_adjustsFontForContentSizeCategory = NO;
-
-  [MDCChipViewTypographyThemer applyTypographyScheme:typographyScheme toChipView:chip];
-
-  XCTAssertEqualObjects(chip.titleLabel.font, typographyScheme.body2);
-}
-
 - (void)testFontThemerWhenCurrentContentSizeCategoryIsUsed {
   if (@available(iOS 10.0, *)) {
     // Given

--- a/components/List/src/TypographyThemer/MDCListTypographyThemer.m
+++ b/components/List/src/TypographyThemer/MDCListTypographyThemer.m
@@ -22,16 +22,7 @@
   UIFont *titleFont = typographyScheme.subtitle1;
   UIFont *detailFont = typographyScheme.body2;
 
-  BOOL useCurrentContentSizeCategoryWhenApplied = NO;
-  if ([typographyScheme respondsToSelector:@selector(useCurrentContentSizeCategoryWhenApplied)]) {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.useCurrentContentSizeCategoryWhenApplied;
-  } else {
-    useCurrentContentSizeCategoryWhenApplied =
-        typographyScheme.mdc_adjustsFontForContentSizeCategory;
-  }
-
-  if (useCurrentContentSizeCategoryWhenApplied) {
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
     titleFont = [titleFont mdc_scaledFontForTraitEnvironment:cell];
     detailFont = [detailFont mdc_scaledFontForTraitEnvironment:cell];
   }

--- a/components/schemes/Typography/src/MDCTypographyScheme.h
+++ b/components/schemes/Typography/src/MDCTypographyScheme.h
@@ -83,15 +83,3 @@ typedef NS_ENUM(NSInteger, MDCTypographySchemeDefaults) {
 - (nonnull instancetype)initWithDefaults:(MDCTypographySchemeDefaults)defaults;
 
 @end
-
-@interface MDCTypographyScheme (ToBeDeprecated)
-
-/**
- @warning Will eventually be deprecated and removed. Please use
- useCurrentContentSizeCategoryWhenApplied instead.
-
- Modifying this property will also modify useCurrentContentSizeCategoryWhenApplied, and vice-versa.
- */
-@property(nonatomic, assign, readwrite) BOOL mdc_adjustsFontForContentSizeCategory;
-
-@end

--- a/components/schemes/Typography/src/MDCTypographyScheming.h
+++ b/components/schemes/Typography/src/MDCTypographyScheming.h
@@ -86,33 +86,11 @@
 @property(nonatomic, nonnull, readonly, copy) UIFont *overline;
 
 /**
- Whether user interface elements should automatically resize based on the device's setting.
-
- This can be used by client to communicate whether they support dynamic type to both our theming
- functionality and embedded frameworks that also render UI.
-
- @warning This API will eventually be deprecated. Please use
- @c useCurrentContentSizeCategoryWhenApplied instead.
-
- @note  The value of @c useCurrentContentSizeCategoryWhenApplied (if implemented) and @c
- mdc_adjustsFontForContentSizeCategory must always be the same.
-
-*/
-@property(nonatomic, readonly) BOOL mdc_adjustsFontForContentSizeCategory __deprecated_msg(
-    "Use useCurrentContentSizeCategoryWhenApplied instead.");
-
-@optional
-
-/**
  A hint for how fonts in this scheme should be applied to components in relation to Dynamic Type.
 
  If this flag is enabled and the typography scheme's font is scalable with Dynamic Type, then fonts
  should be adjusted for the current Dynamic Type content size category prior to being assigned to
  the component.
-
- @note This flag will become required in the future as a replacement for
- @c mdc_adjustsFontForContentSizeCategory. The value of this flag needs to be the same as @c
- mdc_adjustsFontForContentSizeCategory.
  */
 @property(nonatomic, assign, readonly) BOOL useCurrentContentSizeCategoryWhenApplied;
 

--- a/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
+++ b/components/schemes/Typography/tests/unit/MDCTypographySchemeTests.m
@@ -167,29 +167,4 @@
   XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
 }
 
-- (void)
-    testMdc_adjustsFontForContentSizeCategoryIsMappedToUseCurrentContentSizeCategoryWhenApplied {
-  // Given
-  MDCTypographyScheme *scheme =
-      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
-
-  // When
-  scheme.mdc_adjustsFontForContentSizeCategory = YES;
-
-  // Then
-  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
-
-  // When
-  scheme.mdc_adjustsFontForContentSizeCategory = NO;
-
-  // Then
-  XCTAssertFalse(scheme.useCurrentContentSizeCategoryWhenApplied);
-
-  // When (just in case the initial "truth" equality was a coincidence)
-  scheme.mdc_adjustsFontForContentSizeCategory = YES;
-
-  // Then
-  XCTAssertTrue(scheme.useCurrentContentSizeCategoryWhenApplied);
-}
-
 @end


### PR DESCRIPTION
Replaces the deprecated API `mdc_adjustsFontForContentSizeCategory` with its
stated replacement, `useCurrentContentSizeCategoryWhenApplied`. Also makes the
replacement API required to ensure there is an available API to communicate
this information to theming code.

This change has already been tested internally and the necessary changes are captured in cl/270386732.

Closes #7618