### PR TITLE
[Catalog] Correct Banner tests in schemes.

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
+               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
+               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
+               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
                BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -70,9 +70,37 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "722E8BB6AD8C6485B800B83BA2E5089F"
+               BlueprintIdentifier = "6D639A36C9D1FE04FD788429B31BD983"
                BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -82,720 +110,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B4007B964B906502259A30F7E31A8AEF"
-               BuildableName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
-               BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F9A1C2C676D59A467CE625CC201AECD7"
-               BuildableName = "MaterialComponents-Unit-ActivityIndicator-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ActivityIndicator-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8C46E47EB837574D5E196A3C581844C0"
-               BuildableName = "MaterialComponents-Unit-AnimationTiming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-AnimationTiming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D37ABB65F9E6B518263D31AFB3D087C2"
-               BuildableName = "MaterialComponents-Unit-AppBar+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-AppBar+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94B3E58C44A700988ADE2A82BF33C9A9"
-               BuildableName = "MaterialComponents-Unit-AppBar-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-AppBar-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0D21D281D2C2BAB92899837B215F5450"
-               BuildableName = "MaterialComponents-Unit-BottomAppBar-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-BottomAppBar-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BA2DD0920A9B3BB5FE27034EBFA62ABA"
-               BuildableName = "MaterialComponents-Unit-BottomNavigation-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-BottomNavigation-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "80173564EC18CF366248DFC25163ED6B"
-               BuildableName = "MaterialComponents-Unit-BottomSheet-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-BottomSheet-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "745B0D3392123254C65B9F418977041A"
-               BuildableName = "MaterialComponents-Unit-ButtonBar-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ButtonBar-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "43DCFEF96304B034C3664F305572ABD5"
-               BuildableName = "MaterialComponents-Unit-Buttons+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Buttons+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "45D58D0961BC20F6D59C95F2C4F1FDA5"
-               BuildableName = "MaterialComponents-Unit-Buttons-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Buttons-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD528C02CBDEFDE0F458DD2D6B1B4676"
-               BuildableName = "MaterialComponents-Unit-Cards+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Cards+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "05810B57A981A5B06B768C24EEB8E7DB"
-               BuildableName = "MaterialComponents-Unit-Cards-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Cards-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0B7115667542383E0A99478310BA194D"
-               BuildableName = "MaterialComponents-Unit-Chips+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Chips+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EA9FAB6D74825D78CBF90D53164BB7FC"
-               BuildableName = "MaterialComponents-Unit-Chips-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Chips-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1D1B2FAA23E11B1893BDCD191E2F2FBA"
-               BuildableName = "MaterialComponents-Unit-CollectionCells-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-CollectionCells-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41F2D6961E1E281C845A16F1C4FC18C8"
-               BuildableName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD92690A61F9B8339B2E406D4836688E"
-               BuildableName = "MaterialComponents-Unit-Collections-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Collections-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6B7855B0186993EAABB1825E38EA7A6B"
-               BuildableName = "MaterialComponents-Unit-Dialogs-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Dialogs-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "16B54118DCADAB12E1C7971638192E70"
-               BuildableName = "MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-FeatureHighlight-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "919EA9C4B1DA0DCE8A22DA6AD6D22004"
-               BuildableName = "MaterialComponents-Unit-FlexibleHeader-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-FlexibleHeader-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD96F0D40893D6684084982F979474AE"
-               BuildableName = "MaterialComponents-Unit-HeaderStackView-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-HeaderStackView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EFD44542DBC0185BC0D566684BA50A6E"
-               BuildableName = "MaterialComponents-Unit-Ink-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Ink-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9F58F86853D3E0FDDBA5631E1A35CA43"
-               BuildableName = "MaterialComponents-Unit-LibraryInfo-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-LibraryInfo-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E6CBB25095E0170DF57B0DD05CBC412"
-               BuildableName = "MaterialComponents-Unit-List-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-List-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EF7CF22657C5369FC2106F817D7E141E"
-               BuildableName = "MaterialComponents-Unit-MaskedTransition-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-MaskedTransition-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "23FFE4D5F6492A6DC712F0AB717741D2"
-               BuildableName = "MaterialComponents-Unit-NavigationBar-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-NavigationBar-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "14A620A56D2AD82F9273153203BD5EAF"
-               BuildableName = "MaterialComponents-Unit-NavigationDrawer-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-NavigationDrawer-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD081D1A63ACC6AC7A71F3F5556FD8AD"
-               BuildableName = "MaterialComponents-Unit-OverlayWindow-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-OverlayWindow-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E29E55A4639CE37E8FB3DDAC9B20194E"
-               BuildableName = "MaterialComponents-Unit-PageControl-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-PageControl-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D6EAEAC9D49B3CFED17B43BF62B01346"
-               BuildableName = "MaterialComponents-Unit-Palettes-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Palettes-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "53F0D8C581B4758659FD35C94EB31E13"
-               BuildableName = "MaterialComponents-Unit-ProgressView-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ProgressView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "02F2617D094EB7169C123E283AA13B67"
-               BuildableName = "MaterialComponents-Unit-Ripple-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Ripple-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BE98BC65FA9999766C2E69A304C35FF2"
-               BuildableName = "MaterialComponents-Unit-ShadowElevations-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ShadowElevations-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F1E296B410A2D87309640290B20388D2"
-               BuildableName = "MaterialComponents-Unit-ShadowLayer-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ShadowLayer-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E0C04DEA8AC278158FBE4D9257F931E3"
-               BuildableName = "MaterialComponents-Unit-ShapeLibrary-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ShapeLibrary-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1D03AA9B31017661DD29289E59523231"
-               BuildableName = "MaterialComponents-Unit-Shapes-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Shapes-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "01E9D9C6A91BEF14E7D80A62F4FAA5FA"
-               BuildableName = "MaterialComponents-Unit-Slider-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Slider-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AB33E94F75E49ED1F52E2D0DBCC4D2CB"
-               BuildableName = "MaterialComponents-Unit-Snackbar-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Snackbar-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "677E70310D5DAC22ECBB5BA8BB191675"
-               BuildableName = "MaterialComponents-Unit-Tabs+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Tabs+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65C7EC9341922173CB5AEC619C857BFE"
-               BuildableName = "MaterialComponents-Unit-Tabs-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Tabs-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C6A23C8B5908FD78FE34A67729C2963A"
-               BuildableName = "MaterialComponents-Unit-TextFields+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextFields+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9F61A38CA52D206DF08D9E5D94647280"
-               BuildableName = "MaterialComponents-Unit-TextFields-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextFields-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0CB893291E1B4FC20AC7FDDAD0A68D43"
-               BuildableName = "MaterialComponents-Unit-Themes-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Themes-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "37E1456A86A5A28FD3D831E9AB71F5BC"
-               BuildableName = "MaterialComponents-Unit-Typography-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Typography-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B07C48452F3391E69111165EB171C4C9"
-               BuildableName = "MaterialComponents-Unit-private-Application-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-Application-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C7628DA70B1BCEC947183B38BE5ECD17"
-               BuildableName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F01DD0A685E0FD0FC0C7D8D74F0F0D15"
-               BuildableName = "MaterialComponents-Unit-private-Math-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-Math-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2CCB248F91C25755FA45D758D56FC4D2"
-               BuildableName = "MaterialComponents-Unit-private-Overlay-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-Overlay-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9D52CDF22F9BD517B5E19353CF9F7F19"
-               BuildableName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EDA533AD1F1B185ED1F39DCB9D1E1853"
-               BuildableName = "MaterialComponents-Unit-private-UIMetrics-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-UIMetrics-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "67D836C778895EBC6E55636E4F918DD1"
-               BuildableName = "MaterialComponents-Unit-schemes-Color-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-schemes-Color-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3CA10DECBC9881C3CF8CECC909A2C10B"
-               BuildableName = "MaterialComponents-Unit-schemes-Container-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-schemes-Container-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9D30DFB4194781852526722245FD987E"
-               BuildableName = "MaterialComponents-Unit-schemes-Shape-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-schemes-Shape-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "058FCCE5EAAE9D3A4AF5D2C3C8F3462A"
-               BuildableName = "MaterialComponents-Unit-schemes-Typography-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-schemes-Typography-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
-               BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
-               BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACE8F8377BC344DD26C128FBE324B08E"
-               BuildableName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3EF1C285419E755C019EC7F5334722D6"
-               BuildableName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94C1D3154090898637E0243EBB10377B"
-               BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
-               BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7F8F825884AA0C4686D14359DF4344AB"
-               BuildableName = "MaterialComponents-Unit-List+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-List+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8C8DCDF159BDAF73E764F62FE202514D"
-               BuildableName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F42EF0E7EEE873B8FD4CEB200A146CD5"
-               BuildableName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "80FDCBA97111C2F0E5D54C41D9C997FC"
-               BuildableName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A207417F15F963263F5D6F3BAB63C75A"
-               BuildableName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "722E8BB6AD8C6485B800B83BA2E5089F"
-               BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6EFF48F9EE72411F71576F22B197F62D"
-               BuildableName = "MaterialComponentsBeta-Unit-Banner-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-Banner-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0184BB648CA66A248247C2228748118B"
-               BuildableName = "MaterialComponents-Unit-Elevation-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-Elevation-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41A5C3CA19A72E9A7972D4A10AAB39E9"
-               BuildableName = "MaterialComponents-Unit-private-Color-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-private-Color-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "417F4BB5FA07D3B5C1A334F54B8555C5"
-               BuildableName = "MaterialComponentsBeta-Unit-Banner+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-Banner+Theming-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -812,8 +128,718 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5AEABD73C978E231D0994587B4ACF0E1"
+               BuildableName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
+               BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B0A8024F093ADA9CC587BC090A4419AC"
+               BuildableName = "MaterialComponents-Unit-ActivityIndicator-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ActivityIndicator-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "027EC1DCE82E80AD5CB428F3AD39E984"
+               BuildableName = "MaterialComponents-Unit-AnimationTiming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-AnimationTiming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01685AAF95CBA5141F9D3EA6BBE3F6BC"
+               BuildableName = "MaterialComponents-Unit-AppBar+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-AppBar+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3CF8C2598DC6D0BCB9945A3AD65F04B6"
+               BuildableName = "MaterialComponents-Unit-AppBar-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-AppBar-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03FA600006B7E2633E888EEF668E440C"
+               BuildableName = "MaterialComponents-Unit-BottomAppBar-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-BottomAppBar-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27A570C3560F017DFBA0E30DFB39517E"
+               BuildableName = "MaterialComponents-Unit-BottomNavigation-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-BottomNavigation-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F308FA69D1B592D4B533AE4C17612901"
+               BuildableName = "MaterialComponents-Unit-BottomSheet-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-BottomSheet-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E83366297A43215B3B11A00FF810EFAF"
+               BuildableName = "MaterialComponents-Unit-ButtonBar-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ButtonBar-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77C34355FC0CD1527B69ED2B007A7DD4"
+               BuildableName = "MaterialComponents-Unit-Buttons+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Buttons+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A71EAA04FB08E01EE3FAC73A2E95767F"
+               BuildableName = "MaterialComponents-Unit-Buttons-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Buttons-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5A4FC0F41A2DEB369D630388A554614F"
+               BuildableName = "MaterialComponents-Unit-Cards+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Cards+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81C4EE9F6E002798282F33F8910D6ACB"
+               BuildableName = "MaterialComponents-Unit-Cards-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Cards-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E5CF4CA83D5E81EF70FE005E6A8C8FEA"
+               BuildableName = "MaterialComponents-Unit-Chips+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Chips+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "19A6FEC8B2FB764ED6B5C90B84F56EBB"
+               BuildableName = "MaterialComponents-Unit-Chips-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Chips-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "45FDA756DF5E703C196D4AB94261BD5B"
+               BuildableName = "MaterialComponents-Unit-CollectionCells-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-CollectionCells-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77CED09DA4CB77C956A8F549CBDA11A8"
+               BuildableName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4B8E12E2380F086C99D6CE2939B11E5"
+               BuildableName = "MaterialComponents-Unit-Collections-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Collections-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B6D50BC877CBCEB53C3910BD4E8EF26"
+               BuildableName = "MaterialComponents-Unit-Dialogs-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Dialogs-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BD3536BF760F8AEEF8E9E04AEEB496E6"
+               BuildableName = "MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-FeatureHighlight-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "54DA72D929DF5C601614DEA46BF8BCBD"
+               BuildableName = "MaterialComponents-Unit-FlexibleHeader-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-FlexibleHeader-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "40538FB8F5280A29E587B2AC7FA19996"
+               BuildableName = "MaterialComponents-Unit-HeaderStackView-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-HeaderStackView-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "39534A756102CCEB20BCB47FA182E668"
+               BuildableName = "MaterialComponents-Unit-Ink-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Ink-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F02FF61FFD3A802B2E6990E6B9EE5055"
+               BuildableName = "MaterialComponents-Unit-LibraryInfo-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-LibraryInfo-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03427D937E6D8A8191170B67AE7889C9"
+               BuildableName = "MaterialComponents-Unit-List-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-List-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "54E4A1F93A01EFD44DF2FE9F161F5432"
+               BuildableName = "MaterialComponents-Unit-MaskedTransition-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-MaskedTransition-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B4629C7878F9AFE418078795704416C5"
+               BuildableName = "MaterialComponents-Unit-NavigationBar-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-NavigationBar-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E3CBD9C1497A4E2DAAC98B2EAAA0479E"
+               BuildableName = "MaterialComponents-Unit-NavigationDrawer-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-NavigationDrawer-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D170AD26DF679291AB1D74BB27AC7C8B"
+               BuildableName = "MaterialComponents-Unit-OverlayWindow-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-OverlayWindow-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EE6CF86481A77C792D90EFD206C1CECB"
+               BuildableName = "MaterialComponents-Unit-PageControl-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-PageControl-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D874218BA137CC6352E8E6E9332504FD"
+               BuildableName = "MaterialComponents-Unit-Palettes-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Palettes-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "11781C83418AE7B8585083ED3C25C17F"
+               BuildableName = "MaterialComponents-Unit-ProgressView-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ProgressView-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E55985B3B36899547E3DAD57139D837"
+               BuildableName = "MaterialComponents-Unit-Ripple-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Ripple-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "40DF556CD433DD58174A388CB98720BA"
+               BuildableName = "MaterialComponents-Unit-ShadowElevations-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ShadowElevations-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63BECCA23B5C7169DC15BE5A873A72DE"
+               BuildableName = "MaterialComponents-Unit-ShadowLayer-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ShadowLayer-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "39710615DB72A2B845D5C1FAE318B3FD"
+               BuildableName = "MaterialComponents-Unit-ShapeLibrary-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ShapeLibrary-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3B3E8A72DCB2CA75D4911B5D2451F50"
+               BuildableName = "MaterialComponents-Unit-Shapes-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Shapes-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A458D45BCEE7FA0DDDA98F1CDE6DF9CC"
+               BuildableName = "MaterialComponents-Unit-Slider-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Slider-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DD00D81B63E0194EE3564DE3ACE5C85E"
+               BuildableName = "MaterialComponents-Unit-Snackbar-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Snackbar-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2E7D3177D716EEC8BDDA94E73594540"
+               BuildableName = "MaterialComponents-Unit-Tabs+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Tabs+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ECB402E3778D6604B67D9334F798E2F0"
+               BuildableName = "MaterialComponents-Unit-Tabs-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Tabs-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B50EEF945A805597D167E9A4A2BF40E1"
+               BuildableName = "MaterialComponents-Unit-TextFields+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextFields+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9DA1A0A583AD4899700804119FFD82FD"
+               BuildableName = "MaterialComponents-Unit-TextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "284C1435D749967DBB39C2C7BEEC913D"
+               BuildableName = "MaterialComponents-Unit-Themes-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Themes-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6D6C1C5C03CAFD5D168FAB91261516D7"
+               BuildableName = "MaterialComponents-Unit-Typography-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Typography-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8F3FD7328015DC98B8037E7FFF518448"
+               BuildableName = "MaterialComponents-Unit-private-Application-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-Application-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B806406D612E43DCE5A95FEEA92EC974"
+               BuildableName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B0715BE751696065197E7B132CF798F"
+               BuildableName = "MaterialComponents-Unit-private-Math-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-Math-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB469A2460E3EB8813D9C7F41CEE2CBE"
+               BuildableName = "MaterialComponents-Unit-private-Overlay-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-Overlay-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1696A1FD72898E5DC7DA0796EB5316E1"
+               BuildableName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9AFC701DBAF2EF24708C16FEEBD31375"
+               BuildableName = "MaterialComponents-Unit-private-UIMetrics-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-UIMetrics-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4ACBFD51FB960AC748AEB19DF9674935"
+               BuildableName = "MaterialComponents-Unit-schemes-Color-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-schemes-Color-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B44ED38F9D474CF38FADA04FDF5D2690"
+               BuildableName = "MaterialComponents-Unit-schemes-Container-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-schemes-Container-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C748C221DF64CED78C87F098E988341D"
+               BuildableName = "MaterialComponents-Unit-schemes-Shape-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-schemes-Shape-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7155239C0BF2B487269FB421906F7B92"
+               BuildableName = "MaterialComponents-Unit-schemes-Typography-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-schemes-Typography-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
+               BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
+               BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "88EDC6F080DD13A85C457E8DF3D5680A"
+               BuildableName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1407E65B882514BA19258E4E7E2CD8E7"
+               BuildableName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "653B6FE35A1B4CDC5CA7D92E67DF97A6"
+               BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
+               BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BEFB959C8B8734803945286E9C2346C5"
+               BuildableName = "MaterialComponents-Unit-List+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-List+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCD06113384824F0016FA0CF5D813CF6"
+               BuildableName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BD5BBE89295C3C6B3C801FCC69091C85"
+               BuildableName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests.xctest"
+               BlueprintName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DA89912E26C1D30834DA796EADFD68E"
+               BuildableName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8E9B17CEB9CECE59A5FEEB2347DF98BE"
+               BuildableName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6D639A36C9D1FE04FD788429B31BD983"
+               BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "46A0CD17FDDAF1CACABA145E5854C52A"
+               BuildableName = "MaterialComponents-Unit-Elevation-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Elevation-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E59EBFC9F0205AB50A9355945690F57C"
+               BuildableName = "MaterialComponents-Unit-private-Color-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-private-Color-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -835,8 +861,6 @@
             ReferencedContainer = "container:MDCCatalog.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
