### PR TITLE
[PR templete] Updated link in template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@
 - [ ] Please add unit tests, snapshot tests, or manual testing steps depending on the change.
 - [ ] Sign the CLA bot. You can do this once the pull request is opened.
 
-[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
+[Contributing](https://github.com/material-components/material-components-ios/tree/develop/contributing) has more information and tips for a great
 pull request.


### PR DESCRIPTION
It was resolving to https://github.com/material-components/material-components-ios/compare/contributing/README.md?expand=1

