### PR TITLE
Add git steps around .gitattributes file to keep it correct throughout the branches.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,25 @@
-# Do not merge this version into `stable`.
-snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
-.gitattributes merge=gitattributes
+# DO NOT CHANGE THIS FILE
+# DO NOT EDIT THE LINE BELOW.
+/.gitattributes merge=gitattributes
+# DO NOT EDIT THE LINE ABOVE.
+#
+# You can of course edit this file, but make sure you understand what you are
+# doing. This file defines a custom filter driver that prevents snapshot test
+# images from being merged into `stable`. Snapshot test images are only
+# valuable in `develop` because they are only intended to help developers
+# identify changes in the appearance of the library.
+#
+# Before you change this file, please carefully consider whether such a change
+# is actually necessary. When you do change this file, it should almost always
+# be done in a dedicated commit directly on the `stable` branch and not part
+# of a release.  If you see this file being changed as part of a release,
+# block the release and work with the releaser to ensure that the change needs
+# to be propagated from the `develop` branch to the `stable` branch. In nearly
+# all cases, it should not be propagated from `develop` to `stable`.
+#
+# If you are a releaser and see this file change and you're not sure why, you
+# might have accidentally skipped [setting the correct
+# driver in your cloned
+# repository](https://github.com/material-components/material-components-ios/blob/develop/contributing/releasing.md#configure-the-merge-strategy-for-gitattributes).
+# If that's the case, please either revert the accidental change manually or
+# restart the release with a fresh clone and the correct driver.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,25 +1,3 @@
-# DO NOT CHANGE THIS FILE
-# DO NOT EDIT THE LINE BELOW.
-/.gitattributes merge=gitattributes
-# DO NOT EDIT THE LINE ABOVE.
-#
-# You can of course edit this file, but make sure you understand what you are
-# doing. This file defines a custom filter driver that prevents snapshot test
-# images from being merged into `stable`. Snapshot test images are only
-# valuable in `develop` because they are only intended to help developers
-# identify changes in the appearance of the library.
-#
-# Before you change this file, please carefully consider whether such a change
-# is actually necessary. When you do change this file, it should almost always
-# be done in a dedicated commit directly on the `stable` branch and not part
-# of a release.  If you see this file being changed as part of a release,
-# block the release and work with the releaser to ensure that the change needs
-# to be propagated from the `develop` branch to the `stable` branch. In nearly
-# all cases, it should not be propagated from `develop` to `stable`.
-#
-# If you are a releaser and see this file change and you're not sure why, you
-# might have accidentally skipped [setting the correct
-# driver in your cloned
-# repository](https://github.com/material-components/material-components-ios/blob/develop/contributing/releasing.md#configure-the-merge-strategy-for-gitattributes).
-# If that's the case, please either revert the accidental change manually or
-# restart the release with a fresh clone and the correct driver.
+# Do not merge this version into `stable`.
+snapshot_test_goldens/**/*.png filter=lfs diff=lfs merge=lfs -text
+.gitattributes merge=gitattributes

--- a/scripts/release
+++ b/scripts/release
@@ -142,6 +142,7 @@ cut_release() {
   fi
   echo $branch_message
   git checkout -b release-candidate $branch
+  git checkout stable -- .gitattributes
 
   touch "$rootdir/CHANGELOG.md"
   if ! grep "# #develop#" "$rootdir/CHANGELOG.md" >> /dev/null; then
@@ -307,8 +308,10 @@ merge_release() {
     git checkout develop
   fi
   git rebase origin/develop
-  git merge --no-ff release-candidate --no-edit
-
+  git merge --no-ff --no-commit release-candidate --no-edit
+  git reset HEAD .gitattributes
+  git checkout -- .gitattributes
+  git commit -m "merged release-candidate"
   git branch -D release-candidate
 
   git checkout stable

--- a/scripts/release
+++ b/scripts/release
@@ -308,6 +308,7 @@ merge_release() {
     git checkout develop
   fi
   git rebase origin/develop
+  # The following lines will only create one commit thanks to the --no-commit argument here.
   git merge --no-ff --no-commit release-candidate --no-edit
   git reset HEAD .gitattributes
   git checkout -- .gitattributes


### PR DESCRIPTION
To keep .gitattributes correct in both develop and stable branches, 2 additions were added, one to the cut and one to the merge steps.

1. In cut we checkout the .gitattributes from stable before opening the PR to merge from release-candidate to stable, as release-candidate was created from Develop, and therefore without checking out the .gitattributes version from stable, when merged it would take the develop version.

2. In merge, we do a no-commit merge and then reset the .gitattributes so that develop branch won't take the release-candidate/stable version.

Closes #8392