+               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,9 +42,37 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
+               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -76,7 +104,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B4007B964B906502259A30F7E31A8AEF"
+               BlueprintIdentifier = "5AEABD73C978E231D0994587B4ACF0E1"
                BuildableName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -86,7 +114,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
+               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
                BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -96,7 +124,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F9A1C2C676D59A467CE625CC201AECD7"
+               BlueprintIdentifier = "B0A8024F093ADA9CC587BC090A4419AC"
                BuildableName = "MaterialComponents-Unit-ActivityIndicator-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActivityIndicator-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -106,7 +134,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8C46E47EB837574D5E196A3C581844C0"
+               BlueprintIdentifier = "027EC1DCE82E80AD5CB428F3AD39E984"
                BuildableName = "MaterialComponents-Unit-AnimationTiming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AnimationTiming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -116,7 +144,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D37ABB65F9E6B518263D31AFB3D087C2"
+               BlueprintIdentifier = "01685AAF95CBA5141F9D3EA6BBE3F6BC"
                BuildableName = "MaterialComponents-Unit-AppBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -126,7 +154,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94B3E58C44A700988ADE2A82BF33C9A9"
+               BlueprintIdentifier = "3CF8C2598DC6D0BCB9945A3AD65F04B6"
                BuildableName = "MaterialComponents-Unit-AppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -136,7 +164,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0D21D281D2C2BAB92899837B215F5450"
