### PR TITLE
[TextFields] Preserve placeholder font.

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -142,6 +142,7 @@ mdc_unit_test_objc_library(
         ":FontThemer",
         ":TextFields",
         ":TypographyThemer",
+        ":private",
     ],
 )
 

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -606,8 +606,9 @@
 
 - (void)setFont:(UIFont *)font {
   if (self.textView.font != font) {
+    UIFont *previousFont = self.textView.font;
     [self.textView setFont:font];
-    [_fundament didSetFont];
+    [_fundament didSetFont:previousFont];
   }
 }
 

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -433,8 +433,9 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
 }
 
 - (void)setFont:(UIFont *)font {
+  UIFont *previousFont = self.font;
   [super setFont:font];
-  [_fundament didSetFont];
+  [_fundament didSetFont:previousFont];
 }
 
 - (void)setEnabled:(BOOL)enabled {

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -50,8 +50,12 @@ UIKIT_EXTERN UIColor *_Nonnull MDCTextInputCursorColor(void);
 /** Text stopped being edited event. */
 - (void)didEndEditing;
 
-/** Called by the controlled text input to notify the controller that it's font was set. */
-- (void)didSetFont;
+/**
+ Called by the controlled text input to notify the controller that it's font was set.
+
+ @param previousFont The font previously set on the text input.
+ */
+- (void)didSetFont:(nullable UIFont *)previousFont;
 
 /** Called by the controlled text input to notify the controller that it's text was set manually. */
 - (void)didSetText;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -973,9 +973,12 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   [self updateClearButton];
 }
 
-- (void)didSetFont {
+- (void)didSetFont:(UIFont *)previousFont {
   UIFont *font = self.textInput.font;
-  self.placeholderLabel.font = font;
+  // Don't replace a custom placeholderLabel font.
+  if (!self.placeholderLabel.font || self.placeholderLabel.font == previousFont) {
+    self.placeholderLabel.font = font;
+  }
 
   [self updatePlaceholderPosition];
 }

--- a/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
+++ b/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
@@ -1,0 +1,80 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "../../src/private/MDCTextInputCommonFundament.h"
+#import "MaterialTextFields.h"
+
+/** Unit tests for @c MDCTextInputCommonFundament. */
+@interface MDCTextInputCommonFundamentTests : XCTestCase
+/** The text input under test. */
+@property(nonatomic, strong) MDCTextInputCommonFundament *textInput;
+@end
+
+@implementation MDCTextInputCommonFundamentTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.textInput =
+      [[MDCTextInputCommonFundament alloc] initWithTextInput:[[MDCTextField alloc] init]];
+}
+
+- (void)tearDown {
+  self.textInput = nil;
+
+  [super tearDown];
+}
+
+- (void)testDefaultFontValues {
+  // Then
+  XCTAssertNotNil(self.textInput.font);
+  XCTAssertNotNil(self.textInput.placeholderLabel);
+  XCTAssertEqual(self.textInput.font, self.textInput.placeholderLabel.font);
+}
+
+- (void)testDidSetFontChangesFontUpdatesPlaceholderFontWhenFontsMatch {
+  // Given
+  UIFont *originalFont = [UIFont systemFontOfSize:10];
+  self.textInput.font = originalFont;
+  self.textInput.placeholderLabel.font = self.textInput.font;
+
+  // When
+  UIFont *assignedFont = [UIFont systemFontOfSize:99];
+  self.textInput.font = assignedFont;
+  [self.textInput didSetFont:originalFont];
+
+  // Then
+  XCTAssertEqual(self.textInput.font, assignedFont);
+  XCTAssertEqual(self.textInput.placeholderLabel.font, self.textInput.font);
+}
+
+- (void)testDidSetFontChangesFontDoesNotUpdatePlaceholderFontWhenFontsDoNotMatch {
+  // Given
+  UIFont *originalFont = [UIFont systemFontOfSize:66];
+  self.textInput.font = originalFont;
+  self.textInput.placeholderLabel.font = [UIFont systemFontOfSize:55];
+
+  // When
+  UIFont *assignedFont = [UIFont systemFontOfSize:99];
+  self.textInput.font = assignedFont;
+  [self.textInput didSetFont:originalFont];
+
+  // Then
+  XCTAssertEqual(self.textInput.font, assignedFont);
+  XCTAssertNotEqual(self.textInput.placeholderLabel.font, self.textInput.font);
+}
+
+@end


### PR DESCRIPTION
When the `placeholderLabel.font` is different from the `font` property on an
MDCTextInputCommonFundament, it was possible that the placeholder font would
be overwritten by the `.font` property accidentally.

|Before|After|
|---|---|
|![textfield-font-broken](https://user-images.githubusercontent.com/1753199/64789910-32019380-d543-11e9-90c0-5362c54cc18c.gif)|![textfield-fontfix-after](https://user-images.githubusercontent.com/1753199/64789916-35951a80-d543-11e9-9a67-e5b15169fc66.gif)|

**Testing Steps**
1. Create an MDCTextField and MDCTextInputControllerFilled
2. Assign different fonts to the controller's `textInputFont` and
   `inlinePlaceholderFont`.
3. Tap into the text field to have it become the first responder and observe
   the placeholder font.
4. Type one letter into the text field and observe the placeholder font.

**Expected Outcome**
Typing the letter does not cause the placeholder font to change.

**Note**: This is a roll-forward of commit d66d586

Closes #8390