### PR TITLE
[Chips] Move ChipModel into ChipsTypicalUseViewController.

### DIFF
--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -12,10 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "supplemental/ChipsExampleAssets.h"
 #import "supplemental/ChipsExamplesSupplemental.h"
 
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
+
+@interface ChipModel : NSObject
+@property(nonatomic, strong) NSString *title;
+@property(nonatomic, assign) BOOL showProfilePic;
+@property(nonatomic, assign) BOOL showDoneImage;
+@property(nonatomic, assign) BOOL showDeleteButton;
+- (void)apply:(MDCChipView *)cell;
+@end
+
+@implementation ChipModel
+
+- (void)apply:(MDCChipView *)chipView {
+  chipView.enableRippleBehavior = YES;
+  chipView.titleLabel.text = self.title;
+  chipView.imageView.image = self.showProfilePic ? ChipsExampleAssets.faceImage : nil;
+  chipView.selectedImageView.image = self.showDoneImage ? ChipsExampleAssets.doneImage : nil;
+  chipView.accessoryView = self.showDeleteButton ? ChipsExampleAssets.deleteButton : nil;
+}
+
+@end
+
+static ChipModel *MakeModel(NSString *title,
+                            BOOL showProfilePic,
+                            BOOL showDoneImage,
+                            BOOL showDeleteButton) {
+  ChipModel *chip = [[ChipModel alloc] init];
+  chip.title = title;
+  chip.showProfilePic = showProfilePic;
+  chip.showDoneImage = showDoneImage;
+  chip.showDeleteButton = showDeleteButton;
+  return chip;
+};
 
 @implementation ChipsTypicalUseViewController
 

--- a/components/Chips/examples/ChipsTypicalUseViewController.m
+++ b/components/Chips/examples/ChipsTypicalUseViewController.m
@@ -23,19 +23,9 @@
 @property(nonatomic, assign) BOOL showProfilePic;
 @property(nonatomic, assign) BOOL showDoneImage;
 @property(nonatomic, assign) BOOL showDeleteButton;
-- (void)apply:(MDCChipView *)cell;
 @end
 
 @implementation ChipModel
-
-- (void)apply:(MDCChipView *)chipView {
-  chipView.enableRippleBehavior = YES;
-  chipView.titleLabel.text = self.title;
-  chipView.imageView.image = self.showProfilePic ? ChipsExampleAssets.faceImage : nil;
-  chipView.selectedImageView.image = self.showDoneImage ? ChipsExampleAssets.doneImage : nil;
-  chipView.accessoryView = self.showDeleteButton ? ChipsExampleAssets.deleteButton : nil;
-}
-
 @end
 
 static ChipModel *MakeModel(NSString *title,
@@ -146,7 +136,13 @@ static ChipModel *MakeModel(NSString *title,
   cell.alwaysAnimateResize = YES;
 
   ChipModel *model = self.model[indexPath.row];
-  [model apply:cell.chipView];
+
+  cell.chipView.enableRippleBehavior = YES;
+  cell.chipView.titleLabel.text = model.title;
+  cell.chipView.imageView.image = model.showProfilePic ? ChipsExampleAssets.faceImage : nil;
+  cell.chipView.selectedImageView.image = model.showDoneImage ? ChipsExampleAssets.doneImage : nil;
+  cell.chipView.accessoryView = model.showDeleteButton ? ChipsExampleAssets.deleteButton : nil;
+
   [cell.chipView applyThemeWithScheme:self.containerScheme];
   return cell;
 }

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -76,23 +76,3 @@
 @interface ChipsShapingExampleViewController : UIViewController
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
-
-@interface ChipModel : NSObject
-@property(nonatomic, strong) NSString *title;
-@property(nonatomic, assign) BOOL showProfilePic;
-@property(nonatomic, assign) BOOL showDoneImage;
-@property(nonatomic, assign) BOOL showDeleteButton;
-- (void)apply:(MDCChipView *)cell;
-@end
-
-static inline ChipModel *MakeModel(NSString *title,
-                                   BOOL showProfilePic,
-                                   BOOL showDoneImage,
-                                   BOOL showDeleteButton) {
-  ChipModel *chip = [[ChipModel alloc] init];
-  chip.title = title;
-  chip.showProfilePic = showProfilePic;
-  chip.showDoneImage = showDoneImage;
-  chip.showDeleteButton = showDeleteButton;
-  return chip;
-};

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -171,15 +171,3 @@
 }
 
 @end
-
-@implementation ChipModel
-
-- (void)apply:(MDCChipView *)chipView {
-  chipView.enableRippleBehavior = YES;
-  chipView.titleLabel.text = self.title;
-  chipView.imageView.image = self.showProfilePic ? ChipsExampleAssets.faceImage : nil;
-  chipView.selectedImageView.image = self.showDoneImage ? ChipsExampleAssets.doneImage : nil;
-  chipView.accessoryView = self.showDeleteButton ? ChipsExampleAssets.deleteButton : nil;
-}
-
-@end


### PR DESCRIPTION
It is not reused by any other example. Folding it into the example removes one layer of file indirection required to understand this example.

Polish as part of https://github.com/material-components/material-components-ios/issues/8459