+               BlueprintIdentifier = "03FA600006B7E2633E888EEF668E440C"
                BuildableName = "MaterialComponents-Unit-BottomAppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomAppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -146,7 +174,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BA2DD0920A9B3BB5FE27034EBFA62ABA"
+               BlueprintIdentifier = "27A570C3560F017DFBA0E30DFB39517E"
                BuildableName = "MaterialComponents-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -156,7 +184,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "80173564EC18CF366248DFC25163ED6B"
+               BlueprintIdentifier = "F308FA69D1B592D4B533AE4C17612901"
                BuildableName = "MaterialComponents-Unit-BottomSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -166,7 +194,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "745B0D3392123254C65B9F418977041A"
+               BlueprintIdentifier = "E83366297A43215B3B11A00FF810EFAF"
                BuildableName = "MaterialComponents-Unit-ButtonBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ButtonBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -176,7 +204,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "43DCFEF96304B034C3664F305572ABD5"
+               BlueprintIdentifier = "77C34355FC0CD1527B69ED2B007A7DD4"
                BuildableName = "MaterialComponents-Unit-Buttons+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -186,7 +214,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "45D58D0961BC20F6D59C95F2C4F1FDA5"
+               BlueprintIdentifier = "A71EAA04FB08E01EE3FAC73A2E95767F"
                BuildableName = "MaterialComponents-Unit-Buttons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -196,7 +224,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD528C02CBDEFDE0F458DD2D6B1B4676"
