### PR TITLE
[Chips] Fold supplemental code into the examples.

### DIFF
--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -56,7 +56,7 @@
   // Action chips should allow single selection, collection view default is based on single
   // selection. Note that MDCChipCollectionViewCell manages the state of the chip accordingly.
   self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
-                                       collectionViewLayout:layout];
+                                           collectionViewLayout:layout];
   self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
@@ -69,7 +69,7 @@
   self.collectionView.backgroundColor = [UIColor whiteColor];
   self.collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
   [self.collectionView registerClass:[MDCChipCollectionViewCell class]
-      forCellWithReuseIdentifier:@"Cell"];
+          forCellWithReuseIdentifier:@"Cell"];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;

--- a/components/Chips/examples/ChipsActionExampleViewController.m
+++ b/components/Chips/examples/ChipsActionExampleViewController.m
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
 
-@implementation ChipsActionExampleViewController {
-  UICollectionView *_collectionView;
-  BOOL _isOutlined;
-}
+@interface ChipsActionExampleViewController
+    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
+@property(nonatomic, strong) NSArray<NSString *> *titles;
+@property(nonatomic, strong) UICollectionView *collectionView;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, assign, getter=isOutlined) BOOL outlined;
+@end
+
+@implementation ChipsActionExampleViewController
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -30,8 +33,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.titles = @[
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _titles = @[
       @"Change Title to Action 0",
       @"Change Title to Action 1",
       @"Change Title to Action 2",
@@ -52,33 +55,33 @@
 
   // Action chips should allow single selection, collection view default is based on single
   // selection. Note that MDCChipCollectionViewCell manages the state of the chip accordingly.
-  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+  self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
                                        collectionViewLayout:layout];
-  _collectionView.autoresizingMask =
+  self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   // Since there is no scrolling turning off the delaysContentTouches makes the cells respond faster
-  _collectionView.delaysContentTouches = NO;
+  self.collectionView.delaysContentTouches = NO;
 
   // Collection view setup
-  _collectionView.dataSource = self;
-  _collectionView.delegate = self;
-  _collectionView.backgroundColor = [UIColor whiteColor];
-  _collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
-  [_collectionView registerClass:[MDCChipCollectionViewCell class]
+  self.collectionView.dataSource = self;
+  self.collectionView.delegate = self;
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+  self.collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
+  [self.collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"Cell"];
 
   if (@available(iOS 11.0, *)) {
-    _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
 
-  [self.view addSubview:_collectionView];
+  [self.view addSubview:self.collectionView];
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  _isOutlined = NO;
+  self.outlined = NO;
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithTitle:@"Outlined Style"
                                        style:UIBarButtonItemStylePlain
@@ -94,19 +97,19 @@
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification {
-  [_collectionView.collectionViewLayout invalidateLayout];
+  [self.collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)switchStyle {
-  _isOutlined = !_isOutlined;
-  NSString *buttonTitle = _isOutlined ? @"Filled Style" : @"Outlined Style";
+  self.outlined = !self.outlined;
+  NSString *buttonTitle = self.outlined ? @"Filled Style" : @"Outlined Style";
   [self.navigationItem.rightBarButtonItem setTitle:buttonTitle];
-  NSArray *indexPaths = [_collectionView indexPathsForSelectedItems];
-  [_collectionView reloadData];
+  NSArray *indexPaths = [self.collectionView indexPathsForSelectedItems];
+  [self.collectionView reloadData];
   for (NSIndexPath *path in indexPaths) {
-    [_collectionView selectItemAtIndexPath:path
-                                  animated:NO
-                            scrollPosition:UICollectionViewScrollPositionNone];
+    [self.collectionView selectItemAtIndexPath:path
+                                      animated:NO
+                                scrollPosition:UICollectionViewScrollPositionNone];
   }
 }
 
@@ -115,8 +118,8 @@
   return self.titles.count;
 }
 
-- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-                           cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   MDCChipView *chipView = cell.chipView;
@@ -127,7 +130,7 @@
   chipView.titleLabel.text = self.titles[indexPath.row];
 
   // Apply Theming
-  if (_isOutlined) {
+  if (self.outlined) {
     [chipView applyOutlinedThemeWithScheme:self.containerScheme];
   } else {
     [chipView applyThemeWithScheme:self.containerScheme];
@@ -145,6 +148,18 @@
 
   // Do the action related to the chip
   [self setTitle:[NSString stringWithFormat:@"Action %d", (int)indexPath.row]];
+}
+
+@end
+
+@implementation ChipsActionExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Action" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES,
+  };
 }
 
 @end

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
 
-@interface ChipsChoiceExampleViewController ()
+@interface ChipsChoiceExampleViewController
+    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
+@property(nonatomic, strong) NSArray<NSString *> *titles;
+@property(nonatomic, strong) UICollectionView *collectionView;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @property(nonatomic, assign, getter=isOutlined) BOOL outlined;
 @end
 
@@ -31,8 +33,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.titles = @[
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _titles = @[
       @"The Bronx",
       @"Brooklyn",
       @"Manhattan",
@@ -45,6 +47,7 @@
 
 - (void)loadView {
   [super loadView];
+
   self.view.backgroundColor = [UIColor whiteColor];
 
   // Our preferred CollectionView Layout For chips
@@ -53,27 +56,27 @@
   MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
   layout.estimatedItemSize = [cell intrinsicContentSize];
 
-  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+  self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
                                        collectionViewLayout:layout];
-  _collectionView.autoresizingMask =
+  self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   // Since there is no scrolling turning off the delaysContentTouches makes the cells respond faster
-  _collectionView.delaysContentTouches = NO;
+  self.collectionView.delaysContentTouches = NO;
 
   // Collection view setup
-  _collectionView.dataSource = self;
-  _collectionView.delegate = self;
-  _collectionView.backgroundColor = [UIColor whiteColor];
-  _collectionView.contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
-  [_collectionView registerClass:[MDCChipCollectionViewCell class]
+  self.collectionView.dataSource = self;
+  self.collectionView.delegate = self;
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+  self.collectionView.contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
+  [self.collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"Cell"];
 
   if (@available(iOS 11.0, *)) {
-    _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
   }
 
-  [self.view addSubview:_collectionView];
+  [self.view addSubview:self.collectionView];
 }
 
 - (void)viewDidLoad {
@@ -95,17 +98,17 @@
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification {
-  [_collectionView.collectionViewLayout invalidateLayout];
+  [self.collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)switchStyle {
   self.outlined = !self.isOutlined;
   NSString *buttonTitle = self.isOutlined ? @"Filled Style" : @"Outlined Style";
   [self.navigationItem.rightBarButtonItem setTitle:buttonTitle];
-  NSArray *indexPaths = [_collectionView indexPathsForSelectedItems];
-  [_collectionView reloadData];
+  NSArray *indexPaths = [self.collectionView indexPathsForSelectedItems];
+  [self.collectionView reloadData];
   for (NSIndexPath *path in indexPaths) {
-    [_collectionView selectItemAtIndexPath:path
+    [self.collectionView selectItemAtIndexPath:path
                                   animated:NO
                             scrollPosition:UICollectionViewScrollPositionNone];
   }
@@ -116,8 +119,8 @@
   return self.titles.count;
 }
 
-- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-                           cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   MDCChipView *chipView = cell.chipView;
@@ -136,6 +139,18 @@
   }
 
   return cell;
+}
+
+@end
+
+@implementation ChipsChoiceExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Choice" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES,
+  };
 }
 
 @end

--- a/components/Chips/examples/ChipsChoiceExampleViewController.m
+++ b/components/Chips/examples/ChipsChoiceExampleViewController.m
@@ -57,7 +57,7 @@
   layout.estimatedItemSize = [cell intrinsicContentSize];
 
   self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
-                                       collectionViewLayout:layout];
+                                           collectionViewLayout:layout];
   self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
@@ -70,7 +70,7 @@
   self.collectionView.backgroundColor = [UIColor whiteColor];
   self.collectionView.contentInset = UIEdgeInsetsMake(20, 20, 20, 20);
   [self.collectionView registerClass:[MDCChipCollectionViewCell class]
-      forCellWithReuseIdentifier:@"Cell"];
+          forCellWithReuseIdentifier:@"Cell"];
 
   if (@available(iOS 11.0, *)) {
     self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAlways;
@@ -109,8 +109,8 @@
   [self.collectionView reloadData];
   for (NSIndexPath *path in indexPaths) {
     [self.collectionView selectItemAtIndexPath:path
-                                  animated:NO
-                            scrollPosition:UICollectionViewScrollPositionNone];
+                                      animated:NO
+                                scrollPosition:UICollectionViewScrollPositionNone];
   }
 }
 

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 
 #import "supplemental/ChipsExampleAssets.h"
 
