### PR TITLE
[TextFields] Adding border stroke color

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -72,6 +72,13 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
 @property(class, nonatomic, null_resettable, strong) UIColor *borderFillColorDefault;
 
 /**
+ The color the input field's border in the resting state. A nil value yields a clear border.
+
+ Default is clear.
+ */
+@property(nonatomic, nullable, strong) UIColor *borderStrokeColor;
+
+/**
  Should the controller's .textInput grow vertically as new lines are added.
 
  If the text input does not conform to MDCMultilineTextInput, this parameter has no effect.

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -74,7 +74,7 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
 /**
  The color the input field's border in the resting state. A nil value yields a clear border.
 
- Default is clear.
+ Default is nil.
  */
 @property(nonatomic, nullable, strong) UIColor *borderStrokeColor;
 

--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -99,6 +99,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   UIColor *_activeColor;
   UIColor *_borderFillColor;
+  UIColor *_borderStrokeColor;
   UIColor *_disabledColor;
   UIColor *_errorColor;
   UIColor *_floatingPlaceholderActiveColor;
@@ -186,6 +187,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   copy.activeColor = self.activeColor;
   copy.borderFillColor = self.borderFillColor;
+  copy.borderStrokeColor = self.borderStrokeColor;
   copy.characterCounter = self.characterCounter;  // Just a pointer value copy
   copy.characterCountViewMode = self.characterCountViewMode;
   copy.characterCountMax = self.characterCountMax;
@@ -329,6 +331,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
 - (void)updateBorder {
   self.textInput.borderView.borderFillColor = self.borderFillColor;
+  self.textInput.borderView.borderStrokeColor = self.borderStrokeColor;
   self.textInput.borderPath = [self defaultBorderPath];
 }
 
@@ -811,6 +814,17 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
     _characterCountViewMode = characterCountViewMode;
 
     [self updateLayout];
+  }
+}
+
+- (UIColor *)borderStrokeColor {
+  return _borderStrokeColor;
+}
+
+- (void)setBorderStrokeColor:(UIColor *)borderStrokeColor {
+  if (_borderStrokeColor != borderStrokeColor) {
+    _borderStrokeColor = borderStrokeColor;
+    [self updateBorder];
   }
 }
 

--- a/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
+++ b/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
@@ -21,7 +21,7 @@
  The color applied to the placeholder when floating and the text field is first responder. However,
  when in error state, it will be colored with the error color.
 
- Only relevent when floatingEnabled is true.
+ Only relevant when floatingEnabled is true.
 
  Default is floatingPlaceholderActiveColorDefault.
  */
@@ -38,7 +38,7 @@
  The color applied to the placeholder when floating. However, when in error state, it will be
  colored with the error color and when in active state, it will be colored with the active color.
 
- Only relevent when floatingEnabled is true.
+ Only relevant when floatingEnabled is true.
 
  Default is floatingPlaceholderNormalColorDefault.
  */
@@ -58,7 +58,7 @@
 
 /**
  The scale of the the floating placeholder label in comparison to the inline placeholder specified
- as a value from 0.0 to 1.0. Only relevent when floatingEnabled = true.
+ as a value from 0.0 to 1.0. Only relevant when floatingEnabled = true.
 
  If nil, the floatingPlaceholderScale is @(floatingPlaceholderScaleDefault).
  */

--- a/components/TextFields/src/MDCTextInputControllerOutlined.m
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.m
@@ -199,7 +199,8 @@ static UIRectCorner _roundedCornersDefault = UIRectCornerAllCorners;
   }
   self.textInput.borderPath = path;
 
-  UIColor *borderColor = self.textInput.isEditing ? self.activeColor : self.normalColor;
+  UIColor *borderColor =
+      self.textInput.isEditing ? self.activeColor : (self.borderStrokeColor ?: self.normalColor);
   if (!self.textInput.isEnabled) {
     borderColor = self.disabledColor;
   }

--- a/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
@@ -160,13 +160,10 @@
   MDCTextField *textField = [[MDCTextField alloc] init];
   MDCTextInputControllerOutlined *controller =
       [[MDCTextInputControllerOutlined alloc] initWithTextInput:textField];
-  MDCSemanticColorScheme *colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
 
   // When
   controller.borderStrokeColor = UIColor.redColor;
-  [MDCOutlinedTextFieldColorThemer applySemanticColorScheme:colorScheme
-                                      toTextInputController:controller];
+  controller.normalColor = UIColor.orangeColor;
 
   // Then
   XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.borderStrokeColor);