+               BlueprintIdentifier = "5A4FC0F41A2DEB369D630388A554614F"
                BuildableName = "MaterialComponents-Unit-Cards+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -206,7 +234,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "05810B57A981A5B06B768C24EEB8E7DB"
+               BlueprintIdentifier = "81C4EE9F6E002798282F33F8910D6ACB"
                BuildableName = "MaterialComponents-Unit-Cards-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -216,7 +244,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0B7115667542383E0A99478310BA194D"
+               BlueprintIdentifier = "E5CF4CA83D5E81EF70FE005E6A8C8FEA"
                BuildableName = "MaterialComponents-Unit-Chips+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -226,7 +254,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EA9FAB6D74825D78CBF90D53164BB7FC"
+               BlueprintIdentifier = "19A6FEC8B2FB764ED6B5C90B84F56EBB"
                BuildableName = "MaterialComponents-Unit-Chips-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -236,7 +264,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1D1B2FAA23E11B1893BDCD191E2F2FBA"
+               BlueprintIdentifier = "45FDA756DF5E703C196D4AB94261BD5B"
                BuildableName = "MaterialComponents-Unit-CollectionCells-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionCells-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -246,7 +274,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41F2D6961E1E281C845A16F1C4FC18C8"
+               BlueprintIdentifier = "77CED09DA4CB77C956A8F549CBDA11A8"
                BuildableName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -256,7 +284,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FD92690A61F9B8339B2E406D4836688E"