-@implementation ChipsCustomizedExampleViewController {
-  UICollectionView *_collectionView;
-}
+@interface ChipsCustomizedExampleViewController
+    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
+@property(nonatomic, strong) NSArray<NSString *> *titles;
+@property(nonatomic, strong) UICollectionView *collectionView;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@end
+
+@implementation ChipsCustomizedExampleViewController
 
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -30,8 +33,8 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
-    self.titles = @[
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _titles = @[
       @"Doorman",
       @"Elevator",
       @"Garage Parking",
@@ -77,20 +80,20 @@
   MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
   layout.estimatedItemSize = [cell intrinsicContentSize];
 
-  _collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+  self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
                                        collectionViewLayout:layout];
-  _collectionView.autoresizingMask =
+  self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _collectionView.dataSource = self;
-  _collectionView.delegate = self;
-  _collectionView.allowsMultipleSelection = YES;
-  _collectionView.backgroundColor = [UIColor whiteColor];
-  _collectionView.delaysContentTouches = NO;
-  _collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
-  [_collectionView registerClass:[MDCChipCollectionViewCell class]
+  self.collectionView.dataSource = self;
+  self.collectionView.delegate = self;
+  self.collectionView.allowsMultipleSelection = YES;
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+  self.collectionView.delaysContentTouches = NO;
+  self.collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
+  [self.collectionView registerClass:[MDCChipCollectionViewCell class]
       forCellWithReuseIdentifier:@"MDCChipCollectionViewCell"];
 
-  [self.view addSubview:_collectionView];
+  [self.view addSubview:self.collectionView];
 }
 
 - (void)viewDidLoad {
@@ -105,7 +108,7 @@
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification {
-  [_collectionView.collectionViewLayout invalidateLayout];
+  [self.collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView
@@ -113,8 +116,8 @@
   return self.titles.count;
 }
 
-- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-                           cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"MDCChipCollectionViewCell"
                                                 forIndexPath:indexPath];
@@ -136,6 +139,18 @@
 - (void)collectionView:(UICollectionView *)collectionView
     didDeselectItemAtIndexPath:(NSIndexPath *)indexPath {
   [collectionView performBatchUpdates:nil completion:nil];
+}
+
+@end
+
+@implementation ChipsCustomizedExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Customized" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
 }
 
 @end

--- a/components/Chips/examples/ChipsCustomizedExampleViewController.m
+++ b/components/Chips/examples/ChipsCustomizedExampleViewController.m
@@ -81,7 +81,7 @@
   layout.estimatedItemSize = [cell intrinsicContentSize];
 
   self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
-                                       collectionViewLayout:layout];
+                                           collectionViewLayout:layout];
   self.collectionView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.collectionView.dataSource = self;
