### PR TITLE
Add swift rewrite rules for MDFTesting.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -122,6 +122,7 @@ fix_bazel_imports() {
   rewrite_tests "s/import <MaterialComponentsBeta\/Material(.+)Beta\.h>/import\/\*Material beta prefix framework import\*\/ \"Material\1Beta.h\"/"
   rewrite_tests "s/import <MaterialComponents\/Material(.+)\.h>/import\/\*Material prefix framework import\*\/ \"Material\1.h\"/"
   rewrite_tests "s/import <MDFTesting\/MDFTesting\.h>/import \"MDFTesting.h\"/"
+  rewrite_tests "s/import MDFTesting/import material_testing_ios_MDFTesting/"
   rewrite_tests "s/import MDFTextAccessibility/import material_text_accessibility_ios_MDFTextAccessibility/"
   rewrite_tests "s/import MDFInternationalization/import material_internationalization_ios_MDFInternationalization/"
   stashed_dir="$(pwd)/"
@@ -167,6 +168,7 @@ fix_bazel_imports() {
     rewrite_source "s/import\/\*MDC prefix framework import\*\/ \"MDC(.+)\.h\"/import <MaterialComponents\/MDC\1\.h>/"
     rewrite_tests "s/import\/\*Material prefix framework import\*\/ \"Material(.+)\.h\"/import <MaterialComponents\/Material\1\.h>/"
     rewrite_tests "s/import \"MDFTesting\.h\"/import <MDFTesting\/MDFTesting.h>/"
+    rewrite_tests "s/import material_testing_ios_MDFTesting/import MDFTesting/"
     rewrite_tests "s/import material_text_accessibility_ios_MDFTextAccessibility/import MDFTextAccessibility/"
     rewrite_tests "s/import material_internationalization_ios_MDFInternationalization/import MDFInternationalization/"
   }


### PR DESCRIPTION
MDFTesting rewrite rules for swift files were missing.