+               BlueprintIdentifier = "F4B8E12E2380F086C99D6CE2939B11E5"
                BuildableName = "MaterialComponents-Unit-Collections-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Collections-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -266,7 +294,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6B7855B0186993EAABB1825E38EA7A6B"
+               BlueprintIdentifier = "8B6D50BC877CBCEB53C3910BD4E8EF26"
                BuildableName = "MaterialComponents-Unit-Dialogs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -276,7 +304,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "16B54118DCADAB12E1C7971638192E70"
+               BlueprintIdentifier = "BD3536BF760F8AEEF8E9E04AEEB496E6"
                BuildableName = "MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FeatureHighlight-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -286,7 +314,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "919EA9C4B1DA0DCE8A22DA6AD6D22004"
+               BlueprintIdentifier = "54DA72D929DF5C601614DEA46BF8BCBD"
                BuildableName = "MaterialComponents-Unit-FlexibleHeader-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FlexibleHeader-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -296,7 +324,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD96F0D40893D6684084982F979474AE"
+               BlueprintIdentifier = "40538FB8F5280A29E587B2AC7FA19996"
                BuildableName = "MaterialComponents-Unit-HeaderStackView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-HeaderStackView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -306,7 +334,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EFD44542DBC0185BC0D566684BA50A6E"
