### PR TITLE
[Tabs] Update MDCTabBarView to use a global constant for its animation duration.

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -49,6 +49,15 @@ typedef NS_ENUM(NSUInteger, MDCTabBarViewLayoutStyle) {
 };
 
 /**
+ The total duration for all animations that take place during a selection change.
+
+ This is guaranteed to be the total time between the start of the first animation and the end of
+ the last animation that takes place for selection changes. There may not be a specific animation
+ that has this exact duration.
+ */
+CG_EXTERN const CFTimeInterval MDCTabBarSelectionChangeAnimationDuration;
+
+/**
  An implementation of Material Tabs (https://material.io/design/components/tabs.html).
  */
 __attribute__((objc_subclassing_restricted)) @interface MDCTabBarView : UIScrollView
@@ -100,15 +109,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCTabBarView : UIScroll
  */
 @property(nonatomic, copy, nullable) void (^traitCollectionDidChangeBlock)
     (MDCTabBarView *_Nonnull tabBar, UITraitCollection *_Nullable previousTraitCollection);
-
-/**
- The total duration for all animations that take place during a selection change.
-
- This is guaranteed to be the total time between the start of the first animation and the end of
- the last animation that takes place for selection changes. There may not be a specific animation
- that has this exact duration.
- */
-@property(nonatomic, readonly) CFTimeInterval selectionChangeAnimationDuration;
 
 /**
  The timing function used by the tab bar when selection changes are animated. This should be used

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -43,9 +43,6 @@ static const CGFloat kScrollableTabsLeadingEdgeInset = 52;
 /** The height of the bottom divider view. */
 static const CGFloat kBottomDividerHeight = 1;
 
-/// Default duration in seconds for selection change animations.
-static const NSTimeInterval kSelectionChangeAnimationDuration = 0.3;
-
 static NSString *const kSelectedImageKeyPath = @"selectedImage";
 static NSString *const kImageKeyPath = @"image";
 static NSString *const kTitleKeyPath = @"title";
@@ -53,6 +50,9 @@ static NSString *const kAccessibilityLabelKeyPath = @"accessibilityLabel";
 static NSString *const kAccessibilityHintKeyPath = @"accessibilityHint";
 static NSString *const kAccessibilityIdentifierKeyPath = @"accessibilityIdentifier";
 static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
+
+/// Default duration in seconds for selection change animations.
+const NSTimeInterval MDCTabBarSelectionChangeAnimationDuration = 0.3;
 
 @interface MDCTabBarView ()
 
@@ -117,7 +117,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     _selectionIndicatorView.translatesAutoresizingMaskIntoConstraints = NO;
     _selectionIndicatorView.userInteractionEnabled = NO;
     _selectionIndicatorView.tintColor = UIColor.blackColor;
-    _selectionIndicatorView.indicatorPathAnimationDuration = kSelectionChangeAnimationDuration;
+    _selectionIndicatorView.indicatorPathAnimationDuration = MDCTabBarSelectionChangeAnimationDuration;
     _selectionIndicatorView.indicatorPathTimingFunction =
         [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
 
@@ -460,10 +460,6 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   }
   CGRect frame = CGRectStandardize(self.itemViews[index].frame);
   return [coordinateSpace convertRect:frame fromCoordinateSpace:self];
-}
-
-- (CFTimeInterval)selectionChangeAnimationDuration {
-  return kSelectionChangeAnimationDuration;
 }
 
 - (CAMediaTimingFunction *)selectionChangeAnimationTimingFunction {
@@ -1078,9 +1074,9 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
         [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
     // Wrap in explicit CATransaction to allow layer-based animations with the correct duration.
     [CATransaction begin];
-    [CATransaction setAnimationDuration:self.selectionChangeAnimationDuration];
+    [CATransaction setAnimationDuration:MDCTabBarSelectionChangeAnimationDuration];
     [CATransaction setAnimationTimingFunction:easeInOutFunction];
-    [UIView animateWithDuration:self.selectionChangeAnimationDuration
+    [UIView animateWithDuration:MDCTabBarSelectionChangeAnimationDuration
                           delay:0
                         options:UIViewAnimationOptionBeginFromCurrentState
                      animations:animationBlock

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -52,7 +52,7 @@ static NSString *const kAccessibilityIdentifierKeyPath = @"accessibilityIdentifi
 static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 
 /// Default duration in seconds for selection change animations.
-const NSTimeInterval MDCTabBarSelectionChangeAnimationDuration = 0.3;
+const CFTimeInterval MDCTabBarSelectionChangeAnimationDuration = 0.3;
 
 @interface MDCTabBarView ()
 

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -117,7 +117,8 @@ const CFTimeInterval MDCTabBarSelectionChangeAnimationDuration = 0.3;
     _selectionIndicatorView.translatesAutoresizingMaskIntoConstraints = NO;
     _selectionIndicatorView.userInteractionEnabled = NO;
     _selectionIndicatorView.tintColor = UIColor.blackColor;
-    _selectionIndicatorView.indicatorPathAnimationDuration = MDCTabBarSelectionChangeAnimationDuration;
+    _selectionIndicatorView.indicatorPathAnimationDuration =
+        MDCTabBarSelectionChangeAnimationDuration;
     _selectionIndicatorView.indicatorPathTimingFunction =
         [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionEaseInOut];
 

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -283,7 +283,8 @@ static const UIEdgeInsets kEdgeInsetsImageOnly = {.top = 12, .right = 16, .botto
   };
 
   if (animated) {
-    [UIView animateWithDuration:MDCTabBarSelectionChangeAnimationDuration animations:animationBlock];
+    [UIView animateWithDuration:MDCTabBarSelectionChangeAnimationDuration
+                     animations:animationBlock];
   } else {
     animationBlock();
   }

--- a/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
+++ b/components/Tabs/src/TabBarView/private/MDCTabBarViewItemView.m
@@ -14,6 +14,8 @@
 
 #import "MDCTabBarViewItemView.h"
 
+#import "MDCTabBarView.h"
+
 #import <CoreGraphics/CoreGraphics.h>
 
 #import "MaterialMath.h"
@@ -281,7 +283,7 @@ static const UIEdgeInsets kEdgeInsetsImageOnly = {.top = 12, .right = 16, .botto
   };
 
   if (animated) {
-    [UIView animateWithDuration:0.3 animations:animationBlock];
+    [UIView animateWithDuration:MDCTabBarSelectionChangeAnimationDuration animations:animationBlock];
   } else {
     animationBlock();
   }

--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -1240,7 +1240,7 @@ static UIImage *fakeImage(CGSize size) {
 
 - (void)testDefaultSelectionChangeAnimationDurationValue {
   // Then
-  XCTAssertEqualWithAccuracy(self.tabBarView.selectionChangeAnimationDuration, 0.3, 0.0001);
+  XCTAssertEqualWithAccuracy(MDCTabBarSelectionChangeAnimationDuration, 0.3, 0.0001);
 }
 
 - (void)testDefaultSelectionChangeAnimationTimingFunction {


### PR DESCRIPTION
This value was exposed as a property on MDCTabBarView, however the custom views that conform to <MDCTabBarViewCustomViewable> don't have access to the instance of the tab bar but likely want to keep their animations in sync.

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Please add unit tests, snapshot tests, or manual testing steps depending on the change.
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-ios/tree/develop/contributing) has more information and tips for a great
pull request.
