### PR TITLE
[Dialogs] Explicitly set title and message color

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -495,6 +495,12 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
+  if (self.titleColor == nil) {
+    self.alertView.titleColor = UIColor.blackColor;
+  }
+  if (self.messageColor == nil) {
+    self.alertView.messageColor = UIColor.blackColor;
+  }
   // Recalculate preferredSize, which is based on width available, if the viewSize has changed.
   if (CGRectGetWidth(self.view.bounds) != _previousLayoutSize.width ||
       CGRectGetHeight(self.view.bounds) != _previousLayoutSize.height) {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -419,8 +419,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.accessoryView = self.accessoryView;
   self.alertView.titleFont = self.titleFont;
   self.alertView.messageFont = self.messageFont;
-  self.alertView.titleColor = self.titleColor;
-  self.alertView.messageColor = self.messageColor;
+  self.alertView.titleColor = self.titleColor ?: UIColor.blackColor;
+  self.alertView.messageColor = self.messageColor ?: UIColor.blackColor;
   self.alertView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable =
       self.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
   if (self.backgroundColor) {
@@ -495,12 +495,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  if (self.titleColor == nil) {
-    self.alertView.titleColor = UIColor.blackColor;
-  }
-  if (self.messageColor == nil) {
-    self.alertView.messageColor = UIColor.blackColor;
-  }
   // Recalculate preferredSize, which is based on width available, if the viewSize has changed.
   if (CGRectGetWidth(self.view.bounds) != _previousLayoutSize.width ||
       CGRectGetHeight(self.view.bounds) != _previousLayoutSize.height) {


### PR DESCRIPTION
## Context
MDCAlertControllers use UILabels within the `alertView` this made it so that in dark mode the default color `UIColor.blackColor` would become a dynamic color in iOS 13 with `UIColor.blackColor` in light mode and `UIColor.whiteColor` in dark mode.

The API is `nullable` and is setting the `ivar` so will remain nullable but this no longer returns the value actually being rendered. If a client sets the value to `nil` then we render `UIColor.blackColor` as we have previously done on iOS 12 and below.

## Screenshots

#### Before
| Light mode | Dark mode |
| --- | --- |
|![Simulator Screen Shot - iPhone Xʀ - 2019-10-14 at 23 20 04](https://user-images.githubusercontent.com/7131294/66798128-0cb5cb80-eedb-11e9-9127-f9a1cbee2552.png)|![Simulator Screen Shot - iPhone Xʀ - 2019-10-14 at 23 19 43](https://user-images.githubusercontent.com/7131294/66798130-10e1e900-eedb-11e9-9bfc-ba46e24a9fe0.png)|

#### After
| Light mode | Dark mode |
| --- | --- |
|![Simulator Screen Shot - iPhone Xʀ - 2019-10-14 at 23 21 23](https://user-images.githubusercontent.com/7131294/66798143-1b9c7e00-eedb-11e9-8e28-5697a18409e3.png)|![Simulator Screen Shot - iPhone Xʀ - 2019-10-14 at 23 27 16](https://user-images.githubusercontent.com/7131294/66798149-20f9c880-eedb-11e9-9daa-63b110b0f6ec.png)|

Closes #8584 