@@ -178,16 +175,14 @@
   MDCTextField *textField = [[MDCTextField alloc] init];
   MDCTextInputControllerOutlined *controller =
       [[MDCTextInputControllerOutlined alloc] initWithTextInput:textField];
-  MDCSemanticColorScheme *colorScheme =
-      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
 
   // When
   controller.borderStrokeColor = nil;
-  [MDCOutlinedTextFieldColorThemer applySemanticColorScheme:colorScheme
-                                      toTextInputController:controller];
+  controller.normalColor = UIColor.purpleColor;
 
   // Then
   XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.normalColor);
+  XCTAssertEqualObjects(textField.borderView.borderStrokeColor, UIColor.purpleColor);
 }
 
 @end

--- a/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
+++ b/components/TextFields/tests/unit/OutlinedTextFieldColorThemerTests.m
@@ -47,6 +47,7 @@
   XCTAssertEqualObjects(controller.normalColor,
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.6]);
   XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.normalColor);
+
   XCTAssertEqualObjects(controller.inlinePlaceholderColor,
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.6]);
   XCTAssertEqualObjects(textField.placeholderLabel.textColor, controller.inlinePlaceholderColor);
@@ -152,6 +153,41 @@
   XCTAssertEqualObjects(controller.disabledColor,
                         [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]);
   XCTAssertEqualObjects(textField.underline.disabledColor, controller.disabledColor);
+}
+
+- (void)testOutlinedTextFieldBorderStrokeColorTheming {
+  // Given
+  MDCTextField *textField = [[MDCTextField alloc] init];
+  MDCTextInputControllerOutlined *controller =
+      [[MDCTextInputControllerOutlined alloc] initWithTextInput:textField];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+
+  // When
+  controller.borderStrokeColor = UIColor.redColor;
+  [MDCOutlinedTextFieldColorThemer applySemanticColorScheme:colorScheme
+                                      toTextInputController:controller];
+
+  // Then
+  XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.borderStrokeColor);
+  XCTAssertEqualObjects(textField.borderView.borderStrokeColor, UIColor.redColor);
+}
+
+- (void)testOutlinedTextFieldBorderStrokeColorDefaultsToNormal {
+  // Given
+  MDCTextField *textField = [[MDCTextField alloc] init];
+  MDCTextInputControllerOutlined *controller =
+      [[MDCTextInputControllerOutlined alloc] initWithTextInput:textField];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+
+  // When
+  controller.borderStrokeColor = nil;
+  [MDCOutlinedTextFieldColorThemer applySemanticColorScheme:colorScheme
+                                      toTextInputController:controller];
+
+  // Then
+  XCTAssertEqualObjects(textField.borderView.borderStrokeColor, controller.normalColor);
 }
 
 @end

--- a/components/TextFields/tests/unit/TextFieldTests.swift
+++ b/components/TextFields/tests/unit/TextFieldTests.swift
@@ -49,6 +49,7 @@ class TextFieldTests: XCTestCase {
 
     textField.textInsetsMode = .never
     textField.borderView?.borderFillColor = .purple
+    textField.borderView?.borderStrokeColor = .orange
     textField.borderView?.borderPath =
       UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: 100, height: 100))
     textField.borderView?.borderStrokeColor = .yellow
@@ -72,6 +73,8 @@ class TextFieldTests: XCTestCase {
       XCTAssertEqual(textField.attributedText, textFieldCopy.attributedText)
       XCTAssertEqual(textField.borderView?.borderFillColor,
                      textFieldCopy.borderView?.borderFillColor)
+      XCTAssertEqual(textField.borderView?.borderStrokeColor,
+                    textFieldCopy.borderView?.borderStrokeColor)
       XCTAssertEqual(textField.borderView?.borderPath?.bounds.integral,
                      textFieldCopy.borderView?.borderPath?.bounds.integral)
       XCTAssertEqual(textField.borderView?.borderStrokeColor,


### PR DESCRIPTION
Adding a borderStrokeColor property to input text field to allow better contrast ratio when theming.

See also: cl/270937632.

Example usage of new API in theming:

Before (self.normalColor was used to theme the border):
![image](https://user-images.githubusercontent.com/2329102/65708199-03fc7300-e05c-11e9-97a9-31e3aeb99651.png)

After (self.borderStrokeColor is used to theme the border):
![image](https://user-images.githubusercontent.com/2329102/65708211-0ced4480-e05c-11e9-8fa4-bea658ef438a.png)
