### PR TITLE
Reran ./scripts/generate_all_readmes

### DIFF
--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -110,10 +110,10 @@ let actionSheet = MDCActionSheetController(title: "Action Sheet",
                                            message: "Secondary line text")
 let actionOne = MDCActionSheetAction(title: "Home", 
                                      image: UIImage(named: "Home"), 
-                                     handler: { (action) in print("\(action.title) action")})
+                                     handler: { print("Home action" })
 let actionTwo = MDCActionSheetAction(title: "Email", 
                                      image: UIImage(named: "Email"), 
-                                     handler: { (action) in print("\(action.title) action")})
+                                     handler: { print("Email action" })
 actionSheet.addAction(actionOne)
 actionSheet.addAction(actionTwo)
 

--- a/components/Banner/README.md
+++ b/components/Banner/README.md
@@ -1,4 +1,4 @@
-<!-- This file was auto-generated using scripts/generate_readme Banner -->
+<!-- This file was auto-generated using ./scripts/generate_readme Banner -->
 
 # Banner
 

--- a/components/Ink/README.md
+++ b/components/Ink/README.md
@@ -8,7 +8,7 @@ path: /catalog/ink/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme Ink -->
+<!-- This file was auto-generated using ./scripts/generate_readme Ink -->
 
 # Ink
 

--- a/components/Ripple/README.md
+++ b/components/Ripple/README.md
@@ -8,7 +8,7 @@ path: /catalog/ripple/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme Ripple -->
+<!-- This file was auto-generated using ./scripts/generate_readme Ripple -->
 
 # Ripple
 

--- a/components/Tabs/README.md
+++ b/components/Tabs/README.md
@@ -8,7 +8,7 @@ path: /catalog/tabs/
 api_doc_root: true
 -->
 
-<!-- This file was auto-generated using scripts/generate_readme Tabs -->
+<!-- This file was auto-generated using ./scripts/generate_readme Tabs -->
 
 # Tabs
 

--- a/components/TextFields/README.md
+++ b/components/TextFields/README.md
@@ -38,6 +38,7 @@ For more information on text field styles, and animated images of each style in 
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes.html#/c:objc(cs)MDCTextInputControllerUnderline">MDCTextInputControllerUnderline</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCMultilineTextField.html">MDCMultilineTextField</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextField.html">MDCTextField</a></li>
+  <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputBorderView.html">MDCTextInputBorderView</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputControllerBase.html">MDCTextInputControllerBase</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputControllerFullWidth.html">MDCTextInputControllerFullWidth</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/textfields/api-docs/Classes/MDCTextInputUnderlineView.html">MDCTextInputUnderlineView</a></li>

--- a/components/Typography/README.md
+++ b/components/Typography/README.md
@@ -1,4 +1,4 @@
-<!-- This file was auto-generated using scripts/generate_readme Typography -->
+<!-- This file was auto-generated using ./scripts/generate_readme Typography -->
 
 # Typography
 


### PR DESCRIPTION
Moved changes from https://github.com/material-components/material-components-ios/pull/7360 to the source Readme file

Also some readme files got a minor addition to add `./` in their generation comment