@@ -91,7 +91,7 @@
   self.collectionView.delaysContentTouches = NO;
   self.collectionView.contentInset = UIEdgeInsetsMake(4, 8, 4, 8);
   [self.collectionView registerClass:[MDCChipCollectionViewCell class]
-      forCellWithReuseIdentifier:@"MDCChipCollectionViewCell"];
+          forCellWithReuseIdentifier:@"MDCChipCollectionViewCell"];
 
   [self.view addSubview:self.collectionView];
 }

--- a/components/Chips/examples/ChipsInputExampleViewController.m
+++ b/components/Chips/examples/ChipsInputExampleViewController.m
@@ -12,24 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
 #import "MaterialTextFields.h"
 
-@interface ChipsInputExampleViewController () <MDCChipFieldDelegate>
+@interface ChipsInputExampleViewController : UIViewController <MDCChipFieldDelegate>
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, strong) MDCChipField *chipField;
 @end
 
-@implementation ChipsInputExampleViewController {
-  MDCChipField *_chipField;
-}
+@implementation ChipsInputExampleViewController
 
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -45,18 +43,18 @@
     self.view.backgroundColor = colorScheme.backgroundColor;
   }
 
-  _chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
-  _chipField.delegate = self;
-  _chipField.textField.placeholderLabel.text = @"This is a chip field.";
-  _chipField.textField.mdc_adjustsFontForContentSizeCategory = YES;
+  self.chipField = [[MDCChipField alloc] initWithFrame:CGRectZero];
+  self.chipField.delegate = self;
+  self.chipField.textField.placeholderLabel.text = @"This is a chip field.";
+  self.chipField.textField.mdc_adjustsFontForContentSizeCategory = YES;
   if (self.containerScheme.colorScheme) {
-    _chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
+    self.chipField.backgroundColor = self.containerScheme.colorScheme.surfaceColor;
   } else {
     MDCSemanticColorScheme *colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _chipField.backgroundColor = colorScheme.surfaceColor;
+    self.chipField.backgroundColor = colorScheme.surfaceColor;
   }
