### PR TITLE
[NavigationDrawer] Allow users to scroll to dismiss on lower resolution devices.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -641,8 +641,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
                                                        transitionRatio:transitionPercentage];
 
   [self updateDrawerState:transitionPercentage];
-  self.currentlyFullscreen =
-      self.contentReachesFullscreen && contentOffset.y > 0;
+  self.currentlyFullscreen = self.contentReachesFullscreen && contentOffset.y > 0;
   CGFloat fullscreenHeaderHeight =
       self.contentReachesFullscreen ? self.topHeaderHeight : [self contentHeaderHeight];
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -641,7 +641,8 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
                                                        transitionRatio:transitionPercentage];
 
   [self updateDrawerState:transitionPercentage];
-  self.currentlyFullscreen = self.contentReachesFullscreen && headerTransitionToTop >= 1;
+  self.currentlyFullscreen =
+      self.contentReachesFullscreen && headerTransitionToTop >= 1 && contentOffset.y > 0;
   CGFloat fullscreenHeaderHeight =
       self.contentReachesFullscreen ? self.topHeaderHeight : [self contentHeaderHeight];
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -642,7 +642,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 
   [self updateDrawerState:transitionPercentage];
   self.currentlyFullscreen =
-      self.contentReachesFullscreen && headerTransitionToTop >= 1 && contentOffset.y > 0;
+      self.contentReachesFullscreen && contentOffset.y > 0;
   CGFloat fullscreenHeaderHeight =
       self.contentReachesFullscreen ? self.topHeaderHeight : [self contentHeaderHeight];
 


### PR DESCRIPTION
This change allows `currentlyFullscreen` property on [`MDCBottomDrawerContainerViewController`](https://github.com/material-components/material-components-ios/blob/develop/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m) to become `NO` on lower resolution devices. Currently this property is always `NO`. This doesn't allow the code within `- (void)scrollViewWillEndDragging:withVelocity:targetContentOffset:` to be executed.

## Testing
1. Set `preferredContentSize` on the headerVC of a Navigation Drawer example to 80.
2. Set `preferredContentSize` on the contentVC of the same Navigation Drawer example to a value less than 240. 
3. Open the example on a iPhoneSE
4. Rotate to landscape.
5. Try to swipe to dismiss the drawer.

Closes #8454 