### PR TITLE
[Chips] Deprecate MDCChipViewTypographyThemer.

### DIFF
--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -17,6 +17,7 @@
 #import "MaterialChips+ColorThemer.h"
 #import "MaterialChips+ShapeThemer.h"
 #import "MaterialChips+TypographyThemer.h"
+#import "MaterialTypography.h"
 
 @implementation MDCChipView (MaterialTheming)
 
@@ -43,7 +44,11 @@
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCChipViewTypographyThemer applyTypographyScheme:typographyScheme toChipView:self];
+  UIFont *titleFont = typographyScheme.body2;
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
+    titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
+  }
+  self.titleFont = titleFont;
 }
 
 #pragma mark - Outlined Chip

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -17,7 +17,6 @@
 #import "MaterialChips+ColorThemer.h"
 #import "MaterialChips+ShapeThemer.h"
 #import "MaterialChips+TypographyThemer.h"
-#import "MaterialTypography.h"
 
 @implementation MDCChipView (MaterialTheming)
 
@@ -44,11 +43,7 @@
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  UIFont *titleFont = typographyScheme.body2;
-  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
-    titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
-  }
-  self.titleFont = titleFont;
+  [MDCChipViewTypographyThemer applyTypographyScheme:typographyScheme toChipView:self];
 }
 
 #pragma mark - Outlined Chip

--- a/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.h
+++ b/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.h
@@ -20,10 +20,10 @@
 /**
  The Material Design typography system's themer for instances of MDCChipView.
 
- @warning This API will eventually be deprecated. See the individual method documentation for
- details on replacement APIs.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
+ @warning This API is deprecated. Learn more at
+ docs/theming.md#migration-guide-themers-to-theming-extensions
  */
+__deprecated_msg("Use Chips+Theming instead.")
 @interface MDCChipViewTypographyThemer : NSObject
 
 /**
@@ -32,11 +32,11 @@
  @param typographyScheme The typography scheme to apply to the component instance.
  @param chipView A component instance to which the typography scheme should be applied.
 
- @warning This API will eventually be deprecated. The replacement API is any of `MDCCard`'s theming
- extensions.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
+ @warning This API is deprecated. Learn more at
+ docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyTypographyScheme:(nonnull id<MDCTypographyScheming>)typographyScheme
-                   toChipView:(nonnull MDCChipView *)chipView;
+                   toChipView:(nonnull MDCChipView *)chipView
+    __deprecated_msg("Use Chips+Theming instead.");
 
 @end

--- a/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.h
+++ b/components/Chips/src/TypographyThemer/MDCChipViewTypographyThemer.h
@@ -23,8 +23,7 @@
  @warning This API is deprecated. Learn more at
  docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Use Chips+Theming instead.")
-@interface MDCChipViewTypographyThemer : NSObject
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewTypographyThemer : NSObject
 
 /**
  Applies a typography scheme's properties to an MDCChipView.


### PR DESCRIPTION
There is no internal usage of these APIs.

Part of https://github.com/material-components/material-components-ios/issues/8429

Stacked on top of https://github.com/material-components/material-components-ios/pull/8591