+               BlueprintIdentifier = "39534A756102CCEB20BCB47FA182E668"
                BuildableName = "MaterialComponents-Unit-Ink-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ink-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -316,7 +344,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9F58F86853D3E0FDDBA5631E1A35CA43"
+               BlueprintIdentifier = "F02FF61FFD3A802B2E6990E6B9EE5055"
                BuildableName = "MaterialComponents-Unit-LibraryInfo-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-LibraryInfo-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -326,7 +354,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E6CBB25095E0170DF57B0DD05CBC412"
+               BlueprintIdentifier = "03427D937E6D8A8191170B67AE7889C9"
                BuildableName = "MaterialComponents-Unit-List-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -336,7 +364,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EF7CF22657C5369FC2106F817D7E141E"
+               BlueprintIdentifier = "54E4A1F93A01EFD44DF2FE9F161F5432"
                BuildableName = "MaterialComponents-Unit-MaskedTransition-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-MaskedTransition-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -346,7 +374,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "23FFE4D5F6492A6DC712F0AB717741D2"
+               BlueprintIdentifier = "B4629C7878F9AFE418078795704416C5"
                BuildableName = "MaterialComponents-Unit-NavigationBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -356,7 +384,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "14A620A56D2AD82F9273153203BD5EAF"
+               BlueprintIdentifier = "E3CBD9C1497A4E2DAAC98B2EAAA0479E"
                BuildableName = "MaterialComponents-Unit-NavigationDrawer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationDrawer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -366,7 +394,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD081D1A63ACC6AC7A71F3F5556FD8AD"
+               BlueprintIdentifier = "D170AD26DF679291AB1D74BB27AC7C8B"
                BuildableName = "MaterialComponents-Unit-OverlayWindow-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-OverlayWindow-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -376,7 +404,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E29E55A4639CE37E8FB3DDAC9B20194E"
+               BlueprintIdentifier = "EE6CF86481A77C792D90EFD206C1CECB"
                BuildableName = "MaterialComponents-Unit-PageControl-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-PageControl-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -386,7 +414,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D6EAEAC9D49B3CFED17B43BF62B01346"
+               BlueprintIdentifier = "D874218BA137CC6352E8E6E9332504FD"
                BuildableName = "MaterialComponents-Unit-Palettes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Palettes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -396,7 +424,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "53F0D8C581B4758659FD35C94EB31E13"
