### PR TITLE
[TextFields] Rename "contained input view" to "text control"

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -20,26 +20,26 @@
 
 #import "MDCTextControlState.h"
 #import "private/MDCBaseTextFieldLayout.h"
-#import "private/MDCContainedInputViewColorViewModel.h"
-#import "private/MDCContainedInputViewLabelAnimation.h"
-#import "private/MDCContainedInputViewLabelState.h"
-#import "private/MDCContainedInputViewStyleBase.h"
-#import "private/MDCContainedInputViewVerticalPositioningGuideBase.h"
+#import "private/MDCTextControlColorViewModel.h"
+#import "private/MDCTextControlLabelAnimation.h"
+#import "private/MDCTextControlLabelState.h"
+#import "private/MDCTextControlStyleBase.h"
+#import "private/MDCTextControlVerticalPositioningReferenceBase.h"
 
-@interface MDCBaseTextField () <MDCContainedInputView>
+@interface MDCBaseTextField () <MDCTextControl>
 
 @property(strong, nonatomic) UILabel *label;
 @property(strong, nonatomic) MDCBaseTextFieldLayout *layout;
 @property(nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 @property(nonatomic, assign) MDCTextControlState textControlState;
-@property(nonatomic, assign) MDCContainedInputViewLabelState labelState;
+@property(nonatomic, assign) MDCTextControlLabelState labelState;
 
 /**
  This property maps MDCTextControlStates as NSNumbers to
- MDCContainedInputViewColorViewModels.
+ MDCTextControlColorViewModels.
  */
 @property(nonatomic, strong)
-    NSMutableDictionary<NSNumber *, MDCContainedInputViewColorViewModel *> *colorViewModels;
+    NSMutableDictionary<NSNumber *, MDCTextControlColorViewModel *> *colorViewModels;
 
 @end
 
@@ -76,17 +76,17 @@
   self.labelBehavior = MDCTextControlLabelBehaviorFloats;
   self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
   self.labelState = [self determineCurrentLabelState];
-  self.containerStyle = [[MDCContainedInputViewStyleBase alloc] init];
+  self.containerStyle = [[MDCTextControlStyleBase alloc] init];
   self.colorViewModels = [[NSMutableDictionary alloc] init];
 }
 
 - (void)setUpColorViewModels {
   self.colorViewModels[@(MDCTextControlStateNormal)] =
-      [[MDCContainedInputViewColorViewModel alloc] initWithState:MDCTextControlStateNormal];
+      [[MDCTextControlColorViewModel alloc] initWithState:MDCTextControlStateNormal];
   self.colorViewModels[@(MDCTextControlStateEditing)] =
-      [[MDCContainedInputViewColorViewModel alloc] initWithState:MDCTextControlStateEditing];
+      [[MDCTextControlColorViewModel alloc] initWithState:MDCTextControlStateEditing];
   self.colorViewModels[@(MDCTextControlStateDisabled)] =
-      [[MDCContainedInputViewColorViewModel alloc] initWithState:MDCTextControlStateDisabled];
+      [[MDCTextControlColorViewModel alloc] initWithState:MDCTextControlStateDisabled];
 }
 
 - (void)setUpLabel {
@@ -131,16 +131,16 @@
 - (void)preLayoutSubviews {
   self.textControlState = [self determineCurrentTextControlState];
   self.labelState = [self determineCurrentLabelState];
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:self.textControlState];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:self.textControlState];
   [self applyColorViewModel:colorViewModel withLabelState:self.labelState];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.bounds), CGFLOAT_MAX);
   self.layout = [self calculateLayoutWithTextFieldSize:fittingSize];
 }
 
 - (void)postLayoutSubviews {
-  self.label.hidden = self.labelState == MDCContainedInputViewLabelStateNone;
-  [MDCContainedInputViewLabelAnimation layOutLabel:self.label
+  self.label.hidden = self.labelState == MDCTextControlLabelStateNone;
+  [MDCTextControlLabelAnimation layOutLabel:self.label
                                              state:self.labelState
                                   normalLabelFrame:self.layout.labelFrameNormal
                                 floatingLabelFrame:self.layout.labelFrameFloating
@@ -151,9 +151,9 @@
 }
 
 - (CGRect)textRectFromLayout:(MDCBaseTextFieldLayout *)layout
-                  labelState:(MDCContainedInputViewLabelState)labelState {
+                  labelState:(MDCTextControlLabelState)labelState {
   CGRect textRect = layout.textRectNormal;
-  if (labelState == MDCContainedInputViewLabelStateFloating) {
+  if (labelState == MDCTextControlLabelStateFloating) {
     textRect = layout.textRectFloating;
   }
   return textRect;
@@ -179,7 +179,7 @@
 
 - (MDCBaseTextFieldLayout *)calculateLayoutWithTextFieldSize:(CGSize)textFieldSize {
   CGFloat clearButtonSideLength = [self clearButtonSideLengthWithTextFieldSize:textFieldSize];
-  id<MDCContainerStyleVerticalPositioningReference> positioningReference =
+  id<MDCTextControlVerticalPositioningReference> positioningReference =
       [self createPositioningReference];
   return [[MDCBaseTextFieldLayout alloc] initWithTextFieldSize:textFieldSize
                                           positioningReference:positioningReference
@@ -197,7 +197,7 @@
                                                      isEditing:self.isEditing];
 }
 
-- (id<MDCContainerStyleVerticalPositioningReference>)createPositioningReference {
+- (id<MDCTextControlVerticalPositioningReference>)createPositioningReference {
   return [self.containerStyle positioningReference];
 }
 
@@ -335,15 +335,15 @@
   [self setNeedsLayout];
 }
 
-#pragma mark MDCContainedInputView accessors
+#pragma mark MDCTextControl accessors
 
-- (void)setContainerStyle:(id<MDCContainedInputViewStyle>)containerStyle {
-  id<MDCContainedInputViewStyle> oldStyle = _containerStyle;
+- (void)setContainerStyle:(id<MDCTextControlStyle>)containerStyle {
+  id<MDCTextControlStyle> oldStyle = _containerStyle;
   if (oldStyle) {
     [oldStyle removeStyleFrom:self];
   }
   _containerStyle = containerStyle;
-  [_containerStyle applyStyleToContainedInputView:self];
+  [_containerStyle applyStyleToTextControl:self];
 }
 
 #pragma mark UITextField Layout Overrides
@@ -383,7 +383,7 @@
 }
 
 - (CGRect)clearButtonRectForBounds:(CGRect)bounds {
-  if (self.labelState == MDCContainedInputViewLabelStateFloating) {
+  if (self.labelState == MDCTextControlLabelStateFloating) {
     return self.layout.clearButtonFrameFloating;
   }
   return self.layout.clearButtonFrameNormal;
@@ -451,7 +451,7 @@
 
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelState:(MDCContainedInputViewLabelState)labelState {
+                                       labelState:(MDCTextControlLabelState)labelState {
   BOOL hasPlaceholder = placeholder.length > 0;
   BOOL hasText = text.length > 0;
 
@@ -459,7 +459,7 @@
     if (hasText) {
       return NO;
     } else {
-      if (labelState == MDCContainedInputViewLabelStateNormal) {
+      if (labelState == MDCTextControlLabelStateNormal) {
         return NO;
       } else {
         return YES;
@@ -476,14 +476,14 @@
   return self.labelBehavior == MDCTextControlLabelBehaviorFloats;
 }
 
-- (MDCContainedInputViewLabelState)determineCurrentLabelState {
+- (MDCTextControlLabelState)determineCurrentLabelState {
   return [self labelStateWithLabel:self.label
                               text:self.text
                      canLabelFloat:self.canLabelFloat
                          isEditing:self.isEditing];
 }
 
-- (MDCContainedInputViewLabelState)labelStateWithLabel:(UILabel *)label
+- (MDCTextControlLabelState)labelStateWithLabel:(UILabel *)label
                                                   text:(NSString *)text
                                          canLabelFloat:(BOOL)canLabelFloat
                                              isEditing:(BOOL)isEditing {
@@ -492,23 +492,23 @@
   if (hasFloatingLabelText) {
     if (canLabelFloat) {
       if (isEditing) {
-        return MDCContainedInputViewLabelStateFloating;
+        return MDCTextControlLabelStateFloating;
       } else {
         if (hasText) {
-          return MDCContainedInputViewLabelStateFloating;
+          return MDCTextControlLabelStateFloating;
         } else {
-          return MDCContainedInputViewLabelStateNormal;
+          return MDCTextControlLabelStateNormal;
         }
       }
     } else {
       if (hasText) {
-        return MDCContainedInputViewLabelStateNone;
+        return MDCTextControlLabelStateNone;
       } else {
-        return MDCContainedInputViewLabelStateNormal;
+        return MDCTextControlLabelStateNormal;
       }
     }
   } else {
-    return MDCContainedInputViewLabelStateNone;
+    return MDCTextControlLabelStateNone;
   }
 }
 
@@ -520,30 +520,30 @@
 
 #pragma mark Coloring
 
-- (void)applyColorViewModel:(MDCContainedInputViewColorViewModel *)colorViewModel
-             withLabelState:(MDCContainedInputViewLabelState)labelState {
+- (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
+             withLabelState:(MDCTextControlLabelState)labelState {
   UIColor *labelColor = [UIColor clearColor];
-  if (labelState == MDCContainedInputViewLabelStateNormal) {
+  if (labelState == MDCTextControlLabelStateNormal) {
     labelColor = colorViewModel.normalLabelColor;
-  } else if (labelState == MDCContainedInputViewLabelStateFloating) {
+  } else if (labelState == MDCTextControlLabelStateFloating) {
     labelColor = colorViewModel.floatingLabelColor;
   }
   self.textColor = colorViewModel.textColor;
   self.label.textColor = labelColor;
 }
 
-- (void)setContainedInputViewColorViewModel:(MDCContainedInputViewColorViewModel *)colorViewModel
+- (void)setTextControlColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
                                    forState:(MDCTextControlState)textControlState {
   if (colorViewModel) {
     self.colorViewModels[@(textControlState)] = colorViewModel;
   }
 }
 
-- (MDCContainedInputViewColorViewModel *)containedInputViewColorViewModelForState:
+- (MDCTextControlColorViewModel *)textControlColorViewModelForState:
     (MDCTextControlState)textControlState {
-  MDCContainedInputViewColorViewModel *colorViewModel = self.colorViewModels[@(textControlState)];
+  MDCTextControlColorViewModel *colorViewModel = self.colorViewModels[@(textControlState)];
   if (!colorViewModel) {
-    colorViewModel = [[MDCContainedInputViewColorViewModel alloc] initWithState:textControlState];
+    colorViewModel = [[MDCTextControlColorViewModel alloc] initWithState:textControlState];
   }
   return colorViewModel;
 }
@@ -551,41 +551,41 @@
 #pragma mark Color Accessors
 
 - (void)setNormalLabelColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   colorViewModel.normalLabelColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)normalLabelColorForState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   return colorViewModel.normalLabelColor;
 }
 
 - (void)setFloatingLabelColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   colorViewModel.floatingLabelColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)floatingLabelColorForState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   return colorViewModel.floatingLabelColor;
 }
 
 - (void)setTextColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   colorViewModel.textColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)textColorForState:(MDCTextControlState)state {
-  MDCContainedInputViewColorViewModel *colorViewModel =
-      [self containedInputViewColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel =
+      [self textControlColorViewModelForState:state];
   return colorViewModel.textColor;
 }
 

--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -141,11 +141,11 @@
 - (void)postLayoutSubviews {
   self.label.hidden = self.labelState == MDCTextControlLabelStateNone;
   [MDCTextControlLabelAnimation layOutLabel:self.label
-                                             state:self.labelState
-                                  normalLabelFrame:self.layout.labelFrameNormal
-                                floatingLabelFrame:self.layout.labelFrameFloating
-                                        normalFont:self.normalFont
-                                      floatingFont:self.floatingFont];
+                                      state:self.labelState
+                           normalLabelFrame:self.layout.labelFrameNormal
+                         floatingLabelFrame:self.layout.labelFrameFloating
+                                 normalFont:self.normalFont
+                               floatingFont:self.floatingFont];
   self.leftView.hidden = self.layout.leftViewHidden;
   self.rightView.hidden = self.layout.rightViewHidden;
 }
@@ -484,9 +484,9 @@
 }
 
 - (MDCTextControlLabelState)labelStateWithLabel:(UILabel *)label
-                                                  text:(NSString *)text
-                                         canLabelFloat:(BOOL)canLabelFloat
-                                             isEditing:(BOOL)isEditing {
+                                           text:(NSString *)text
+                                  canLabelFloat:(BOOL)canLabelFloat
+                                      isEditing:(BOOL)isEditing {
   BOOL hasFloatingLabelText = label.text.length > 0;
   BOOL hasText = text.length > 0;
   if (hasFloatingLabelText) {
@@ -533,7 +533,7 @@
 }
 
 - (void)setTextControlColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-                                   forState:(MDCTextControlState)textControlState {
+                            forState:(MDCTextControlState)textControlState {
   if (colorViewModel) {
     self.colorViewModels[@(textControlState)] = colorViewModel;
   }
@@ -551,41 +551,35 @@
 #pragma mark Color Accessors
 
 - (void)setNormalLabelColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   colorViewModel.normalLabelColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)normalLabelColorForState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   return colorViewModel.normalLabelColor;
 }
 
 - (void)setFloatingLabelColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   colorViewModel.floatingLabelColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)floatingLabelColorForState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   return colorViewModel.floatingLabelColor;
 }
 
 - (void)setTextColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   colorViewModel.textColor = labelColor;
   [self setNeedsLayout];
 }
 
 - (UIColor *)textColorForState:(MDCTextControlState)state {
-  MDCTextControlColorViewModel *colorViewModel =
-      [self textControlColorViewModelForState:state];
+  MDCTextControlColorViewModel *colorViewModel = [self textControlColorViewModelForState:state];
   return colorViewModel.textColor;
 }
 

--- a/components/TextFields/src/ContainedInputView/private/MDCBaseTextFieldLayout.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCBaseTextFieldLayout.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "MDCContainerStyleVerticalPositioningReference.h"
+#import "MDCTextControlVerticalPositioningReference.h"
 
 @interface MDCBaseTextFieldLayout : NSObject
 
@@ -36,7 +36,7 @@
 
 - (nonnull instancetype)initWithTextFieldSize:(CGSize)textFieldSize
                          positioningReference:
-                             (nonnull id<MDCContainerStyleVerticalPositioningReference>)
+                             (nonnull id<MDCTextControlVerticalPositioningReference>)
                                  positioningReference
                                          text:(nullable NSString *)text
                                          font:(nonnull UIFont *)font

--- a/components/TextFields/src/ContainedInputView/private/MDCBaseTextFieldLayout.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCBaseTextFieldLayout.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "MDCBaseTextFieldLayout.h"
-#import "MDCContainedInputViewLabelState.h"
+#import "MDCTextControlLabelState.h"
 
 static const CGFloat kHorizontalPadding = (CGFloat)12.0;
 
@@ -26,7 +26,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
 
 - (instancetype)initWithTextFieldSize:(CGSize)textFieldSize
                  positioningReference:
-                     (id<MDCContainerStyleVerticalPositioningReference>)positioningReference
+                     (id<MDCTextControlVerticalPositioningReference>)positioningReference
                                  text:(NSString *)text
                                  font:(UIFont *)font
                          floatingFont:(UIFont *)floatingFont
@@ -64,7 +64,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
 
 - (void)calculateLayoutWithTextFieldSize:(CGSize)textFieldSize
                     positioningReference:
-                        (id<MDCContainerStyleVerticalPositioningReference>)positioningReference
+                        (id<MDCTextControlVerticalPositioningReference>)positioningReference
                                     text:(NSString *)text
                                     font:(UIFont *)font
                             floatingFont:(UIFont *)floatingFont
@@ -201,7 +201,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
                                                clearButtonSideLength, clearButtonSideLength);
 
   CGRect labelFrameNormal = [self labelFrameWithText:label.text
-                                          labelState:MDCContainedInputViewLabelStateNormal
+                                          labelState:MDCTextControlLabelStateNormal
                                                 font:font
                                         floatingFont:floatingFont
                                    floatingLabelMinY:floatingLabelMinY
@@ -210,7 +210,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
                                             textRect:textRectNormal
                                                isRTL:isRTL];
   CGRect labelFrameFloating = [self labelFrameWithText:label.text
-                                            labelState:MDCContainedInputViewLabelStateFloating
+                                            labelState:MDCTextControlLabelStateFloating
                                                   font:font
                                           floatingFont:floatingFont
                                      floatingLabelMinY:floatingLabelMinY
@@ -296,7 +296,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
 }
 
 - (CGRect)labelFrameWithText:(NSString *)text
-                  labelState:(MDCContainedInputViewLabelState)labelState
+                  labelState:(MDCTextControlLabelState)labelState
                         font:(UIFont *)font
                 floatingFont:(UIFont *)floatingFont
            floatingLabelMinY:(CGFloat)floatingLabelMinY
@@ -310,9 +310,9 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
   CGFloat originX = 0;
   CGFloat originY = 0;
   switch (labelState) {
-    case MDCContainedInputViewLabelStateNone:
+    case MDCTextControlLabelStateNone:
       break;
-    case MDCContainedInputViewLabelStateFloating:
+    case MDCTextControlLabelStateFloating:
       size = [self floatingLabelSizeWithText:text maxWidth:maxWidth font:floatingFont];
       originY = floatingLabelMinY;
       if (isRTL) {
@@ -322,7 +322,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
       }
       rect = CGRectMake(originX, originY, size.width, size.height);
       break;
-    case MDCContainedInputViewLabelStateNormal:
+    case MDCTextControlLabelStateNormal:
       size = [self floatingLabelSizeWithText:text maxWidth:maxWidth font:font];
       CGFloat textRectMidY = CGRectGetMidY(textRect);
       originY = textRectMidY - ((CGFloat)0.5 * size.height);

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
@@ -17,10 +17,10 @@
 
 #import "MDCTextControlColorViewModel.h"
 #import "MDCTextControlLabelAnimation.h"
-#import "MDCTextControlLabelState.h"
-#import "MDCTextControlVerticalPositioningReference.h"
 #import "MDCTextControlLabelBehavior.h"
+#import "MDCTextControlLabelState.h"
 #import "MDCTextControlState.h"
+#import "MDCTextControlVerticalPositioningReference.h"
 
 static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
 
@@ -81,7 +81,7 @@ static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
  */
 - (void)setTextControlColorViewModel:
             (nonnull MDCTextControlColorViewModel *)textControlColorViewModel
-                                   forState:(MDCTextControlState)textFieldState;
+                            forState:(MDCTextControlState)textFieldState;
 
 @end
 

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
@@ -15,25 +15,25 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "MDCContainedInputViewColorViewModel.h"
-#import "MDCContainedInputViewLabelAnimation.h"
-#import "MDCContainedInputViewLabelState.h"
-#import "MDCContainerStyleVerticalPositioningReference.h"
+#import "MDCTextControlColorViewModel.h"
+#import "MDCTextControlLabelAnimation.h"
+#import "MDCTextControlLabelState.h"
+#import "MDCTextControlVerticalPositioningReference.h"
 #import "MDCTextControlLabelBehavior.h"
 #import "MDCTextControlState.h"
 
-static const CGFloat kMDCContainedInputViewDefaultAnimationDuration = (CGFloat)0.15;
+static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
 
-@protocol MDCContainedInputViewStyle;
+@protocol MDCTextControlStyle;
 
-@protocol MDCContainedInputView <NSObject>
+@protocol MDCTextControl <NSObject>
 
 /**
  This object represents the style of the text control, i.e. the thing that makes it filled or
- outlined. See the documentation for MDCContainedInputViewStyle for more information on its
+ outlined. See the documentation for MDCTextControlStyle for more information on its
  responsibilities.
  */
-@property(nonatomic, strong, nonnull) id<MDCContainedInputViewStyle> containerStyle;
+@property(nonatomic, strong, nonnull) id<MDCTextControlStyle> containerStyle;
 
 /**
  Describes the current @c MDCtextControlState of the view. This value is affected by things like
@@ -42,11 +42,11 @@ static const CGFloat kMDCContainedInputViewDefaultAnimationDuration = (CGFloat)0
 @property(nonatomic, assign, readonly) MDCTextControlState textControlState;
 
 /**
- Describes the current MDCContainedInputViewLabelState of the contained input view. This
+ Describes the current MDCTextControlLabelState of the contained input view. This
  value is affected by things like the view's @c textControlState, its @c labelBehavior, and the
  text of the floating label.
  */
-@property(nonatomic, assign, readonly) MDCContainedInputViewLabelState labelState;
+@property(nonatomic, assign, readonly) MDCTextControlLabelState labelState;
 
 /**
  Describes the behavior of the label when the view begins editing.
@@ -71,32 +71,32 @@ static const CGFloat kMDCContainedInputViewDefaultAnimationDuration = (CGFloat)0
 @property(strong, nonatomic, readonly, nonnull) UIFont *floatingFont;
 
 /**
- This method returns a MDCContainedInputViewColorViewModel for a given MDCTextControlState.
+ This method returns a MDCTextControlColorViewModel for a given MDCTextControlState.
  */
-- (nonnull MDCContainedInputViewColorViewModel *)containedInputViewColorViewModelForState:
+- (nonnull MDCTextControlColorViewModel *)textControlColorViewModelForState:
     (MDCTextControlState)textControlState;
 
 /**
- This method sets a MDCContainedInputViewColorViewModel for a given MDCTextControlState.
+ This method sets a MDCTextControlColorViewModel for a given MDCTextControlState.
  */
-- (void)setContainedInputViewColorViewModel:
-            (nonnull MDCContainedInputViewColorViewModel *)containedInputViewColorViewModel
+- (void)setTextControlColorViewModel:
+            (nonnull MDCTextControlColorViewModel *)textControlColorViewModel
                                    forState:(MDCTextControlState)textFieldState;
 
 @end
 
-@protocol MDCContainedInputViewStyle <NSObject>
+@protocol MDCTextControlStyle <NSObject>
 
 /**
- This method allows objects conforming to MDCContainedInputViewStyle to apply themselves to objects
- conforming to MDCContainedInputView.
+ This method allows objects conforming to MDCTextControlStyle to apply themselves to objects
+ conforming to MDCTextControl.
  */
-- (void)applyStyleToContainedInputView:(nonnull id<MDCContainedInputView>)containedInputView;
+- (void)applyStyleToTextControl:(nonnull id<MDCTextControl>)textControl;
 /**
- This method allows objects conforming to MDCContainedInputViewStyle to remove the styling
- previously applied to objects conforming to MDCContainedInputView.
+ This method allows objects conforming to MDCTextControlStyle to remove the styling
+ previously applied to objects conforming to MDCTextControl.
  */
-- (void)removeStyleFrom:(nonnull id<MDCContainedInputView>)containedInputView;
+- (void)removeStyleFrom:(nonnull id<MDCTextControl>)textControl;
 
 /**
  The method returns a UIFont for the floating label based on the @c normalFont of the
@@ -108,6 +108,6 @@ static const CGFloat kMDCContainedInputViewDefaultAnimationDuration = (CGFloat)0
  This method returns an object that tells the view where to position it's views
  vertically.
  */
-- (nonnull id<MDCContainerStyleVerticalPositioningReference>)positioningReference;
+- (nonnull id<MDCTextControlVerticalPositioningReference>)positioningReference;
 
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlColorViewModel.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlColorViewModel.h
@@ -19,9 +19,9 @@
 
 /**
  This object represents a group of colors that are applied on a state by state basis to
- MDCContainedInputViews. Each property corresponds to a Contained Input View specific subview.
+ MDCTextControls. Each property corresponds to a Contained Input View specific subview.
  */
-@interface MDCContainedInputViewColorViewModel : NSObject
+@interface MDCTextControlColorViewModel : NSObject
 /**
  The color of the contained input view's text.
  */

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlColorViewModel.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlColorViewModel.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCContainedInputViewColorViewModel.h"
+#import "MDCTextControlColorViewModel.h"
 
 #import <Foundation/Foundation.h>
 
-@implementation MDCContainedInputViewColorViewModel
+@implementation MDCTextControlColorViewModel
 
 - (instancetype)initWithState:(MDCTextControlState)state {
   self = [super init];

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
@@ -14,20 +14,20 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "MDCContainedInputViewLabelState.h"
+#import "MDCTextControlLabelState.h"
 
 /**
- The logic to animate labels is extracted into its own class so that any MDCContainedInputView can
+ The logic to animate labels is extracted into its own class so that any MDCTextControl can
  make use of it.
  */
-@interface MDCContainedInputViewLabelAnimation : NSObject
+@interface MDCTextControlLabelAnimation : NSObject
 
 /**
  This method lays out the label in an animated fashion, often from normal position to the floating
  position, and vice versa.
  */
 + (void)layOutLabel:(nonnull UILabel *)floatingLabel
-                 state:(MDCContainedInputViewLabelState)labelState
+                 state:(MDCTextControlLabelState)labelState
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCContainedInputViewLabelAnimation.h"
+#import "MDCTextControlLabelAnimation.h"
 
-#import "MDCContainedInputView.h"
+#import "MDCTextControl.h"
 #import "MaterialAnimationTiming.h"
 
-@implementation MDCContainedInputViewLabelAnimation
+@implementation MDCTextControlLabelAnimation
 
 + (void)layOutLabel:(nonnull UILabel *)label
-                 state:(MDCContainedInputViewLabelState)labelState
+                 state:(MDCTextControlLabelState)labelState
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
           floatingFont:(nonnull UIFont *)floatingFont {
   UIFont *targetFont;
   CGRect targetFrame;
-  if (labelState == MDCContainedInputViewLabelStateFloating) {
+  if (labelState == MDCTextControlLabelStateFloating) {
     targetFont = floatingFont;
     targetFrame = floatingLabelFrame;
   } else {
@@ -46,7 +46,7 @@
   CAMediaTimingFunction *timingFunction =
       [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionStandard];
   [UIView mdc_animateWithTimingFunction:timingFunction
-                               duration:kMDCContainedInputViewDefaultAnimationDuration
+                               duration:kMDCTextControlDefaultAnimationDuration
                                   delay:0
                                 options:0
                              animations:^{

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelState.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelState.h
@@ -14,15 +14,20 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCContainerStyleVerticalPositioningReference.h"
-
-@interface MDCContainedInputViewVerticalPositioningGuideBase
-    : NSObject <MDCContainerStyleVerticalPositioningReference>
-
-@property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndFloatingLabel;
-@property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndNormalLabel;
-@property(nonatomic, assign, readonly) CGFloat paddingBetweenFloatingLabelAndText;
-@property(nonatomic, assign, readonly) CGFloat paddingBetweenTextAndBottom;
-@property(nonatomic, assign, readonly) CGFloat containerHeight;
-
-@end
+/**
+ This enum represents different states the floating label can be in.
+ */
+typedef NS_ENUM(NSUInteger, MDCTextControlLabelState) {
+  /**
+   The state where the floating label is not visible.
+   */
+  MDCTextControlLabelStateNone,
+  /**
+   The state where the floating label is floating.
+   */
+  MDCTextControlLabelStateFloating,
+  /**
+   The state where the floating label is occupying the normal text area.
+   */
+  MDCTextControlLabelStateNormal,
+};

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.h
@@ -13,29 +13,13 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-#import "MDCContainedInputViewVerticalPositioningGuideBase.h"
+#import "MDCTextControl.h"
 
-@interface MDCContainedInputViewVerticalPositioningGuideBase ()
-
-@end
-
-@implementation MDCContainedInputViewVerticalPositioningGuideBase
-
-- (CGFloat)paddingBetweenTopAndFloatingLabel {
-  return 10;
-}
-
-- (CGFloat)paddingBetweenTopAndNormalLabel {
-  return 20;
-}
-
-- (CGFloat)paddingBetweenFloatingLabelAndText {
-  return 5;
-}
-
-- (CGFloat)containerHeight {
-  return 50;
-}
-
+/**
+ A base implementation of MDCTextControlStyle. This is only used for base text controls, i.e.
+ ones that are not filled or outlined.
+ */
+@interface MDCTextControlStyleBase : NSObject <MDCTextControlStyle>
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCContainedInputViewStyleBase.h"
+#import "MDCTextControlStyleBase.h"
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "MDCContainedInputView.h"
-#import "MDCContainedInputViewVerticalPositioningGuideBase.h"
+#import "MDCTextControl.h"
+#import "MDCTextControlVerticalPositioningReferenceBase.h"
 
 static const CGFloat kBaseFloatingLabelScaleFactor = 0.75;
 
-@implementation MDCContainedInputViewStyleBase
+@implementation MDCTextControlStyleBase
 
 - (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
   CGFloat scaleFactor = kBaseFloatingLabelScaleFactor;
@@ -30,14 +30,14 @@ static const CGFloat kBaseFloatingLabelScaleFactor = 0.75;
   return [font fontWithSize:floatingFontSize];
 }
 
-- (void)applyStyleToContainedInputView:(id<MDCContainedInputView>)inputView {
+- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
 }
 
-- (void)removeStyleFrom:(id<MDCContainedInputView>)containedInputView {
+- (void)removeStyleFrom:(id<MDCTextControl>)textControl {
 }
 
-- (id<MDCContainerStyleVerticalPositioningReference>)positioningReference {
-  return [[MDCContainedInputViewVerticalPositioningGuideBase alloc] init];
+- (id<MDCTextControlVerticalPositioningReference>)positioningReference {
+  return [[MDCTextControlVerticalPositioningReferenceBase alloc] init];
 }
 
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReference.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReference.h
@@ -20,7 +20,7 @@
  helps achieve the variations in floating label and text rect position across the filled and
  outlined styles, and also allows different densities to be possible.
  */
-@protocol MDCContainerStyleVerticalPositioningReference <NSObject>
+@protocol MDCTextControlVerticalPositioningReference <NSObject>
 
 @property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndFloatingLabel;
 @property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndNormalLabel;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReferenceBase.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReferenceBase.h
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "MDCContainedInputView.h"
+#import "MDCTextControlVerticalPositioningReference.h"
 
-/**
- A base implementation of MDCContainedInputViewStyle. This is only used for base text controls, i.e.
- ones that are not filled or outlined.
- */
-@interface MDCContainedInputViewStyleBase : NSObject <MDCContainedInputViewStyle>
+@interface MDCTextControlVerticalPositioningReferenceBase
+    : NSObject <MDCTextControlVerticalPositioningReference>
+
+@property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndFloatingLabel;
+@property(nonatomic, assign, readonly) CGFloat paddingBetweenTopAndNormalLabel;
+@property(nonatomic, assign, readonly) CGFloat paddingBetweenFloatingLabelAndText;
+@property(nonatomic, assign, readonly) CGFloat paddingBetweenTextAndBottom;
+@property(nonatomic, assign, readonly) CGFloat containerHeight;
+
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReferenceBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlVerticalPositioningReferenceBase.m
@@ -12,22 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
-/**
- This enum represents different states the floating label can be in.
- */
-typedef NS_ENUM(NSUInteger, MDCContainedInputViewLabelState) {
-  /**
-   The state where the floating label is not visible.
-   */
-  MDCContainedInputViewLabelStateNone,
-  /**
-   The state where the floating label is floating.
-   */
-  MDCContainedInputViewLabelStateFloating,
-  /**
-   The state where the floating label is occupying the normal text area.
-   */
-  MDCContainedInputViewLabelStateNormal,
-};
+#import "MDCTextControlVerticalPositioningReferenceBase.h"
+
+@interface MDCTextControlVerticalPositioningReferenceBase ()
+
+@end
+
+@implementation MDCTextControlVerticalPositioningReferenceBase
+
+- (CGFloat)paddingBetweenTopAndFloatingLabel {
+  return 10;
+}
+
+- (CGFloat)paddingBetweenTopAndNormalLabel {
+  return 20;
+}
+
+- (CGFloat)paddingBetweenFloatingLabelAndText {
+  return 5;
+}
+
+- (CGFloat)containerHeight {
+  return 50;
+}
+
+@end

--- a/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldLayoutTests.m
+++ b/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldLayoutTests.m
@@ -15,7 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #import "../../../src/ContainedInputView/private/MDCBaseTextFieldLayout.h"
-#import "../../../src/ContainedInputView/private/MDCContainedInputViewVerticalPositioningGuideBase.h"
+#import "../../../src/ContainedInputView/private/MDCTextControlVerticalPositioningReferenceBase.h"
 #import "MaterialTextFields+ContainedInputView.h"
 
 @interface MDCBaseTextFieldLayout (Testing)
@@ -41,8 +41,8 @@
   UIFont *font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
   UIFont *floatingFont = [font fontWithSize:(font.pointSize * (CGFloat)0.5)];
 
-  MDCContainedInputViewVerticalPositioningGuideBase *positioningReference =
-      [[MDCContainedInputViewVerticalPositioningGuideBase alloc] init];
+  MDCTextControlVerticalPositioningReferenceBase *positioningReference =
+      [[MDCTextControlVerticalPositioningReferenceBase alloc] init];
   MDCBaseTextFieldLayout *layout =
       [[MDCBaseTextFieldLayout alloc] initWithTextFieldSize:textFieldSize
                                        positioningReference:positioningReference

--- a/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldTests.m
+++ b/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldTests.m
@@ -17,7 +17,7 @@
 #import <objc/runtime.h>
 #import "MaterialTextFields+ContainedInputView.h"
 
-#import "../../../src/ContainedInputView/private/MDCContainedInputViewLabelState.h"
+#import "../../../src/ContainedInputView/private/MDCTextControlLabelState.h"
 
 @interface MDCBaseTextField (Private)
 @property(nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
@@ -25,7 +25,7 @@
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame;
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelState:(MDCContainedInputViewLabelState)labelState;
+                                       labelState:(MDCTextControlLabelState)labelState;
 @end
 
 @interface MDCBaseTextFieldTests : XCTestCase
@@ -283,19 +283,19 @@
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:nilPlaceholder
                                            text:text
-                                     labelState:MDCContainedInputViewLabelStateNormal]);
+                                     labelState:MDCTextControlLabelStateNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:text
-                                     labelState:MDCContainedInputViewLabelStateNormal]);
+                                     labelState:MDCTextControlLabelStateNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCContainedInputViewLabelStateNormal]);
+                                     labelState:MDCTextControlLabelStateNormal]);
   XCTAssertTrue([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCContainedInputViewLabelStateFloating]);
+                                     labelState:MDCTextControlLabelStateFloating]);
 }
 
 @end


### PR DESCRIPTION
In this PR I am beginning the naming transition from "contained input view" to "text control." This is just a renaming PR, there are no other changes.

At some point after this I want to make it its own component, rather than an extension on TextFields, in the spirit of Ripple and Ink.

Related to #6942.

