### PR TITLE
[TextFields] Adding floatingPlaceholder Error Active color API to cont…

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -103,6 +103,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   UIColor *_errorColor;
   UIColor *_floatingPlaceholderActiveColor;
   UIColor *_floatingPlaceholderNormalColor;
+  UIColor *_floatingPlaceholderErrorActiveColor;
   UIColor *_inlinePlaceholderColor;
   UIColor *_leadingUnderlineLabelTextColor;
   UIColor *_normalColor;
@@ -198,6 +199,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   copy.floatingEnabled = self.isFloatingEnabled;
   copy.floatingPlaceholderActiveColor = self.floatingPlaceholderActiveColor;
   copy.floatingPlaceholderNormalColor = self.floatingPlaceholderNormalColor;
+  copy.floatingPlaceholderErrorActiveColor = self.floatingPlaceholderErrorActiveColor;
   copy.floatingPlaceholderScale = self.floatingPlaceholderScale;
   copy.helperText = [self.helperText copy];
   copy.inlinePlaceholderColor = self.inlinePlaceholderColor;
@@ -428,10 +430,13 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
 
   UIColor *placeholderColor;
   if ([self isPlaceholderUp]) {
+    UIColor *errorColor = self.textInput.isEditing
+                              ? (self.floatingPlaceholderErrorActiveColor ?: self.errorColor)
+                              : self.errorColor;
     UIColor *nonErrorColor = self.textInput.isEditing ? self.floatingPlaceholderActiveColor
                                                       : self.floatingPlaceholderNormalColor;
     placeholderColor = (self.isDisplayingCharacterCountError || self.isDisplayingErrorText)
-                           ? self.errorColor
+                           ? errorColor
                            : nonErrorColor;
   } else {
     placeholderColor = self.inlinePlaceholderColor;
@@ -954,6 +959,17 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
   _floatingPlaceholderNormalColorDefault = floatingPlaceholderNormalColorDefault
                                                ? floatingPlaceholderNormalColorDefault
                                                : [self class].inlinePlaceholderColorDefault;
+}
+
+- (UIColor *)floatingPlaceholderErrorActiveColor {
+  return _floatingPlaceholderErrorActiveColor;
+}
+
+- (void)setFloatingPlaceholderErrorActiveColor:(UIColor *)floatingPlaceholderErrorActiveColor {
+  if (![_floatingPlaceholderErrorActiveColor isEqual:floatingPlaceholderErrorActiveColor]) {
+    _floatingPlaceholderErrorActiveColor = floatingPlaceholderErrorActiveColor;
+    [self updatePlaceholder];
+  }
 }
 
 - (void)setFloatingEnabled:(BOOL)floatingEnabled {

--- a/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
+++ b/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
@@ -19,7 +19,7 @@
 
 /**
  The color applied to the placeholder when floating and the text field is first responder. However,
- when in error state, it will be colored with the error color.
+ when in error state, it will be colored with the floatingPlaceholderErrorActive Color.
 
  Only relevent when floatingEnabled is true.
 
@@ -50,6 +50,17 @@
  Default is black with Material Design hint text opacity (textInput's tint).
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *floatingPlaceholderNormalColorDefault;
+
+/**
+ The error color of the border of the input field while being in edit mode.
+ The color applied to the placeholder when floating and the text field is first responder and is in
+ the error state.
+
+ Only relevent when floatingEnabled is true.
+
+ Default is errorColor.
+ */
+@property(nonatomic, nullable, strong) UIColor *floatingPlaceholderErrorActiveColor;
 
 /**
  When the placeholder floats up, constraints are created that use this value for constants.

--- a/components/TextFields/tests/unit/Theming/TextFieldsMaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/TextFieldsMaterialThemingTests.swift
@@ -63,6 +63,7 @@ class TextFieldsMaterialThemingTests: XCTestCase {
                    scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledOnSurfaceAlpha))
     XCTAssertEqual(textFieldControllerFilled.floatingPlaceholderActiveColor,
                    scheme.colorScheme.primaryColor.withAlphaComponent(filledActiveAlpha))
+    XCTAssertNil(textFieldControllerFilled.floatingPlaceholderErrorActiveColor)
     XCTAssertEqual(textFieldControllerFilled.textInputClearButtonTintColor,
                    scheme.colorScheme.onSurfaceColor.withAlphaComponent(filledIconAlpha))
 
@@ -103,6 +104,7 @@ class TextFieldsMaterialThemingTests: XCTestCase {
     XCTAssertEqual(textFieldControllerOutlined.textInputClearButtonTintColor, scheme.colorScheme.onSurfaceColor.withAlphaComponent(outlinedTextFieldIconAlpha))
     XCTAssertEqual(textFieldControllerOutlined.floatingPlaceholderNormalColor, onSurfaceOpacity)
     XCTAssertEqual(textFieldControllerOutlined.floatingPlaceholderActiveColor, scheme.colorScheme.primaryColor.withAlphaComponent(outlinedTextFieldActiveAlpha))
+    XCTAssertNil(textFieldControllerOutlined.floatingPlaceholderErrorActiveColor)
 
     // Typography
     XCTAssertEqual(textFieldControllerOutlined.inlinePlaceholderFont,


### PR DESCRIPTION
Adding an error color for the active state of the floating placeholder label (the label that floats up when the TextField is in editing mode).

Also note cl/271208733.

Example usage of new API in theming:

**Before** (the floating placeholder label defaults to the error color when editing): 
![image](https://user-images.githubusercontent.com/2329102/65803463-adbb2d00-e14c-11e9-861b-2694bb5d0cef.png)

**After** (when assigning UIColor.orange to floatingPlaceholderErrorActiveColor):
![image](https://user-images.githubusercontent.com/2329102/65803401-764c8080-e14c-11e9-8c1d-15005f047991.png)

