### PR TITLE
[Chips] Add Dynamic Type support to the remaining chip collection examples.

### DIFF
--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -25,6 +25,10 @@
 
 @implementation ChipsChoiceExampleViewController
 
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (id)init {
   self = [super init];
   if (self) {
@@ -43,6 +47,8 @@
   // Our preferred CollectionView Layout For chips
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
+  MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
+  layout.estimatedItemSize = [cell intrinsicContentSize];
 
   _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
 
@@ -74,6 +80,17 @@
                                        style:UIBarButtonItemStylePlain
                                       target:self
                                       action:@selector(switchStyle)];
+
+  // When Dynamic Type changes we need to invalidate the collection view layout in order to let the
+  // cells change their dimensions because our chips use manual layout.
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contentSizeCategoryDidChange:)
+                                               name:UIContentSizeCategoryDidChangeNotification
+                                             object:nil];
+}
+
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  [_collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)switchStyle {
@@ -105,6 +122,8 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   MDCChipView *chipView = cell.chipView;
+
+  chipView.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Customize Chip
   chipView.titleLabel.text = self.titles[indexPath.row];

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -41,6 +41,8 @@
   // Our preferred CollectionView Layout For chips
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
+  MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
+  layout.estimatedItemSize = [cell intrinsicContentSize];
 
   _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
   // Filter chips should allow multiSelection, MDCChipCollectionViewCell manages the state of the
@@ -77,6 +79,17 @@
                                        style:UIBarButtonItemStylePlain
                                       target:self
                                       action:@selector(switchStyle)];
+
+  // When Dynamic Type changes we need to invalidate the collection view layout in order to let the
+  // cells change their dimensions because our chips use manual layout.
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contentSizeCategoryDidChange:)
+                                               name:UIContentSizeCategoryDidChangeNotification
+                                             object:nil];
+}
+
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  [_collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)switchStyle {
@@ -107,6 +120,8 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   MDCChipView *chipView = cell.chipView;
+
+  chipView.mdc_adjustsFontForContentSizeCategory = YES;
 
   // Customize Chip
   chipView.titleLabel.text = self.titles[indexPath.row];

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -17,18 +17,16 @@
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
-@implementation ChipsTypicalUseViewController {
-  MDCChipView *_sizingChip;
-}
+@implementation ChipsTypicalUseViewController
 
 - (instancetype)init {
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
   layout.minimumInteritemSpacing = 10;
+  MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
+  layout.estimatedItemSize = [cell intrinsicContentSize];
 
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
-    _sizingChip = [[MDCChipView alloc] init];
-    _sizingChip.mdc_adjustsFontForContentSizeCategory = YES;
     self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
@@ -42,8 +40,6 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  [_sizingChip applyThemeWithScheme:self.containerScheme];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -118,17 +114,6 @@
     didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
   [collectionView performBatchUpdates:nil completion:nil];
   [self updateClearButton];
-}
-
-- (CGSize)collectionView:(UICollectionView *)collectionView
-                    layout:(UICollectionViewLayout *)collectionViewLayout
-    sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-  NSArray *selectedPaths = [collectionView indexPathsForSelectedItems];
-  _sizingChip.selected = [selectedPaths containsObject:indexPath];
-
-  ChipModel *model = self.model[indexPath.row];
-  [model apply:_sizingChip];
-  return [_sizingChip sizeThatFits:collectionView.bounds.size];
 }
 
 - (NSArray *)model {


### PR DESCRIPTION
This follows the steps implemented in https://github.com/material-components/material-components-ios/pull/8565 to enable Dynamic Type behavior. It also standardizes the "Typical Use" example on this pattern. The pattern essentially boils down to:

```objc
// Step 1: Set the collection view layout's `estimatedItemSize`.
MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
layout.estimatedItemSize = [cell intrinsicContentSize];

// Step 2: Observe UIContentSizeCategoryDidChangeNotification events.
- (void)viewDidLoad {
  [super viewDidLoad];
  ...
  [[NSNotificationCenter defaultCenter] addObserver:self
                                           selector:@selector(contentSizeCategoryDidChange:)
                                               name:UIContentSizeCategoryDidChangeNotification
                                             object:nil];
}

- (void)dealloc {
  [[NSNotificationCenter defaultCenter] removeObserver:self
                                                  name:UIContentSizeCategoryDidChangeNotification
                                                object:nil];
}

- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
  [_collectionView.collectionViewLayout invalidateLayout];
 }

// Step 3: Enable mdc_adjustsFontForContentSizeCategory on the chip cell's chip view.
- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
  MDCChipCollectionViewCell *cell = ...
  cell.chipView.mdc_adjustsFontForContentSizeCategory = YES;
  ...
}
```

This is part of https://github.com/material-components/material-components-ios/issues/8459

## Screenshots

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-10 at 16 14 01](https://user-images.githubusercontent.com/45670/66604486-49e92900-eb7c-11e9-83f8-89abb3f1fc78.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-10 at 16 19 38](https://user-images.githubusercontent.com/45670/66604493-4e154680-eb7c-11e9-9315-c593bd700078.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-10 at 16 29 23](https://user-images.githubusercontent.com/45670/66604504-51103700-eb7c-11e9-9587-695d8c9df418.png)
