### PR TITLE
{WIP} [ActionSheet] Support Dynamic Type fonts.

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -40,7 +40,7 @@
 
  */
 __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
-    : UIViewController<MDCElevatable, MDCElevationOverriding>
+    : UIViewController<MDCElevatable, MDCElevationOverriding, UIContentSizeCategoryAdjusting>
 
 /**
  Designated initializer to create and return a view controller for displaying an alert to the user.

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -329,7 +329,9 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   cell.imageRenderingMode = self.imageRenderingMode;
   cell.addLeadingPadding = self.addLeadingPaddingToCell;
   cell.actionTextColor = action.titleColor ?: self.actionTextColor;
-  cell.actionLabel.adjustsFontForContentSizeCategory = self.adjustsFontForContentSizeCategory;
+  if (@available(iOS 10.0, *)) {
+    cell.actionLabel.adjustsFontForContentSizeCategory = self.adjustsFontForContentSizeCategory;
+  }
   return cell;
 }
 
@@ -363,9 +365,10 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   }
 #endif
 
-  if (self.adjustsFontForContentSizeCategory) {
-    if (@available(iOS 10.0, *)) {
-      if (![self.traitCollection.preferredContentSizeCategory isEqualToString:previousTraitCollection.preferredContentSizeCategory]) {
+  if (@available(iOS 10.0, *)) {
+    if (self.adjustsFontForContentSizeCategory) {
+      if (![self.traitCollection.preferredContentSizeCategory
+              isEqualToString:previousTraitCollection.preferredContentSizeCategory]) {
         [self.view setNeedsLayout];
       }
     }

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -468,10 +468,12 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 }
 
 - (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
-  _adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
-  self.header.titleLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
-  self.header.messageLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
-  [self updateTable];
+  if (@available(iOS 10.0, *)) {
+    _adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+    self.header.titleLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
+    self.header.messageLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
+    [self updateTable];
+  }
 }
 
 #pragma mark - Table customization

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -89,6 +89,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
 @synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 @synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
+@synthesize adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
 
 + (instancetype)actionSheetControllerWithTitle:(NSString *)title message:(NSString *)message {
   return [[MDCActionSheetController alloc] initWithTitle:title message:message];
@@ -328,6 +329,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   cell.imageRenderingMode = self.imageRenderingMode;
   cell.addLeadingPadding = self.addLeadingPaddingToCell;
   cell.actionTextColor = action.titleColor ?: self.actionTextColor;
+  cell.actionLabel.adjustsFontForContentSizeCategory = self.adjustsFontForContentSizeCategory;
   return cell;
 }
 
@@ -360,6 +362,14 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
     }
   }
 #endif
+
+  if (self.adjustsFontForContentSizeCategory) {
+    if (@available(iOS 10.0, *)) {
+      if (![self.traitCollection.preferredContentSizeCategory isEqualToString:previousTraitCollection.preferredContentSizeCategory]) {
+        [self.view setNeedsLayout];
+      }
+    }
+  }
 
   if (self.traitCollectionDidChangeBlock) {
     self.traitCollectionDidChangeBlock(self, previousTraitCollection);
@@ -452,6 +462,13 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 - (void)updateFontsForDynamicType {
   [self updateTableFonts];
   [self.view setNeedsLayout];
+}
+
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  _adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+  self.header.titleLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
+  self.header.messageLabel.adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
+  [self updateTable];
 }
 
 #pragma mark - Table customization

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.h
@@ -21,6 +21,12 @@
 /** Header must be created with initWithFrame */
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
 
+/** Shows the title of the Action Sheet. */
+@property(nonatomic, nonnull, strong, readonly) UILabel *titleLabel;
+
+/** Shows the message of the Action Sheet. */
+@property(nonatomic, nonnull, strong, readonly) UILabel *messageLabel;
+
 @property(nonatomic, nullable, copy) NSString *title;
 
 @property(nonatomic, nullable, copy) NSString *message;

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -26,11 +26,6 @@ static const CGFloat kTrailingPadding = 0;
 static const CGFloat kTitleOnlyPadding = 18;
 static const CGFloat kMiddlePadding = 8;
 
