### PR TITLE
[Chips] Move all example assets to a supplemental file.

### DIFF
--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -17,6 +17,8 @@
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
+#import "supplemental/ChipsExampleAssets.h"
+
 @implementation ChipsCustomizedExampleViewController {
   UICollectionView *_collectionView;
 }
@@ -106,7 +108,7 @@
 
   [[self class] configureChip:cell.chipView];
   cell.chipView.titleLabel.text = self.titles[indexPath.row];
-  cell.chipView.selectedImageView.image = [self doneImage];
+  cell.chipView.selectedImageView.image = ChipsExampleAssets.doneImage;
   cell.chipView.mdc_adjustsFontForContentSizeCategory = YES;
   cell.alwaysAnimateResize = YES;
   [cell.chipView applyThemeWithScheme:self.containerScheme];

--- a/components/Chips/examples/ChipsFilterExampleViewController.m
+++ b/components/Chips/examples/ChipsFilterExampleViewController.m
@@ -18,6 +18,8 @@
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
 
+#import "supplemental/ChipsExampleAssets.h"
+
 @implementation ChipsFilterExampleViewController {
   UICollectionView *_collectionView;
   NSMutableArray *_selectedIndecies;
@@ -119,7 +121,7 @@
   // Customize Chip
   chipView.titleLabel.text = self.titles[indexPath.row];
   chipView.selectedImageView.image =
-      [[self doneImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+      [ChipsExampleAssets.doneImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   if (self.containerScheme.colorScheme) {
     chipView.selectedImageView.tintColor =
         [self.containerScheme.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.54];

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -22,6 +22,8 @@
 #import "MaterialSlider+ColorThemer.h"
 #import "MaterialSlider.h"
 
+#import "supplemental/ChipsExampleAssets.h"
+
 @implementation ChipsShapingExampleViewController {
   MDCChipView *_chipView;
   MDCSlider *_cornerSlider;
@@ -46,8 +48,8 @@
 
   _chipView = [[MDCChipView alloc] init];
   _chipView.titleLabel.text = @"Material";
-  _chipView.imageView.image = [self faceImage];
-  _chipView.accessoryView = [self deleteButton];
+  _chipView.imageView.image = ChipsExampleAssets.faceImage;
+  _chipView.accessoryView = ChipsExampleAssets.deleteButton;
   _chipView.imagePadding = UIEdgeInsetsMake(0, 10, 0, 0);
   _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
   CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -18,6 +18,8 @@
 #import "MaterialChips.h"
 #import "MaterialSlider.h"
 
+#import "supplemental/ChipsExampleAssets.h"
+
 @implementation ChipsSizingExampleViewController {
   MDCChipView *_chipView;
   MDCSlider *_widthSlider;
@@ -40,8 +42,8 @@
 
   _chipView = [[MDCChipView alloc] init];
   _chipView.titleLabel.text = @"Material";
-  _chipView.imageView.image = [self faceImage];
-  _chipView.accessoryView = [self deleteButton];
+  _chipView.imageView.image = ChipsExampleAssets.faceImage;
+  _chipView.accessoryView = ChipsExampleAssets.deleteButton;
   [_chipView applyThemeWithScheme:self.containerScheme];
   [self.view addSubview:_chipView];
 

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.h
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-@interface ChipsExampleAssets: NSObject
+@interface ChipsExampleAssets : NSObject
 
 @property(class, nonatomic, readonly, nonnull) UIImage *doneImage;
 @property(class, nonatomic, readonly, nonnull) UIImage *faceImage;

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.h
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.h
@@ -1,0 +1,24 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface ChipsExampleAssets: NSObject
+
+@property(class, nonatomic, readonly, nonnull) UIImage *doneImage;
+@property(class, nonatomic, readonly, nonnull) UIImage *faceImage;
+@property(class, nonatomic, readonly, nonnull) UIButton *deleteButton;
+
+@end

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.m
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.m
@@ -16,21 +16,21 @@
 
 @implementation ChipsExampleAssets
 
-+ (nonnull UIImage *)doneImage {
++ (UIImage *)doneImage {
   UIImage *image = [UIImage imageNamed:@"ic_done"
                               inBundle:[NSBundle bundleForClass:self]
          compatibleWithTraitCollection:nil];
   return image;
 }
 
-+ (nonnull UIImage *)faceImage {
++ (UIImage *)faceImage {
   UIImage *image = [UIImage imageNamed:@"ic_mask"
                               inBundle:[NSBundle bundleForClass:self]
          compatibleWithTraitCollection:nil];
   return image;
 }
 
-+ (nonnull UIButton *)deleteButton {
++ (UIButton *)deleteButton {
   UIImage *image = [UIImage imageNamed:@"ic_cancel"
                               inBundle:[NSBundle bundleForClass:self]
          compatibleWithTraitCollection:nil];

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.m
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.m
@@ -1,0 +1,46 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "ChipsExampleAssets.h"
+
+@implementation ChipsExampleAssets
+
++ (nonnull UIImage *)doneImage {
+  UIImage *image = [UIImage imageNamed:@"ic_done"
+                              inBundle:[NSBundle bundleForClass:self]
+         compatibleWithTraitCollection:nil];
+  return image;
+}
+
++ (nonnull UIImage *)faceImage {
+  UIImage *image = [UIImage imageNamed:@"ic_mask"
+                              inBundle:[NSBundle bundleForClass:self]
+         compatibleWithTraitCollection:nil];
+  return image;
+}
+
++ (nonnull UIButton *)deleteButton {
+  UIImage *image = [UIImage imageNamed:@"ic_cancel"
+                              inBundle:[NSBundle bundleForClass:self]
+         compatibleWithTraitCollection:nil];
+  image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+
+  UIButton *button = [[UIButton alloc] initWithFrame:CGRectZero];
+  button.tintColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.7];
+  [button setImage:image forState:UIControlStateNormal];
+
+  return button;
+}
+
+@end

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.m
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.m
@@ -39,7 +39,6 @@
   UIButton *button = [[UIButton alloc] initWithFrame:CGRectZero];
   button.tintColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.7];
   [button setImage:image forState:UIControlStateNormal];
-
   return button;
 }
 

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.m
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.m
@@ -17,17 +17,15 @@
 @implementation ChipsExampleAssets
 
 + (UIImage *)doneImage {
-  UIImage *image = [UIImage imageNamed:@"ic_done"
-                              inBundle:[NSBundle bundleForClass:self]
-         compatibleWithTraitCollection:nil];
-  return image;
+  return [UIImage imageNamed:@"ic_done"
+                           inBundle:[NSBundle bundleForClass:self]
+      compatibleWithTraitCollection:nil];
 }
 
 + (UIImage *)faceImage {
-  UIImage *image = [UIImage imageNamed:@"ic_mask"
-                              inBundle:[NSBundle bundleForClass:self]
-         compatibleWithTraitCollection:nil];
-  return image;
+  return [UIImage imageNamed:@"ic_mask"
+                           inBundle:[NSBundle bundleForClass:self]
+      compatibleWithTraitCollection:nil];
 }
 
 + (UIButton *)deleteButton {

--- a/components/Chips/examples/supplemental/ChipsExampleAssets.m
+++ b/components/Chips/examples/supplemental/ChipsExampleAssets.m
@@ -18,19 +18,19 @@
 
 + (UIImage *)doneImage {
   return [UIImage imageNamed:@"ic_done"
-                           inBundle:[NSBundle bundleForClass:self]
+                           inBundle:[NSBundle bundleForClass:[ChipsExampleAssets class]]
       compatibleWithTraitCollection:nil];
 }
 
 + (UIImage *)faceImage {
   return [UIImage imageNamed:@"ic_mask"
-                           inBundle:[NSBundle bundleForClass:self]
+                           inBundle:[NSBundle bundleForClass:[ChipsExampleAssets class]]
       compatibleWithTraitCollection:nil];
 }
 
 + (UIButton *)deleteButton {
   UIImage *image = [UIImage imageNamed:@"ic_cancel"
-                              inBundle:[NSBundle bundleForClass:self]
+                              inBundle:[NSBundle bundleForClass:[ChipsExampleAssets class]]
          compatibleWithTraitCollection:nil];
   image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -47,10 +47,6 @@
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
-@interface ChipsCustomizedExampleViewController (Supplemental)
-- (UIImage *)doneImage;
-@end
-
 @interface ChipsFilterExampleViewController
     : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
@@ -61,21 +57,12 @@
     : ChipsFilterExampleViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @end
 
-@interface ChipsFilterExampleViewController (Supplemental)
-- (UIImage *)doneImage;
-@end
-
 @interface ChipsInputExampleViewController : UIViewController
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface ChipsSizingExampleViewController : UIViewController
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
-@interface ChipsSizingExampleViewController (Supplemental)
-- (UIImage *)faceImage;
-- (UIButton *)deleteButton;
 @end
 
 @interface ChipsTypicalUseViewController
@@ -86,17 +73,8 @@
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
-@interface ChipsTypicalUseViewController (Supplemental)
-- (UIImage *)doneImage;
-@end
-
 @interface ChipsShapingExampleViewController : UIViewController
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
-@interface ChipsShapingExampleViewController (Supplemental)
-- (UIImage *)faceImage;
-- (UIButton *)deleteButton;
 @end
 
 @interface ChipModel : NSObject

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -16,35 +16,7 @@
 
 #import "MaterialChips.h"
 
-static UIImage *DoneImage() {
-  NSBundle *bundle = [NSBundle bundleForClass:[ChipsTypicalUseViewController class]];
-  UIImage *image = [UIImage imageNamed:@"ic_done"
-                              inBundle:bundle
-         compatibleWithTraitCollection:nil];
-  return image;
-}
-
-static UIImage *FaceImage() {
-  NSBundle *bundle = [NSBundle bundleForClass:[ChipsTypicalUseViewController class]];
-  UIImage *image = [UIImage imageNamed:@"ic_mask"
-                              inBundle:bundle
-         compatibleWithTraitCollection:nil];
-  return image;
-}
-
-static UIButton *DeleteButton() {
-  NSBundle *bundle = [NSBundle bundleForClass:[ChipsTypicalUseViewController class]];
-  UIImage *image = [UIImage imageNamed:@"ic_cancel"
-                              inBundle:bundle
-         compatibleWithTraitCollection:nil];
-  image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-
-  UIButton *button = [[UIButton alloc] initWithFrame:CGRectZero];
-  button.tintColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.7];
-  [button setImage:image forState:UIControlStateNormal];
-
-  return button;
-}
+#import "ChipsExampleAssets.h"
 
 @implementation ExampleChipCollectionViewController {
   BOOL _popRecognizerDelaysTouches;
@@ -122,10 +94,6 @@ static UIButton *DeleteButton() {
   };
 }
 
-- (UIImage *)doneImage {
-  return DoneImage();
-}
-
 @end
 
 @implementation ChipsFilterExampleViewController (Supplemental)
@@ -138,10 +106,6 @@ static UIButton *DeleteButton() {
   };
 }
 
-- (UIImage *)doneImage {
-  return DoneImage();
-}
-
 @end
 
 @implementation ChipsFilterAnimatedExampleViewController (Supplemental)
@@ -152,10 +116,6 @@ static UIButton *DeleteButton() {
     @"primaryDemo" : @NO,
     @"presentable" : @NO,
   };
-}
-
-- (UIImage *)doneImage {
-  return DoneImage();
 }
 
 @end
@@ -185,14 +145,6 @@ static UIButton *DeleteButton() {
   };
 }
 
-- (UIImage *)faceImage {
-  return FaceImage();
-}
-
-- (UIButton *)deleteButton {
-  return DeleteButton();
-}
-
 @end
 
 @implementation ChipsTypicalUseViewController (Supplemental)
@@ -204,10 +156,6 @@ static UIButton *DeleteButton() {
     @"primaryDemo" : @YES,
     @"presentable" : @YES,
   };
-}
-
-- (UIImage *)doneImage {
-  return DoneImage();
 }
 
 @end
@@ -222,14 +170,6 @@ static UIButton *DeleteButton() {
   };
 }
 
-- (UIImage *)faceImage {
-  return FaceImage();
-}
-
-- (UIButton *)deleteButton {
-  return DeleteButton();
-}
-
 @end
 
 @implementation ChipModel
@@ -237,21 +177,9 @@ static UIButton *DeleteButton() {
 - (void)apply:(MDCChipView *)chipView {
   chipView.enableRippleBehavior = YES;
   chipView.titleLabel.text = self.title;
-  chipView.imageView.image = self.showProfilePic ? [self faceImage] : nil;
-  chipView.selectedImageView.image = self.showDoneImage ? [self doneImage] : nil;
-  chipView.accessoryView = self.showDeleteButton ? [self deleteButton] : nil;
-}
-
-- (UIImage *)faceImage {
-  return FaceImage();
-}
-
-- (UIImage *)doneImage {
-  return DoneImage();
-}
-
-- (UIButton *)deleteButton {
-  return DeleteButton();
+  chipView.imageView.image = self.showProfilePic ? ChipsExampleAssets.faceImage : nil;
+  chipView.selectedImageView.image = self.showDoneImage ? ChipsExampleAssets.doneImage : nil;
+  chipView.accessoryView = self.showDeleteButton ? ChipsExampleAssets.deleteButton : nil;
 }
 
 @end


### PR DESCRIPTION
This reduces method duplication complexity across all of the examples. It also removes a layer of indirection between the examples and the assets.

Polish for https://github.com/material-components/material-components-ios/issues/8459
