### PR TITLE
[*] Add newlines following `super` calls.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -403,6 +403,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 - (void)layoutSubviews {
   [super layoutSubviews];
+
   [self invalidateIntrinsicContentSize];
 }
 

--- a/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarColorThemerTests.m
@@ -26,6 +26,7 @@
 
 - (void)setUp {
   [super setUp];
+
   self.bottomAppBar = [[MDCBottomAppBarView alloc] init];
 }
 

--- a/components/BottomAppBar/tests/unit/BottomAppBarTests.m
+++ b/components/BottomAppBar/tests/unit/BottomAppBarTests.m
@@ -49,6 +49,7 @@
 
 - (void)setUp {
   [super setUp];
+
   self.bottomAppBar = [[MDCBottomAppBarView alloc] init];
 }
 

--- a/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
+++ b/components/BottomNavigation/src/private/MDCBottomNavigationItemView.m
@@ -571,6 +571,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (void)setAccessibilityValue:(NSString *)accessibilityValue {
   [super setAccessibilityValue:accessibilityValue];
+
   self.button.accessibilityValue = accessibilityValue;
 }
 
@@ -580,6 +581,7 @@ static NSString *const kMDCBottomNavigationItemViewTabString = @"tab";
 
 - (void)setAccessibilityHint:(NSString *)accessibilityHint {
   [super setAccessibilityHint:accessibilityHint];
+
   self.button.accessibilityHint = accessibilityHint;
 }
 

--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -64,6 +64,7 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 
 - (void)layoutSubviews {
   [super layoutSubviews];
+
   if (self.aSwitch.superview != self) {
     [self addSubview:_aSwitch];
     [self.aSwitch addTarget:self
@@ -134,6 +135,7 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
   self.title = kExampleTitle;
   NSBundle *selfBundle = [NSBundle bundleForClass:[self class]];
   self.contentInsetToggleEnabledImage = [[UIImage imageNamed:@"contentInset_enabled"
@@ -439,6 +441,7 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
   [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
   [coordinator
       animateAlongsideTransition:nil
                       completion:^(
@@ -449,6 +452,7 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
+
   [self logItemVisibilityChanges];
 }
 


### PR DESCRIPTION
Moves our code toward more consistent empty-line-after-super-calls style.

Found in #8494