+               BlueprintIdentifier = "11781C83418AE7B8585083ED3C25C17F"
                BuildableName = "MaterialComponents-Unit-ProgressView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -406,7 +434,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "02F2617D094EB7169C123E283AA13B67"
+               BlueprintIdentifier = "3E55985B3B36899547E3DAD57139D837"
                BuildableName = "MaterialComponents-Unit-Ripple-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ripple-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -416,7 +444,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BE98BC65FA9999766C2E69A304C35FF2"
+               BlueprintIdentifier = "40DF556CD433DD58174A388CB98720BA"
                BuildableName = "MaterialComponents-Unit-ShadowElevations-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowElevations-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -426,7 +454,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F1E296B410A2D87309640290B20388D2"
+               BlueprintIdentifier = "63BECCA23B5C7169DC15BE5A873A72DE"
                BuildableName = "MaterialComponents-Unit-ShadowLayer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowLayer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -436,7 +464,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E0C04DEA8AC278158FBE4D9257F931E3"
+               BlueprintIdentifier = "39710615DB72A2B845D5C1FAE318B3FD"
                BuildableName = "MaterialComponents-Unit-ShapeLibrary-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShapeLibrary-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -446,7 +474,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1D03AA9B31017661DD29289E59523231"
+               BlueprintIdentifier = "A3B3E8A72DCB2CA75D4911B5D2451F50"
                BuildableName = "MaterialComponents-Unit-Shapes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Shapes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -456,7 +484,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "01E9D9C6A91BEF14E7D80A62F4FAA5FA"
+               BlueprintIdentifier = "A458D45BCEE7FA0DDDA98F1CDE6DF9CC"
                BuildableName = "MaterialComponents-Unit-Slider-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Slider-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -466,7 +494,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AB33E94F75E49ED1F52E2D0DBCC4D2CB"
+               BlueprintIdentifier = "DD00D81B63E0194EE3564DE3ACE5C85E"
                BuildableName = "MaterialComponents-Unit-Snackbar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Snackbar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -476,7 +504,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "677E70310D5DAC22ECBB5BA8BB191675"
+               BlueprintIdentifier = "D2E7D3177D716EEC8BDDA94E73594540"
                BuildableName = "MaterialComponents-Unit-Tabs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -486,7 +514,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65C7EC9341922173CB5AEC619C857BFE"
+               BlueprintIdentifier = "ECB402E3778D6604B67D9334F798E2F0"
                BuildableName = "MaterialComponents-Unit-Tabs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -496,7 +524,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C6A23C8B5908FD78FE34A67729C2963A"
+               BlueprintIdentifier = "B50EEF945A805597D167E9A4A2BF40E1"
                BuildableName = "MaterialComponents-Unit-TextFields+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -506,7 +534,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9F61A38CA52D206DF08D9E5D94647280"
+               BlueprintIdentifier = "9DA1A0A583AD4899700804119FFD82FD"
                BuildableName = "MaterialComponents-Unit-TextFields-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -516,7 +544,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0CB893291E1B4FC20AC7FDDAD0A68D43"
+               BlueprintIdentifier = "284C1435D749967DBB39C2C7BEEC913D"
                BuildableName = "MaterialComponents-Unit-Themes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Themes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -526,7 +554,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "37E1456A86A5A28FD3D831E9AB71F5BC"
+               BlueprintIdentifier = "6D6C1C5C03CAFD5D168FAB91261516D7"
                BuildableName = "MaterialComponents-Unit-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -536,7 +564,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B07C48452F3391E69111165EB171C4C9"
+               BlueprintIdentifier = "8F3FD7328015DC98B8037E7FFF518448"
                BuildableName = "MaterialComponents-Unit-private-Application-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Application-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -546,7 +574,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C7628DA70B1BCEC947183B38BE5ECD17"
+               BlueprintIdentifier = "B806406D612E43DCE5A95FEEA92EC974"
                BuildableName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -556,7 +584,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F01DD0A685E0FD0FC0C7D8D74F0F0D15"
+               BlueprintIdentifier = "3B0715BE751696065197E7B132CF798F"
                BuildableName = "MaterialComponents-Unit-private-Math-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Math-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -566,7 +594,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2CCB248F91C25755FA45D758D56FC4D2"
