### PR TITLE
[Chips] Add Dynamic Type support to ChipsInputExampleViewController.

### DIFF
--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -81,6 +81,8 @@
   if (@available(iOS 11.0, *)) {
     frame = UIEdgeInsetsInsetRect(frame, self.view.safeAreaInsets);
   }
+  MDCChipView *chip = _chipField.chips.lastObject;
+  [self recomputeChipFieldChipHeightWithChip:chip];
   frame.size = [_chipField sizeThatFits:frame.size];
   _chipField.frame = frame;
 }
@@ -97,12 +99,17 @@
     [chip applyThemeWithScheme:self.containerScheme];
   }
   chip.mdc_adjustsFontForContentSizeCategory = YES;
-  [chip sizeToFit];
-
-  _chipField.chipHeight = MAX(_chipField.chipHeight, chip.frame.size.height);
+  [self recomputeChipFieldChipHeightWithChip:chip];
 
   CGFloat chipVerticalInset = MIN(0, (CGRectGetHeight(chip.bounds) - 48) / 2);
   chip.hitAreaInsets = UIEdgeInsetsMake(chipVerticalInset, 0, chipVerticalInset, 0);
+}
+
+- (void)recomputeChipFieldChipHeightWithChip:(MDCChipView *)chip {
+  [chip sizeToFit];
+  if (chip.frame.size.height > 0) {
+    _chipField.chipHeight = chip.frame.size.height;
+  }
 }
 
 @end


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8459

Testing strategy:

1. Open the ChipsInputExampleViewController example in MDCCatalog.
2. Type some chips.
3. Change the system Dynamic Type size to a large and then small size and back again. After each change, verify that the chip field changed in reaction.

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-11 at 08 55 22](https://user-images.githubusercontent.com/45670/66652939-df300000-ec04-11e9-9083-b97427b14bd5.png)
