### PR TITLE
[Releasing] Specify origin when checking out stable's .gitattributes

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -142,7 +142,7 @@ cut_release() {
   fi
   echo $branch_message
   git checkout -b release-candidate $branch
-  git checkout stable -- .gitattributes
+  git checkout origin/stable -- .gitattributes
 
   touch "$rootdir/CHANGELOG.md"
   if ! grep "# #develop#" "$rootdir/CHANGELOG.md" >> /dev/null; then


### PR DESCRIPTION
The problem is that when you have a fresh clone (and you're not doing a hotfix) the "branch" variable in `scripts/release` points to `origin/develop`. There is no notion of a local stable branch. So commands like the one this PR changes need to specify a remote.

Closes #8585.