### PR TITLE
[NavigationDrawer] Fix broken header when content expands

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -662,7 +662,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 
   [self updateDrawerState:transitionPercentage];
   self.currentlyFullscreen =
-    self.contentReachesFullscreen && headerTransitionToTop >= 1 && contentOffset.y > 0;
+      self.contentReachesFullscreen && headerTransitionToTop >= 1 && contentOffset.y > 0;
   CGFloat fullscreenHeaderHeight =
       self.contentReachesFullscreen ? self.topHeaderHeight : [self contentHeaderHeight];
 

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -661,7 +661,8 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
                                                        transitionRatio:transitionPercentage];
 
   [self updateDrawerState:transitionPercentage];
-  self.currentlyFullscreen = self.contentReachesFullscreen && contentOffset.y > 0;
+  self.currentlyFullscreen =
+    self.contentReachesFullscreen && headerTransitionToTop >= 1 && contentOffset.y > 0;
   CGFloat fullscreenHeaderHeight =
       self.contentReachesFullscreen ? self.topHeaderHeight : [self contentHeaderHeight];
 


### PR DESCRIPTION
In #8503 this line was removed but after further testing when the contentViewController expands it's preferredContentSize this causes a regression in the header behavior. With this line added back into the check this behavior is fixed.