-@interface MDCActionSheetHeaderView ()
-@property(nonatomic, strong) UILabel *titleLabel;
-@property(nonatomic, strong) UILabel *messageLabel;
-@end
-
 @implementation MDCActionSheetHeaderView
 
 @synthesize mdc_adjustsFontForContentSizeCategory = _mdc_adjustsFontForContentSizeCategory;
@@ -213,6 +208,15 @@ static const CGFloat kMiddlePadding = 8;
 - (void)setMessageTextColor:(UIColor *)messageTextColor {
   _messageTextColor = messageTextColor;
   [self updateLabelColors];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  if (@available(iOS 10.0, *)) {
+    if (![previousTraitCollection.preferredContentSizeCategory isEqualToString:self.traitCollection.preferredContentSizeCategory]) {
+      [self setNeedsLayout];
+    }
+  }
 }
 
 @end

--- a/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
+++ b/components/ActionSheet/src/private/MDCActionSheetHeaderView.m
@@ -213,7 +213,8 @@ static const CGFloat kMiddlePadding = 8;
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
   if (@available(iOS 10.0, *)) {
-    if (![previousTraitCollection.preferredContentSizeCategory isEqualToString:self.traitCollection.preferredContentSizeCategory]) {
+    if (![previousTraitCollection.preferredContentSizeCategory
+            isEqualToString:self.traitCollection.preferredContentSizeCategory]) {
       [self setNeedsLayout];
     }
   }

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
@@ -27,6 +27,9 @@
 @property(nonatomic, setter=mdc_setAdjustsFontForContentSizeCategory:)
     BOOL mdc_adjustsFontForContentSizeCategory;
 
+/** Label for the action's title text. */
+@property(nonatomic, nonnull, readonly, strong) UILabel *actionLabel;
+
 @property(nonatomic, nonnull, strong) UIFont *actionFont;
 
 @property(nonatomic, strong, nullable) UIColor *actionTextColor;

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -30,7 +30,6 @@ static inline UIColor *RippleColor() {
 }
 
 @interface MDCActionSheetItemTableViewCell ()
-@property(nonatomic, strong) UILabel *actionLabel;
 @property(nonatomic, strong) UIImageView *actionImageView;
 @property(nonatomic, strong) MDCInkTouchController *inkTouchController;
 @property(nonatomic, strong) MDCRippleTouchController *rippleTouchController;
@@ -179,6 +178,9 @@ static inline UIColor *RippleColor() {
 }
 
 - (void)setActionFont:(UIFont *)actionFont {
+  if ([actionFont isEqual:_actionFont]) {
+    return;
+  }
   _actionFont = actionFont;
   [self updateTitleFont];
 }
@@ -197,6 +199,9 @@ static inline UIColor *RippleColor() {
 }
 
 - (void)mdc_setAdjustsFontForContentSizeCategory:(BOOL)adjusts {
+  if (_mdc_adjustsFontForContentSizeCategory == adjusts) {
+    return;
+  }
   _mdc_adjustsFontForContentSizeCategory = adjusts;
   [self updateTitleFont];
 }


### PR DESCRIPTION
Adds support for UIFont's `preferredFont...` APIs to render Dynamic Type
fonts. Adds conformance to `UIContentSizeCategoryAdjusting` so that the fonts
can be adjusted automatically if desired by clients.

## Outstanding Issue

The PR is currently a WIP due to lack of resizing of the content view when the content size category causes the `preferredContentSize` to shrink.

|Initial (small size category)|Change to a large size category|Readjust sheet resting position|Change to small size category|
|---|---|---|---|
|![Simulator Screen Shot - iPhone 7 - 2019-10-15 at 21 33 49](https://user-images.githubusercontent.com/1753199/66881223-31ba4500-ef94-11e9-89fc-c1214cc6ddee.png)|![Simulator Screen Shot - iPhone 7 - 2019-10-15 at 21 34 01](https://user-images.githubusercontent.com/1753199/66881233-3979e980-ef94-11e9-9392-9d7010d5d895.png)|![Simulator Screen Shot - iPhone 7 - 2019-10-15 at 21 34 06](https://user-images.githubusercontent.com/1753199/66881243-45fe4200-ef94-11e9-8402-ac24005d66ab.png)|![Simulator Screen Shot - iPhone 7 - 2019-10-15 at 21 34 12](https://user-images.githubusercontent.com/1753199/66881249-4dbde680-ef94-11e9-9bea-9a85ca6891dc.png)|

Part of #8595
