### PR TITLE
[ActivityIndicator] Removes 72dp radius limit on activity indicator

### DIFF
--- a/components/ActivityIndicator/src/MDCActivityIndicator.h
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.h
@@ -56,9 +56,9 @@ IB_DESIGNABLE
 @property(nonatomic, assign, getter=isAnimating) BOOL animating;
 
 /**
- Spinner radius width. Defaults to 12dp (24x24dp circle), constrained to range [5dp, 72dp]. The
- spinner is centered in the view's bounds. If the bounds are smaller than the diameter of the
- spinner, the spinner may be clipped when clipToBounds is true.
+ Spinner radius width. Defaults to 12dp (24x24dp circle), with a minimum of 5dp. The spinner is
+ centered in the view's bounds. If the bounds are smaller than the diameter of the spinner, the
+ spinner may be clipped when clipToBounds is true.
  */
 @property(nonatomic, assign) CGFloat radius UI_APPEARANCE_SELECTOR;
 

--- a/components/ActivityIndicator/src/MDCActivityIndicator.m
+++ b/components/ActivityIndicator/src/MDCActivityIndicator.m
@@ -424,7 +424,7 @@ static const CGFloat kSingleCycleRotation =
 }
 
 - (void)setRadius:(CGFloat)radius {
-  _radius = MIN(MAX(radius, 5), 72);
+  _radius = MAX(radius, 5);
 
   [self updateStrokePath];
 }

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -16,7 +16,7 @@
 #import "MaterialActivityIndicator.h"
 
 static CGFloat randomNumber() {
-  return arc4random_uniform(64) + 8;
+  return arc4random_uniform(128) + 8;
 }
 
 @interface MDCActivityIndicator (Private)
@@ -40,19 +40,6 @@ static CGFloat randomNumber() {
 
   // Then
   XCTAssertGreaterThanOrEqual(indicator.radius, 5);
-  XCTAssertLessThanOrEqual(indicator.radius, 72);
-}
-
-- (void)testSetRadiusMax {
-  // Given
-  MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];
-
-  // When
-  indicator.radius = 80;
-
-  // Then
-  XCTAssertGreaterThanOrEqual(indicator.radius, 8);
-  XCTAssertLessThanOrEqual(indicator.radius, 72);
 }
 
 - (void)testSetRadius {
@@ -65,7 +52,6 @@ static CGFloat randomNumber() {
 
   // Then
   XCTAssertGreaterThanOrEqual(indicator.radius, 8);
-  XCTAssertLessThanOrEqual(indicator.radius, 72);
   XCTAssertEqual(indicator.radius, random);
 }
 

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -64,6 +64,7 @@ static CGFloat randomNumber() {
                        @"The default value for |cycleColors| should be a non-empty array.");
 }
 
+
 - (void)testSetCycleColorsEmptyReturnsDefault {
   // Given
   MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];

--- a/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
+++ b/components/ActivityIndicator/tests/unit/ActivityIndicatorTests.m
@@ -64,7 +64,6 @@ static CGFloat randomNumber() {
                        @"The default value for |cycleColors| should be a non-empty array.");
 }
 
-
 - (void)testSetCycleColorsEmptyReturnsDefault {
   // Given
   MDCActivityIndicator *indicator = [[MDCActivityIndicator alloc] init];


### PR DESCRIPTION
This change removes the 72dp limit on an MDCActivityIndicator's radius.

closes #8533