-  [self.view addSubview:_chipField];
+  [self.view addSubview:self.chipField];
 
   // When Dynamic Type changes we need to invalidate the collection view layout in order to let the
   // cells change their dimensions because our chips use manual layout.
@@ -81,10 +79,10 @@
   if (@available(iOS 11.0, *)) {
     frame = UIEdgeInsetsInsetRect(frame, self.view.safeAreaInsets);
   }
-  MDCChipView *chip = _chipField.chips.lastObject;
+  MDCChipView *chip = self.chipField.chips.lastObject;
   [self recomputeChipFieldChipHeightWithChip:chip];
-  frame.size = [_chipField sizeThatFits:frame.size];
-  _chipField.frame = frame;
+  frame.size = [self.chipField sizeThatFits:frame.size];
+  self.chipField.frame = frame;
 }
 
 - (void)chipFieldHeightDidChange:(MDCChipField *)chipField {
@@ -108,8 +106,20 @@
 - (void)recomputeChipFieldChipHeightWithChip:(MDCChipView *)chip {
   [chip sizeToFit];
   if (chip.frame.size.height > 0) {
-    _chipField.chipHeight = chip.frame.size.height;
+    self.chipField.chipHeight = chip.frame.size.height;
   }
+}
+
+@end
+
+@implementation ChipsInputExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Input" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES,
+  };
 }
 
 @end

--- a/components/Chips/examples/ChipsShapingExampleViewController.m
+++ b/components/Chips/examples/ChipsShapingExampleViewController.m
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialContainerScheme.h"
@@ -24,17 +22,20 @@
 
 #import "supplemental/ChipsExampleAssets.h"
 
-@implementation ChipsShapingExampleViewController {
-  MDCChipView *_chipView;
-  MDCSlider *_cornerSlider;
-  MDCRectangleShapeGenerator *_rectangleShapeGenerator;
-  UISegmentedControl *_cornerStyleControl;
-}
+@interface ChipsShapingExampleViewController : UIViewController
+@property(nonatomic, strong) MDCChipView *chipView;
+@property(nonatomic, strong) MDCSlider *cornerSlider;
+@property(nonatomic, strong) MDCRectangleShapeGenerator *rectangleShapeGenerator;
+@property(nonatomic, strong) UISegmentedControl *cornerStyleControl;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@end
+
+@implementation ChipsShapingExampleViewController
 
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -44,83 +45,97 @@
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _rectangleShapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
+  self.rectangleShapeGenerator = [[MDCRectangleShapeGenerator alloc] init];
 
