### PR TITLE
[Chips] Remove unnecessary explicit layout code.

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -41,7 +41,10 @@
 
   // Action chips should allow single selection, collection view default is based on single
   // selection. Note that MDCChipCollectionViewCell manages the state of the chip accordingly.
-  _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+                                       collectionViewLayout:layout];
+  _collectionView.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   // Since there is no scrolling turning off the delaysContentTouches makes the cells respond faster
   _collectionView.delaysContentTouches = NO;
@@ -87,12 +90,6 @@
                                   animated:NO
                             scrollPosition:UICollectionViewScrollPositionNone];
   }
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  _collectionView.frame = self.view.bounds;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -44,7 +44,10 @@
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
 
-  _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+                                       collectionViewLayout:layout];
+  _collectionView.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   // Since there is no scrolling turning off the delaysContentTouches makes the cells respond faster
   _collectionView.delaysContentTouches = NO;
@@ -87,12 +90,6 @@
                                   animated:NO
                             scrollPosition:UICollectionViewScrollPositionNone];
   }
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  _collectionView.frame = self.view.bounds;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -57,7 +57,10 @@
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
 
-  _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+                                       collectionViewLayout:layout];
+  _collectionView.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   _collectionView.dataSource = self;
   _collectionView.delegate = self;
   _collectionView.allowsMultipleSelection = YES;
@@ -77,12 +80,6 @@
   [super viewDidLoad];
 
   [_sizingChip applyThemeWithScheme:self.containerScheme];
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  _collectionView.frame = self.view.bounds;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -42,7 +42,10 @@
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
 
-  _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+                                       collectionViewLayout:layout];
+  _collectionView.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   // Filter chips should allow multiSelection, MDCChipCollectionViewCell manages the state of the
   // chip accordingly.
   _collectionView.allowsMultipleSelection = YES;
@@ -89,12 +92,6 @@
                                   animated:NO
                             scrollPosition:UICollectionViewScrollPositionNone];
   }
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  _collectionView.frame = self.view.bounds;
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView


### PR DESCRIPTION
Initializing with the container bounds & using autoresizing width + height when possible is preferred to explicit layout.

Cleanup as part of https://github.com/material-components/material-components-ios/issues/8459
