### PR TITLE
[Typography] Fix scaling test.

### DIFF
--- a/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
+++ b/components/Typography/tests/unit/UIFont+MaterialTypographyTests.m
@@ -46,8 +46,8 @@
   if (@available(iOS 10.0, *)) {
     // Given
     UIFont *font = [UIFont systemFontOfSize:22.0];
-    font =
-        [[MDCFontScaler scalerForMaterialTextStyle:MDCTextStyleHeadline1] scaledFontWithFont:font];
+    font = [[[MDCFontScaler scalerForMaterialTextStyle:MDCTextStyleHeadline1]
+        scaledFontWithFont:font] mdc_scaledFontAtDefaultSize];
     MDCTypographyMockTraitEnvironment *traitEnvironment =
         [[MDCTypographyMockTraitEnvironment alloc] init];
     traitEnvironment.traitCollection = [UITraitCollection


### PR DESCRIPTION
Corrects a bug in an font scaling test that assumed the test host had its
content sizes category set to `UIContentSizeCategoryLarge`.

Discovered while authoring #8476.