-  _chipView = [[MDCChipView alloc] init];
-  _chipView.titleLabel.text = @"Material";
-  _chipView.imageView.image = ChipsExampleAssets.faceImage;
-  _chipView.accessoryView = ChipsExampleAssets.deleteButton;
-  _chipView.imagePadding = UIEdgeInsetsMake(0, 10, 0, 0);
-  _chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
-  CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
-  _chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
-  [_chipView applyThemeWithScheme:self.containerScheme];
-  _chipView.shapeGenerator = _rectangleShapeGenerator;
-  [self.view addSubview:_chipView];
+  self.chipView = [[MDCChipView alloc] init];
+  self.chipView.titleLabel.text = @"Material";
+  self.chipView.imageView.image = ChipsExampleAssets.faceImage;
+  self.chipView.accessoryView = ChipsExampleAssets.deleteButton;
+  self.chipView.imagePadding = UIEdgeInsetsMake(0, 10, 0, 0);
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
+  CGSize chipSize = [self.chipView sizeThatFits:self.view.bounds.size];
+  self.chipView.frame = CGRectMake(20, 20, chipSize.width + 20, chipSize.height + 20);
+  [self.chipView applyThemeWithScheme:self.containerScheme];
+  self.chipView.shapeGenerator = self.rectangleShapeGenerator;
+  [self.view addSubview:self.chipView];
 
-  _cornerSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
-  _cornerSlider.maximumValue =
-      MIN(CGRectGetWidth(_chipView.bounds), CGRectGetHeight(_chipView.bounds)) / 2;
-  _cornerSlider.value = _cornerSlider.maximumValue / 2;
-  [_cornerSlider addTarget:self
-                    action:@selector(cornerSliderChanged:)
-          forControlEvents:UIControlEventValueChanged];
+  self.cornerSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
+  self.cornerSlider.maximumValue =
+      MIN(CGRectGetWidth(self.chipView.bounds), CGRectGetHeight(self.chipView.bounds)) / 2;
+  self.cornerSlider.value = self.cornerSlider.maximumValue / 2;
+  [self.cornerSlider addTarget:self
+                        action:@selector(cornerSliderChanged:)
+              forControlEvents:UIControlEventValueChanged];
   if (self.containerScheme.colorScheme) {
     [MDCSliderColorThemer applySemanticColorScheme:self.containerScheme.colorScheme
-                                          toSlider:_cornerSlider];
+                                          toSlider:self.cornerSlider];
   } else {
     MDCSemanticColorScheme *colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    [MDCSliderColorThemer applySemanticColorScheme:colorScheme toSlider:_cornerSlider];
+    [MDCSliderColorThemer applySemanticColorScheme:colorScheme toSlider:self.cornerSlider];
   }
-  [self.view addSubview:_cornerSlider];
+  [self.view addSubview:self.cornerSlider];
 
-  _cornerStyleControl = [[UISegmentedControl alloc] initWithItems:@[ @"Rounded", @"Cut", @"None" ]];
-  _cornerStyleControl.selectedSegmentIndex = 0;
-  [_cornerStyleControl addTarget:self
-                          action:@selector(cornerStyleChanged:)
-                forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:_cornerStyleControl];
+  self.cornerStyleControl =
+      [[UISegmentedControl alloc] initWithItems:@[ @"Rounded", @"Cut", @"None" ]];
+  self.cornerStyleControl.selectedSegmentIndex = 0;
+  [self.cornerStyleControl addTarget:self
+                              action:@selector(cornerStyleChanged:)
+                    forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:self.cornerStyleControl];
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  CGSize sliderSize = [_cornerSlider sizeThatFits:self.view.bounds.size];
-  _cornerSlider.frame = CGRectMake(20, 140, self.view.bounds.size.width - 40, sliderSize.height);
-  _cornerSlider.frame = CGRectMake(20, 140 + sliderSize.height + 20,
-                                   self.view.bounds.size.width - 40, sliderSize.height);
-  _cornerStyleControl.frame =
-      CGRectMake(20, CGRectGetMaxY(_cornerSlider.frame) + 20, self.view.bounds.size.width - 40,
-                 _cornerStyleControl.frame.size.height);
+  CGSize sliderSize = [self.cornerSlider sizeThatFits:self.view.bounds.size];
+  self.cornerSlider.frame =
+      CGRectMake(20, 140, self.view.bounds.size.width - 40, sliderSize.height);
+  self.cornerSlider.frame = CGRectMake(20, 140 + sliderSize.height + 20,
+                                       self.view.bounds.size.width - 40, sliderSize.height);
+  self.cornerStyleControl.frame =
+      CGRectMake(20, CGRectGetMaxY(self.cornerSlider.frame) + 20, self.view.bounds.size.width - 40,
+                 self.cornerStyleControl.frame.size.height);
 
