### PR TITLE
[Ripple] Add callbacks for MDCRippleView and MDCRippleLayer NO is passed in for animated parameter

### DIFF
--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -120,6 +120,13 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)cancelAllRipplesAnimated:(BOOL)animated completion:(MDCRippleCompletionBlock)completion {
   NSArray<CALayer *> *sublayers = [self.layer.sublayers copy];
+  // Call callbacks immediately if no sublayers existing
+  if (sublayers.count == 0) {
+    if (completion) {
+      completion();
+      return;
+    }
+  }
   if (animated) {
     CFTimeInterval latestBeginTouchDownRippleTime = DBL_MIN;
     for (CALayer *layer in sublayers) {
@@ -155,6 +162,9 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
         MDCRippleLayer *rippleLayer = (MDCRippleLayer *)layer;
         [rippleLayer removeFromSuperlayer];
       }
+    }
+    if (completion) {
+      completion();
     }
   }
 }
@@ -203,14 +213,38 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)beginRippleTouchUpAnimated:(BOOL)animated
                         completion:(nullable MDCRippleCompletionBlock)completion {
+  // If all ripple animations are already cancelled and removed from the superlayer call the
+  // short circuit and call the completion handler directly.
+  if (self.activeRippleLayer == nil) {
+    if (completion) {
+      completion();
+      return;
+    }
+  }
   [self.activeRippleLayer endRippleAnimated:animated completion:completion];
 }
 
 - (void)fadeInRippleAnimated:(BOOL)animated completion:(MDCRippleCompletionBlock)completion {
+  // If all ripple animations are already cancelled and removed from the superlayer call the
+  // short circuit and call the completion handler directly.
+  if (self.activeRippleLayer == nil) {
+    if (completion) {
+      completion();
+      return;
+    }
+  }
   [self.activeRippleLayer fadeInRippleAnimated:animated completion:completion];
 }
 
 - (void)fadeOutRippleAnimated:(BOOL)animated completion:(MDCRippleCompletionBlock)completion {
+  // If all ripple animations are already cancelled and removed from the superlayer call the
+  // short circuit and call the completion handler directly.
+  if (self.activeRippleLayer == nil) {
+    if (completion) {
+      completion();
+      return;
+    }
+  }
   [self.activeRippleLayer fadeOutRippleAnimated:animated completion:completion];
 }
 

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -120,13 +120,6 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 
 - (void)cancelAllRipplesAnimated:(BOOL)animated completion:(MDCRippleCompletionBlock)completion {
   NSArray<CALayer *> *sublayers = [self.layer.sublayers copy];
-  // Call callbacks immediately if no sublayers existing
-  if (sublayers.count == 0) {
-    if (completion) {
-      completion();
-      return;
-    }
-  }
   if (animated) {
     CFTimeInterval latestBeginTouchDownRippleTime = DBL_MIN;
     for (CALayer *layer in sublayers) {

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -211,8 +211,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   if (self.activeRippleLayer == nil) {
     if (completion) {
       completion();
-      return;
     }
+    return;
   }
   [self.activeRippleLayer endRippleAnimated:animated completion:completion];
 }
@@ -223,8 +223,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   if (self.activeRippleLayer == nil) {
     if (completion) {
       completion();
-      return;
     }
+    return;
   }
   [self.activeRippleLayer fadeInRippleAnimated:animated completion:completion];
 }
@@ -235,8 +235,8 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   if (self.activeRippleLayer == nil) {
     if (completion) {
       completion();
-      return;
     }
+    return;
   }
   [self.activeRippleLayer fadeOutRippleAnimated:animated completion:completion];
 }

--- a/components/Ripple/src/private/MDCRippleLayer.m
+++ b/components/Ripple/src/private/MDCRippleLayer.m
@@ -58,6 +58,9 @@ static CGFloat GetDefaultRippleRadius(CGRect rect) {
   self.opacity = 1;
   self.position = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
   if (!animated) {
+    if (completion) {
+      completion();
+    }
     [self.rippleLayerDelegate rippleLayerTouchDownAnimationDidEnd:self];
   } else {
     _startAnimationActive = YES;


### PR DESCRIPTION
Currently in certain methods within MDCRippleView and MDCRippleLayer that are taking in an animated and a callback parameter if NO is passed in for the animated parameter the callback will not be called. This can get to problems if the consumer passes in different animated arguments based on some state and expects the callback is called.
