### PR TITLE
[Chips] Deprecate Chips+ChipThemer.

### DIFF
--- a/components/Chips/src/ChipThemer/MDCChipViewScheme.h
+++ b/components/Chips/src/ChipThemer/MDCChipViewScheme.h
@@ -25,9 +25,10 @@
  An instance of this protocol can be applied to an instance of MDCChipView using any of the
  MDCChipViewThemer APIs.
 
- @warning This API will eventually be deprecated. The replacement API is: `MDCContainerScheming`.
+ @warning This API is deprecated. The replacement API is: `MDCContainerScheming`.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
+__deprecated_msg("Use Chips+Theming instead.")
 @protocol MDCChipViewScheming
 
 /**
@@ -50,9 +51,10 @@
 /**
  An MDCChipViewScheme is a mutable representation of the design parameters for an MDCChipView.
 
- @warning This API will eventually be deprecated. The replacement API is: `MDCContainerScheme`.
+ @warning This API is deprecated. The replacement API is: `MDCContainerScheme`.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
+__deprecated_msg("Use Chips+Theming instead.")
 @interface MDCChipViewScheme : NSObject <MDCChipViewScheming>
 
 /**
@@ -60,20 +62,23 @@
 
  By default, this is initialized with the latest color scheme defaults.
  */
-@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme;
+@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme
+__deprecated_msg("Use Chips+Theming instead.");
 
 /**
  A mutable representation of a shape scheme.
 
  By default, this is initialized with the latest shape scheme defaults.
  */
-@property(nonnull, readwrite, nonatomic) id<MDCShapeScheming> shapeScheme;
+@property(nonnull, readwrite, nonatomic) id<MDCShapeScheming> shapeScheme
+__deprecated_msg("Use Chips+Theming instead.");
 
 /**
  A mutable representation of a typography scheme.
 
  By default, this is initialized with the latest typography scheme defaults.
  */
-@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme;
+@property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme
+__deprecated_msg("Use Chips+Theming instead.");
 
 @end

--- a/components/Chips/src/ChipThemer/MDCChipViewScheme.h
+++ b/components/Chips/src/ChipThemer/MDCChipViewScheme.h
@@ -28,8 +28,7 @@
  @warning This API is deprecated. The replacement API is: `MDCContainerScheming`.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Use Chips+Theming instead.")
-@protocol MDCChipViewScheming
+__deprecated_msg("Use Chips+Theming instead.") @protocol MDCChipViewScheming
 
 /**
  The color scheme to apply to a chip view.
@@ -54,24 +53,24 @@ __deprecated_msg("Use Chips+Theming instead.")
  @warning This API is deprecated. The replacement API is: `MDCContainerScheme`.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Use Chips+Theming instead.")
-@interface MDCChipViewScheme : NSObject <MDCChipViewScheming>
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewScheme
+    : NSObject<MDCChipViewScheming>
 
 /**
  A mutable representation of a color scheme.
 
  By default, this is initialized with the latest color scheme defaults.
  */
-@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme
-__deprecated_msg("Use Chips+Theming instead.");
+@property(nonnull, readwrite, nonatomic) id<MDCColorScheming> colorScheme __deprecated_msg(
+    "Use Chips+Theming instead.");
 
 /**
  A mutable representation of a shape scheme.
 
  By default, this is initialized with the latest shape scheme defaults.
  */
-@property(nonnull, readwrite, nonatomic) id<MDCShapeScheming> shapeScheme
-__deprecated_msg("Use Chips+Theming instead.");
+@property(nonnull, readwrite, nonatomic) id<MDCShapeScheming> shapeScheme __deprecated_msg(
+    "Use Chips+Theming instead.");
 
 /**
  A mutable representation of a typography scheme.
@@ -79,6 +78,6 @@ __deprecated_msg("Use Chips+Theming instead.");
  By default, this is initialized with the latest typography scheme defaults.
  */
 @property(nonnull, readwrite, nonatomic) id<MDCTypographyScheming> typographyScheme