+               BlueprintIdentifier = "CB469A2460E3EB8813D9C7F41CEE2CBE"
                BuildableName = "MaterialComponents-Unit-private-Overlay-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Overlay-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -576,7 +604,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9D52CDF22F9BD517B5E19353CF9F7F19"
+               BlueprintIdentifier = "1696A1FD72898E5DC7DA0796EB5316E1"
                BuildableName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -586,7 +614,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EDA533AD1F1B185ED1F39DCB9D1E1853"
+               BlueprintIdentifier = "9AFC701DBAF2EF24708C16FEEBD31375"
                BuildableName = "MaterialComponents-Unit-private-UIMetrics-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-UIMetrics-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -596,7 +624,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "67D836C778895EBC6E55636E4F918DD1"
+               BlueprintIdentifier = "4ACBFD51FB960AC748AEB19DF9674935"
                BuildableName = "MaterialComponents-Unit-schemes-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -606,7 +634,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3CA10DECBC9881C3CF8CECC909A2C10B"
+               BlueprintIdentifier = "B44ED38F9D474CF38FADA04FDF5D2690"
                BuildableName = "MaterialComponents-Unit-schemes-Container-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Container-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -616,7 +644,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9D30DFB4194781852526722245FD987E"
+               BlueprintIdentifier = "C748C221DF64CED78C87F098E988341D"
                BuildableName = "MaterialComponents-Unit-schemes-Shape-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Shape-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -626,7 +654,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "058FCCE5EAAE9D3A4AF5D2C3C8F3462A"
+               BlueprintIdentifier = "7155239C0BF2B487269FB421906F7B92"
                BuildableName = "MaterialComponents-Unit-schemes-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -636,7 +664,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
+               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -646,7 +674,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
+               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -656,7 +684,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACE8F8377BC344DD26C128FBE324B08E"
+               BlueprintIdentifier = "88EDC6F080DD13A85C457E8DF3D5680A"
                BuildableName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -666,7 +694,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3EF1C285419E755C019EC7F5334722D6"
+               BlueprintIdentifier = "1407E65B882514BA19258E4E7E2CD8E7"
                BuildableName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -676,7 +704,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "94C1D3154090898637E0243EBB10377B"
+               BlueprintIdentifier = "653B6FE35A1B4CDC5CA7D92E67DF97A6"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -686,7 +714,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7F8F825884AA0C4686D14359DF4344AB"
+               BlueprintIdentifier = "BEFB959C8B8734803945286E9C2346C5"
                BuildableName = "MaterialComponents-Unit-List+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -696,7 +724,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8C8DCDF159BDAF73E764F62FE202514D"
+               BlueprintIdentifier = "CCD06113384824F0016FA0CF5D813CF6"
                BuildableName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -706,7 +734,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F42EF0E7EEE873B8FD4CEB200A146CD5"
+               BlueprintIdentifier = "BD5BBE89295C3C6B3C801FCC69091C85"
                BuildableName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -716,17 +744,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6EFF48F9EE72411F71576F22B197F62D"
-               BuildableName = "MaterialComponentsBeta-Unit-Banner-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-Banner-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "80FDCBA97111C2F0E5D54C41D9C997FC"
+               BlueprintIdentifier = "4DA89912E26C1D30834DA796EADFD68E"
                BuildableName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -736,7 +754,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A207417F15F963263F5D6F3BAB63C75A"
+               BlueprintIdentifier = "8E9B17CEB9CECE59A5FEEB2347DF98BE"
                BuildableName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -746,7 +764,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "722E8BB6AD8C6485B800B83BA2E5089F"
+               BlueprintIdentifier = "6D639A36C9D1FE04FD788429B31BD983"
                BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -756,7 +774,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41A5C3CA19A72E9A7972D4A10AAB39E9"
+               BlueprintIdentifier = "E59EBFC9F0205AB50A9355945690F57C"
                BuildableName = "MaterialComponents-Unit-private-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -766,7 +784,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0184BB648CA66A248247C2228748118B"
+               BlueprintIdentifier = "46A0CD17FDDAF1CACABA145E5854C52A"
                BuildableName = "MaterialComponents-Unit-Elevation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Elevation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -776,9 +794,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "417F4BB5FA07D3B5C1A334F54B8555C5"
-               BuildableName = "MaterialComponentsBeta-Unit-Banner+Theming-UnitTests.xctest"
-               BlueprintName = "MaterialComponentsBeta-Unit-Banner+Theming-UnitTests"
+               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
Corrects the Catalog and Dragons schemes to include the Banner tests now that
they're no longer Beta components.

Found while working on #8499