-  [self cornerSliderChanged:_cornerSlider];
+  [self cornerSliderChanged:self.cornerSlider];
 }
 
 - (void)cornerSliderChanged:(MDCSlider *)slider {
-  if (_cornerStyleControl.selectedSegmentIndex == 0) {
+  if (self.cornerStyleControl.selectedSegmentIndex == 0) {
     // Rounded
     MDCRoundedCornerTreatment *roundedCorners =
         [[MDCRoundedCornerTreatment alloc] initWithRadius:slider.value];
-    [_rectangleShapeGenerator setCorners:roundedCorners];
-  } else if (_cornerStyleControl.selectedSegmentIndex == 1) {
+    [self.rectangleShapeGenerator setCorners:roundedCorners];
+  } else if (self.cornerStyleControl.selectedSegmentIndex == 1) {
     // Cut
     MDCCutCornerTreatment *cutCorners = [[MDCCutCornerTreatment alloc] initWithCut:slider.value];
-    [_rectangleShapeGenerator setCorners:cutCorners];
+    [self.rectangleShapeGenerator setCorners:cutCorners];
   }
-  [_chipView setNeedsLayout];
+  [self.chipView setNeedsLayout];
 }
 
 - (void)cornerStyleChanged:(UISegmentedControl *)segmentedControl {
   if (segmentedControl.selectedSegmentIndex == 2) {
-    _chipView.shapeGenerator = nil;
-    _cornerSlider.hidden = YES;
+    self.chipView.shapeGenerator = nil;
+    self.cornerSlider.hidden = YES;
   } else {
-    _chipView.shapeGenerator = _rectangleShapeGenerator;
-    _cornerSlider.hidden = NO;
+    self.chipView.shapeGenerator = self.rectangleShapeGenerator;
+    self.cornerSlider.hidden = NO;
   }
-  _cornerSlider.value = _cornerSlider.maximumValue / 2;
-  [self cornerSliderChanged:_cornerSlider];
+  self.cornerSlider.value = self.cornerSlider.maximumValue / 2;
+  [self cornerSliderChanged:self.cornerSlider];
+}
+
+@end
+
+@implementation ChipsShapingExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Shaped Chip" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
 }
 
 @end

--- a/components/Chips/examples/ChipsSizingExampleViewController.m
+++ b/components/Chips/examples/ChipsSizingExampleViewController.m
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "supplemental/ChipsExamplesSupplemental.h"
-
 #import "MaterialChips+Theming.h"
 #import "MaterialChips.h"
 #import "MaterialSlider.h"
 
 #import "supplemental/ChipsExampleAssets.h"
 
-@implementation ChipsSizingExampleViewController {
-  MDCChipView *_chipView;
-  MDCSlider *_widthSlider;
-  MDCSlider *_heightSlider;
-  UISegmentedControl *_horizontalAlignmentControl;
-}
+@interface ChipsSizingExampleViewController : UIViewController
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+@property(nonatomic, strong) MDCChipView *chipView;
+@property(nonatomic, strong) MDCSlider *widthSlider;
+@property(nonatomic, strong) MDCSlider *heightSlider;
+@property(nonatomic, strong) UISegmentedControl *horizontalAlignmentControl;
+@end
+
+@implementation ChipsSizingExampleViewController
 
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -40,73 +41,85 @@
 
   self.view.backgroundColor = [UIColor whiteColor];
 
-  _chipView = [[MDCChipView alloc] init];
-  _chipView.titleLabel.text = @"Material";
-  _chipView.imageView.image = ChipsExampleAssets.faceImage;
-  _chipView.accessoryView = ChipsExampleAssets.deleteButton;
-  [_chipView applyThemeWithScheme:self.containerScheme];
-  [self.view addSubview:_chipView];
+  self.chipView = [[MDCChipView alloc] init];
+  self.chipView.titleLabel.text = @"Material";
+  self.chipView.imageView.image = ChipsExampleAssets.faceImage;
+  self.chipView.accessoryView = ChipsExampleAssets.deleteButton;
+  [self.chipView applyThemeWithScheme:self.containerScheme];
+  [self.view addSubview:self.chipView];
 
