### PR TITLE
[TextFields] Tinkering with snapshot tests

### DIFF
--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -69,7 +69,7 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
     // host's key window. Removing the textfield from the app host's key window
     // before validation can affect the textfield's editing behavior, which has a
     // large effect on the appearance of the textfield.
-    UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:YES];
+    UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:NO];
     [self generateSnapshotAndVerifyForView:textFieldSnapshot];
     [expectation fulfill];
   });

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -18,7 +18,7 @@
 
 #import "MaterialTextFields+ContainedInputView.h"
 
-static const NSTimeInterval kTextFieldValidationEstimatedAnimationDuration = 0.25;
+//This timeout value is intended to be temporary. These snapshot tests currently take longer than we'd want them to.
 static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 
 @interface MDCBaseTextFieldTestsSnapshotTests : MDCSnapshotTestCase
@@ -55,11 +55,12 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 }
 
 - (void)validateTextField:(MDCBaseTextField *)textField {
+  NSLog(@"is main thread: %@",@([NSThread isMainThread]));
+  [textField setNeedsLayout];
+  [textField layoutIfNeeded];
   XCTestExpectation *expectation =
       [[XCTestExpectation alloc] initWithDescription:@"textfield_validation_expectation"];
-  dispatch_after(
-      dispatch_time(DISPATCH_TIME_NOW,
-                    (int64_t)(kTextFieldValidationEstimatedAnimationDuration * NSEC_PER_SEC)),
+  dispatch_async(
       dispatch_get_main_queue(), ^{
         // We take a snapshot of the textfield so we don't have to remove it from the app
         // host's key window. Removing the textfield from the app host's key window

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -35,11 +35,6 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
   self.textField = [self createBaseTextFieldInKeyWindow];
-
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(keyboardDidShow:)
-                                               name:UIKeyboardDidShowNotification
-                                             object:nil];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
   //      self.recordMode = YES;
@@ -47,10 +42,6 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (void)keyboardDidShow:(NSNotification *)notification {
-  NSLog(@"keyboard did show");
 }
 
 - (void)tearDown {
@@ -69,7 +60,6 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 }
 
 - (void)validateTextField:(MDCBaseTextField *)textField {
-  NSLog(@"is main thread: %@", @([NSThread isMainThread]));
   [textField setNeedsLayout];
   [textField layoutIfNeeded];
   XCTestExpectation *expectation =

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -73,7 +73,7 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
     // host's key window. Removing the textfield from the app host's key window
     // before validation can affect the textfield's editing behavior, which has a
     // large effect on the appearance of the textfield.
-    UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:NO];
+    UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:YES];
     [self generateSnapshotAndVerifyForView:textFieldSnapshot];
     [expectation fulfill];
   });

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -18,7 +18,8 @@
 
 #import "MaterialTextFields+ContainedInputView.h"
 
-//This timeout value is intended to be temporary. These snapshot tests currently take longer than we'd want them to.
+// This timeout value is intended to be temporary. These snapshot tests currently take longer than
+// we'd want them to.
 static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 
 @interface MDCBaseTextFieldTestsSnapshotTests : MDCSnapshotTestCase
@@ -34,16 +35,17 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
   self.textField = [self createBaseTextFieldInKeyWindow];
-  
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(keyboardDidShow:)
-                                               name:UIKeyboardDidShowNotification object:nil];
+                                               name:UIKeyboardDidShowNotification
+                                             object:nil];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
   //      self.recordMode = YES;
 }
 
--(void)dealloc {
+- (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -67,21 +69,20 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 }
 
 - (void)validateTextField:(MDCBaseTextField *)textField {
-  NSLog(@"is main thread: %@",@([NSThread isMainThread]));
+  NSLog(@"is main thread: %@", @([NSThread isMainThread]));
   [textField setNeedsLayout];
   [textField layoutIfNeeded];
   XCTestExpectation *expectation =
       [[XCTestExpectation alloc] initWithDescription:@"textfield_validation_expectation"];
-  dispatch_async(
-      dispatch_get_main_queue(), ^{
-        // We take a snapshot of the textfield so we don't have to remove it from the app
-        // host's key window. Removing the textfield from the app host's key window
-        // before validation can affect the textfield's editing behavior, which has a
-        // large effect on the appearance of the textfield.
-        UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:YES];
-        [self generateSnapshotAndVerifyForView:textFieldSnapshot];
-        [expectation fulfill];
-      });
+  dispatch_async(dispatch_get_main_queue(), ^{
+    // We take a snapshot of the textfield so we don't have to remove it from the app
+    // host's key window. Removing the textfield from the app host's key window
+    // before validation can affect the textfield's editing behavior, which has a
+    // large effect on the appearance of the textfield.
+    UIView *textFieldSnapshot = [textField snapshotViewAfterScreenUpdates:YES];
+    [self generateSnapshotAndVerifyForView:textFieldSnapshot];
+    [expectation fulfill];
+  });
   [self waitForExpectations:@[ expectation ] timeout:kTextFieldValidationAnimationTimeout];
 }
 

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -34,9 +34,21 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
   self.textField = [self createBaseTextFieldInKeyWindow];
+  
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(keyboardDidShow:)
+                                               name:UIKeyboardDidShowNotification object:nil];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
   //      self.recordMode = YES;
+}
+
+-(void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)keyboardDidShow:(NSNotification *)notification {
+  NSLog(@"keyboard did show");
 }
 
 - (void)tearDown {

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -40,10 +40,6 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
   //      self.recordMode = YES;
 }
 
-- (void)dealloc {
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)tearDown {
   [super tearDown];
   [self.textField removeFromSuperview];

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -50,6 +50,14 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
 - (MDCBaseTextField *)createBaseTextFieldInKeyWindow {
   MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:CGRectMake(0, 0, 200, 60)];
   textField.borderStyle = UITextBorderStyleRoundedRect;
+
+  // Using a dummy inputView instead of the system keyboard cuts the execution time roughly in half,
+  // at least locally.
+  UIView *dummyInputView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
+  textField.inputView = dummyInputView;
+
+  // Add the textfield to the window so it's part of a valid view hierarchy and things like
+  // `-becomeFirstResponder` work.
   UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
   [keyWindow addSubview:textField];
   return textField;


### PR DESCRIPTION
This PR contains some improvements to MDCBaseTextField snapshot tests. The aim is to reduce the amount of time it takes for them to run. I'm still getting a sense of how much time these changes save.

Related to #6942.