-__deprecated_msg("Use Chips+Theming instead.");
+    __deprecated_msg("Use Chips+Theming instead.");
 
 @end

--- a/components/Chips/src/ChipThemer/MDCChipViewThemer.h
+++ b/components/Chips/src/ChipThemer/MDCChipViewThemer.h
@@ -24,8 +24,7 @@
  @warning This API is deprecated. Learn more at
  + docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Use Chips+Theming instead.")
-@interface MDCChipViewThemer : NSObject
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewThemer : NSObject
 
 /**
  Applies a chip view scheme's properties to an MDCChipView.
@@ -37,8 +36,8 @@ __deprecated_msg("Use Chips+Theming instead.")
  `MDCChipView`'s `-applyThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-+ (void)applyScheme:(nonnull id<MDCChipViewScheming>)scheme toChipView:(nonnull MDCChipView *)chip
-__deprecated_msg("Use Chips+Theming instead.");
++ (void)applyScheme:(nonnull id<MDCChipViewScheming>)scheme
+         toChipView:(nonnull MDCChipView *)chip __deprecated_msg("Use Chips+Theming instead.");
 
 /**
  Applies a chip view scheme's properties to an MDCChipView using the outlined style.
@@ -52,6 +51,6 @@ __deprecated_msg("Use Chips+Theming instead.");
  */
 + (void)applyOutlinedVariantWithScheme:(nonnull id<MDCChipViewScheming>)scheme
                             toChipView:(nonnull MDCChipView *)chip
-__deprecated_msg("Use Chips+Theming instead.");
+    __deprecated_msg("Use Chips+Theming instead.");
 
 @end

--- a/components/Chips/src/ChipThemer/MDCChipViewThemer.h
+++ b/components/Chips/src/ChipThemer/MDCChipViewThemer.h
@@ -21,14 +21,11 @@
 /**
  The Material Design themer for instances of MDCChipView.
 
- @warning This API will eventually be deprecated. See the individual method documentation for
- details on replacement APIs.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
+ @warning This API is deprecated. Learn more at
+ + docs/theming.md#migration-guide-themers-to-theming-extensions
  */
+__deprecated_msg("Use Chips+Theming instead.")
 @interface MDCChipViewThemer : NSObject
-@end
-
-@interface MDCChipViewThemer (ToBeDeprecated)
 
 /**
  Applies a chip view scheme's properties to an MDCChipView.
@@ -36,11 +33,12 @@
  @param scheme The chip view scheme to apply to the component instance.
  @param chip A component instance to which the scheme should be applied.
 
- @warning This API will eventually be deprecated. The replacement API is:
+ @warning This API is deprecated. The replacement API is:
  `MDCChipView`'s `-applyThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-+ (void)applyScheme:(nonnull id<MDCChipViewScheming>)scheme toChipView:(nonnull MDCChipView *)chip;
++ (void)applyScheme:(nonnull id<MDCChipViewScheming>)scheme toChipView:(nonnull MDCChipView *)chip
+__deprecated_msg("Use Chips+Theming instead.");
 
 /**
  Applies a chip view scheme's properties to an MDCChipView using the outlined style.
@@ -48,11 +46,12 @@
  @param scheme The chip view scheme to apply to the component instance.
  @param chip A component instance to which the scheme should be applied.
 
- @warning This API will eventually be deprecated. The replacement API is:
+ @warning This API is deprecated. The replacement API is:
  `MDCChipView`'s `-applyOutlinedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyOutlinedVariantWithScheme:(nonnull id<MDCChipViewScheming>)scheme
-                            toChipView:(nonnull MDCChipView *)chip;
+                            toChipView:(nonnull MDCChipView *)chip
+__deprecated_msg("Use Chips+Theming instead.");
 
 @end


### PR DESCRIPTION
There is no internal usage of these APIs.

Part of https://github.com/material-components/material-components-ios/issues/8429