-  CGSize chipSize = [_chipView sizeThatFits:self.view.bounds.size];
-  _chipView.frame = (CGRect){CGPointMake(20, 20), chipSize};
+  CGSize chipSize = [self.chipView sizeThatFits:self.view.bounds.size];
+  self.chipView.frame = (CGRect){CGPointMake(20, 20), chipSize};
 
-  _widthSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
-  _widthSlider.maximumValue = 200;
-  _widthSlider.value = _chipView.frame.size.width;
-  [_widthSlider addTarget:self
-                   action:@selector(widthSliderChanged:)
-         forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:_widthSlider];
+  self.widthSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
+  self.widthSlider.maximumValue = 200;
+  self.widthSlider.value = self.chipView.frame.size.width;
+  [self.widthSlider addTarget:self
+                       action:@selector(widthSliderChanged:)
+             forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:self.widthSlider];
 
-  _heightSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
-  _heightSlider.maximumValue = 100;
-  _heightSlider.value = _chipView.frame.size.height;
-  [_heightSlider addTarget:self
-                    action:@selector(heightSliderChanged:)
-          forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:_heightSlider];
+  self.heightSlider = [[MDCSlider alloc] initWithFrame:CGRectZero];
+  self.heightSlider.maximumValue = 100;
+  self.heightSlider.value = self.chipView.frame.size.height;
+  [self.heightSlider addTarget:self
+                        action:@selector(heightSliderChanged:)
+              forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:self.heightSlider];
 
-  _horizontalAlignmentControl =
+  self.horizontalAlignmentControl =
       [[UISegmentedControl alloc] initWithItems:@[ @"Default", @"Centered" ]];
-  _horizontalAlignmentControl.selectedSegmentIndex = 0;
-  [_horizontalAlignmentControl addTarget:self
-                                  action:@selector(horizontalAlignmentChanged:)
-                        forControlEvents:UIControlEventValueChanged];
-  [self.view addSubview:_horizontalAlignmentControl];
+  self.horizontalAlignmentControl.selectedSegmentIndex = 0;
+  [self.horizontalAlignmentControl addTarget:self
+                                      action:@selector(horizontalAlignmentChanged:)
+                            forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:self.horizontalAlignmentControl];
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  CGSize sliderSize = [_widthSlider sizeThatFits:self.view.bounds.size];
-  _widthSlider.frame = CGRectMake(20, 140, self.view.bounds.size.width - 40, sliderSize.height);
-  _heightSlider.frame = CGRectMake(20, 140 + sliderSize.height + 20,
-                                   self.view.bounds.size.width - 40, sliderSize.height);
-  _horizontalAlignmentControl.frame =
-      CGRectMake(20, CGRectGetMaxY(_heightSlider.frame) + 20, self.view.bounds.size.width - 40,
-                 _horizontalAlignmentControl.frame.size.height);
+  CGSize sliderSize = [self.widthSlider sizeThatFits:self.view.bounds.size];
+  self.widthSlider.frame = CGRectMake(20, 140, self.view.bounds.size.width - 40, sliderSize.height);
+  self.heightSlider.frame = CGRectMake(20, 140 + sliderSize.height + 20,
+                                       self.view.bounds.size.width - 40, sliderSize.height);
+  self.horizontalAlignmentControl.frame =
+      CGRectMake(20, CGRectGetMaxY(self.heightSlider.frame) + 20, self.view.bounds.size.width - 40,
+                 self.horizontalAlignmentControl.frame.size.height);
 }
 
 - (void)widthSliderChanged:(MDCSlider *)slider {
-  CGRect frame = _chipView.frame;
+  CGRect frame = self.chipView.frame;
   frame.size.width = slider.value;
-  _chipView.frame = frame;
-  [_chipView layoutIfNeeded];
+  self.chipView.frame = frame;
+  [self.chipView layoutIfNeeded];
 }
 
 - (void)heightSliderChanged:(MDCSlider *)slider {
-  CGRect frame = _chipView.frame;
+  CGRect frame = self.chipView.frame;
   frame.size.height = slider.value;
-  _chipView.frame = frame;
-  [_chipView layoutIfNeeded];
+  self.chipView.frame = frame;
+  [self.chipView layoutIfNeeded];
 }
 
 - (void)horizontalAlignmentChanged:(UISegmentedControl *)segmentedControl {
   UIControlContentHorizontalAlignment alignment = (segmentedControl.selectedSegmentIndex == 0)
                                                       ? UIControlContentHorizontalAlignmentFill
                                                       : UIControlContentHorizontalAlignmentCenter;
-  _chipView.contentHorizontalAlignment = alignment;
-  [_chipView layoutIfNeeded];
+  self.chipView.contentHorizontalAlignment = alignment;
+  [self.chipView layoutIfNeeded];
+}
+
+@end
+
+@implementation ChipsSizingExampleViewController (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Chips", @"Sizing" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
 }
 
 @end

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -21,28 +21,8 @@
 @interface ExampleChipCollectionViewController : UICollectionViewController
 @end
 
