### PR TITLE
[Chips] Remove sizing chips from all remaining examples.

### DIFF
--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -19,7 +19,6 @@
 #import "MaterialContainerScheme.h"
 
 @interface ChipsChoiceExampleViewController ()
-@property(nonatomic, strong) MDCChipView *sizingChip;
 @property(nonatomic, assign, getter=isOutlined) BOOL outlined;
 @end
 
@@ -40,9 +39,6 @@
 - (void)loadView {
   [super loadView];
   self.view.backgroundColor = [UIColor whiteColor];
-
-  // This is used to calculate the size of each chip based on the chip setup
-  _sizingChip = [[MDCChipView alloc] init];
 
   // Our preferred CollectionView Layout For chips
   MDCChipCollectionViewFlowLayout *layout = [[MDCChipCollectionViewFlowLayout alloc] init];
@@ -75,7 +71,6 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  [self.sizingChip applyThemeWithScheme:self.containerScheme];
 
   self.outlined = NO;
   self.navigationItem.rightBarButtonItem =
@@ -134,14 +129,6 @@
   }
 
   return cell;
-}
-
-- (CGSize)collectionView:(UICollectionView *)collectionView
-                    layout:(UICollectionViewLayout *)collectionViewLayout
-    sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-  // The size of the chip depends on title here.
-  self.sizingChip.titleLabel.text = self.titles[indexPath.row];
-  return [self.sizingChip sizeThatFits:collectionView.bounds.size];
 }
 
 - (NSArray *)titles {

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -20,7 +20,6 @@
 
 @implementation ChipsFilterExampleViewController {
   UICollectionView *_collectionView;
-  MDCChipView *_sizingChip;
   NSMutableArray *_selectedIndecies;
   BOOL _isOutlined;
 }
@@ -66,9 +65,6 @@
   if (@available(iOS 11.0, *)) {
     _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
-
-  // This is used to calculate the size of each chip based on the chip setup
-  _sizingChip = [[MDCChipView alloc] init];
 
   [self.view addSubview:_collectionView];
 }
@@ -143,16 +139,6 @@
   }
 
   return cell;
-}
-
-- (CGSize)collectionView:(UICollectionView *)collectionView
-                    layout:(UICollectionViewLayout *)collectionViewLayout
-    sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
-  // The size of the chip depends on title, image and selection state.
-  _sizingChip.selected = [_selectedIndecies containsObject:indexPath];
-  _sizingChip.titleLabel.text = self.titles[indexPath.row];
-  _sizingChip.selectedImageView.image = [self doneImage];
-  return [_sizingChip sizeThatFits:collectionView.bounds.size];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView


### PR DESCRIPTION
In doing so, adds Dynamic Type support to ChipsCustomizedExampleViewController (a dragons example).

This is polish of https://github.com/material-components/material-components-ios/issues/8459