### PR TITLE
[Typography] Remove checks for `systemFontOfSize:weight:`.

### DIFF
--- a/components/Typography/src/MDCTypography.m
+++ b/components/Typography/src/MDCTypography.m
@@ -219,14 +219,7 @@ const CGFloat MDCTypographySecondaryOpacity = (CGFloat)0.54;
     return font;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightLight];
-  } else {
-    font = [UIFont fontWithName:@"HelveticaNeue-Light" size:fontSize];
-  }
-#pragma clang diagnostic pop
+  font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightLight];
   if (font) {
     [self.fontCache setObject:font forKey:cacheKey];
   }
@@ -240,15 +233,7 @@ const CGFloat MDCTypographySecondaryOpacity = (CGFloat)0.54;
     return font;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightRegular];
-  } else {
-    font = [UIFont systemFontOfSize:fontSize];
-  }
-#pragma clang diagnostic pop
-
+  font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightRegular];
   [self.fontCache setObject:font forKey:cacheKey];
 
   return (UIFont *)font;
@@ -261,15 +246,7 @@ const CGFloat MDCTypographySecondaryOpacity = (CGFloat)0.54;
     return font;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightMedium];
-  } else {
-    font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:fontSize];
-  }
-#pragma clang diagnostic pop
-
+  font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightMedium];
   if (font) {
     [self.fontCache setObject:font forKey:cacheKey];
   }
@@ -283,14 +260,7 @@ const CGFloat MDCTypographySecondaryOpacity = (CGFloat)0.54;
     return font;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-    font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold];
-  } else {
-    font = [UIFont boldSystemFontOfSize:fontSize];
-  }
-#pragma clang diagnostic pop
+  font = [UIFont systemFontOfSize:fontSize weight:UIFontWeightSemibold];
 
   [self.fontCache setObject:font forKey:cacheKey];
 

--- a/components/Typography/src/UIFontDescriptor+MaterialTypography.m
+++ b/components/Typography/src/UIFontDescriptor+MaterialTypography.m
@@ -36,17 +36,8 @@
   dispatch_once(&onceToken, ^{
     UIFont *smallSystemFont;
     UIFont *largeSystemFont;
-    if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-      smallSystemFont = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
-      largeSystemFont = [UIFont systemFontOfSize:20 weight:UIFontWeightRegular];
-#pragma clang diagnostic pop
-    } else {
-      // TODO: Remove this fallback once we are 8.2+
-      smallSystemFont = [UIFont systemFontOfSize:12];
-      largeSystemFont = [UIFont systemFontOfSize:20];
-    }
+    smallSystemFont = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+    largeSystemFont = [UIFont systemFontOfSize:20 weight:UIFontWeightRegular];
     smallSystemFontFamilyName = [smallSystemFont.familyName copy];
     largeSystemFontFamilyName = [largeSystemFont.familyName copy];
   });

--- a/components/Typography/tests/unit/SystemFontLoaderTests.m
+++ b/components/Typography/tests/unit/SystemFontLoaderTests.m
@@ -27,27 +27,14 @@
   MDCSystemFontLoader *fontLoader = [[MDCSystemFontLoader alloc] init];
 
   // Then
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-    XCTAssertEqual([fontLoader lightFontOfSize:size], [UIFont systemFontOfSize:size
-                                                                        weight:UIFontWeightLight]);
-    XCTAssertEqual([fontLoader regularFontOfSize:size],
-                   [UIFont systemFontOfSize:size weight:UIFontWeightRegular]);
-    XCTAssertEqual([fontLoader mediumFontOfSize:size],
-                   [UIFont systemFontOfSize:size weight:UIFontWeightMedium]);
-    XCTAssertEqual([fontLoader boldFontOfSize:size],
-                   [UIFont systemFontOfSize:size weight:UIFontWeightSemibold]);
-#pragma clang diagnostic pop
-  } else {
-    // Fallback on earlier versions
-    XCTAssertEqual([fontLoader lightFontOfSize:size], [UIFont fontWithName:@"HelveticaNeue-Light"
-                                                                      size:size]);
-    XCTAssertEqual([fontLoader regularFontOfSize:size], [UIFont systemFontOfSize:size]);
-    XCTAssertEqual([fontLoader mediumFontOfSize:size], [UIFont fontWithName:@"HelveticaNeue-Medium"
-                                                                       size:size]);
-    XCTAssertEqual([fontLoader boldFontOfSize:size], [UIFont boldSystemFontOfSize:size]);
-  }
+  XCTAssertEqual([fontLoader lightFontOfSize:size], [UIFont systemFontOfSize:size
+                                                                      weight:UIFontWeightLight]);
+  XCTAssertEqual([fontLoader regularFontOfSize:size],
+                 [UIFont systemFontOfSize:size weight:UIFontWeightRegular]);
+  XCTAssertEqual([fontLoader mediumFontOfSize:size], [UIFont systemFontOfSize:size
+                                                                       weight:UIFontWeightMedium]);
+  XCTAssertEqual([fontLoader boldFontOfSize:size], [UIFont systemFontOfSize:size
+                                                                     weight:UIFontWeightSemibold]);
   UIFontDescriptor *fontDescriptorWithBoldItalic = [[UIFont systemFontOfSize:size].fontDescriptor
       fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic];
   XCTAssertEqual([fontLoader boldItalicFontOfSize:size],

--- a/components/Typography/tests/unit/TypographyTests.m
+++ b/components/Typography/tests/unit/TypographyTests.m
@@ -350,15 +350,7 @@ static const CGFloat kOpacityMedium = (CGFloat)0.87;
     // When
     MDCFontTextStyle style = styleObject.integerValue;
     UIFont *mdcFont = [UIFont mdc_preferredFontForMaterialTextStyle:style];
-    UIFont *systemFont;
-    if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-      systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
-    } else {
-      systemFont = [UIFont systemFontOfSize:mdcFont.pointSize];
-    }
-#pragma clang diagnostic pop
+    UIFont *systemFont = [UIFont systemFontOfSize:mdcFont.pointSize weight:UIFontWeightRegular];
 
     // Then
     XCTAssertEqualObjects(systemFont.familyName, mdcFont.familyName);
@@ -367,15 +359,7 @@ static const CGFloat kOpacityMedium = (CGFloat)0.87;
 
 - (void)testExtendedDescription {
   // Given
-  UIFont *systemFont;
-  if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-    systemFont = [UIFont systemFontOfSize:22.0 weight:UIFontWeightRegular];
-  } else {
-    systemFont = [UIFont systemFontOfSize:22.0];
-  }
-#pragma clang diagnostic pop
+  UIFont *systemFont = [UIFont systemFontOfSize:22.0 weight:UIFontWeightRegular];
   XCTAssertNotNil(systemFont);
 
   // When


### PR DESCRIPTION
Removing conditional checks and guards for the API since we now support iOS 9
as the minimum iOS version and no longer support Xcode 9.

Part of #8580