-@interface ChipsChoiceExampleViewController
-    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
-@property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
-@interface ChipsActionExampleViewController
-    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
-@property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) UICollectionView *collectionView;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
 @interface ChipsCollectionExampleViewController
     : ExampleChipCollectionViewController <UICollectionViewDelegate, UICollectionViewDataSource>
-@property(nonatomic, strong) NSArray<NSString *> *titles;
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
-@interface ChipsCustomizedExampleViewController
-    : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @property(nonatomic, strong) NSArray<NSString *> *titles;
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -44,7 +44,3 @@
 @property(nonatomic, strong) NSArray<ChipModel *> *model;
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
-
-@interface ChipsShapingExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.h
@@ -37,14 +37,6 @@
     : ChipsFilterExampleViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 @end
 
-@interface ChipsInputExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
-@interface ChipsSizingExampleViewController : UIViewController
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-@end
-
 @interface ChipsTypicalUseViewController
     : ExampleChipCollectionViewController <UICollectionViewDelegate,
                                            UICollectionViewDataSource,

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -78,33 +78,6 @@
 
 @end
 
-@interface ChipsInputExampleViewController (Supplemental)
-@end
-
-@implementation ChipsInputExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Input" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @YES,
-  };
-}
-
-@end
-
-@implementation ChipsSizingExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Sizing" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @NO,
-  };
-}
-
-@end
-
 @implementation ChipsTypicalUseViewController (Supplemental)
 
 + (NSDictionary *)catalogMetadata {

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -39,36 +39,6 @@
 
 @end
 
-@interface ChipsChoiceExampleViewController (Supplemental)
-@end
-
-@implementation ChipsChoiceExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Choice" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @YES,
-  };
-}
-
-@end
-
-@interface ChipsActionExampleViewController (Supplemental)
-@end
-
-@implementation ChipsActionExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Action" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @YES,
-  };
-}
-
-@end
-
 @interface ChipsCollectionExampleViewController (Supplemental)
 @end
 
@@ -77,18 +47,6 @@
 + (NSDictionary *)catalogMetadata {
   return @{
     @"breadcrumbs" : @[ @"Chips", @"Collections" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @NO,
-  };
-}
-
-@end
-
-@implementation ChipsCustomizedExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Customized" ],
     @"primaryDemo" : @NO,
     @"presentable" : @NO,
   };

--- a/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
+++ b/components/Chips/examples/supplemental/ChipsExamplesSupplemental.m
@@ -90,15 +90,3 @@
 }
 
 @end
-
-@implementation ChipsShapingExampleViewController (Supplemental)
-
-+ (NSDictionary *)catalogMetadata {
-  return @{
-    @"breadcrumbs" : @[ @"Chips", @"Shaped Chip" ],
-    @"primaryDemo" : @NO,
-    @"presentable" : @NO,
-  };
-}
-
-@end


### PR DESCRIPTION
Also aligned the examples to consistently make use of properties instead of ivars.

ivar -> property replacement done using the following regexp:

- Find: `_(\w+)`
- Replace: `self.$1`

Cleaned up the following examples:

- ChipsActionExampleViewController
- ChipsChoiceExampleViewController
- ChipsCustomizedExampleViewController
- ChipsInputExampleViewController
- ChipsSizingExampleViewController
- ChipsShapingExampleViewController

Polish as part of https://github.com/material-components/material-components-ios/issues/8459