### PR TITLE
[Catalog] Remove checks for `systemFontOfSize:weight:`

### DIFF
--- a/catalog/MaterialCatalog/MDCCatalogTiles.m
+++ b/catalog/MaterialCatalog/MDCCatalogTiles.m
@@ -2531,15 +2531,7 @@ void MDCCatalogDrawNavigationBarTile(CGRect frame, id<MDCColorScheming> colorSch
       NSMutableParagraphStyle* labelStyle = [NSMutableParagraphStyle new];
       labelStyle.alignment = NSTextAlignmentCenter;
 
-      UIFont* font;
-      if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
-        font = [UIFont systemFontOfSize:11 weight:UIFontWeightMedium];
-#pragma clang diagnostic pop
-      } else {
-        font = [UIFont systemFontOfSize:11];
-      }
+      UIFont* font = [UIFont systemFontOfSize:11 weight:UIFontWeightMedium];
       NSDictionary* labelFontAttributes = @{
         NSFontAttributeName : font,
         NSForegroundColorAttributeName : textForeground,


### PR DESCRIPTION
Removing conditional checks and guards for the API since we now support iOS 9
as the minimum iOS version and no longer support Xcode 9.

Tested by forcing this function to be called. It's not currently used (dead code).

Part of #8580