### PR TITLE
[Chips] Fold MDCChipViewTypographyThemer into the Theming extension.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -822,8 +822,8 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+TypographyThemer"
     extension.dependency "MaterialComponents/schemes/Container"
+    extension.dependency "MaterialComponents/Typography"
 
     extension.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -57,7 +57,7 @@ mdc_extension_objc_library(
         ":Chips",
         ":ColorThemer",
         ":ShapeThemer",
-        ":TypographyThemer",
+        "//components/Typography",
         "//components/schemes/Container",
     ],
 )

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -17,6 +17,7 @@
 #import "MaterialChips+ColorThemer.h"
 #import "MaterialChips+ShapeThemer.h"
 #import "MaterialChips+TypographyThemer.h"
+#import "MaterialTypography.h"
 
 @implementation MDCChipView (MaterialTheming)
 
@@ -43,7 +44,11 @@
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCChipViewTypographyThemer applyTypographyScheme:typographyScheme toChipView:self];
+  UIFont *titleFont = typographyScheme.body2;
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
+    titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
+  }
+  self.titleFont = titleFont;
 }
 
 #pragma mark - Outlined Chip

--- a/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
+++ b/components/Chips/src/Theming/MDCChipView+MaterialTheming.m
@@ -16,7 +16,6 @@
 
 #import "MaterialChips+ColorThemer.h"
 #import "MaterialChips+ShapeThemer.h"
-#import "MaterialChips+TypographyThemer.h"
 #import "MaterialTypography.h"
 
 @implementation MDCChipView (MaterialTheming)


### PR DESCRIPTION
MDCChipViewTypographyThemer will be deprecated and deleted as part of https://github.com/material-components/material-components-ios/issues/8429.

MDCChipViewTypographyThemer currently has no internal usage, so the logic is being folded into the Theming extension.

Part of https://github.com/material-components/material-components-ios/issues/8429
