### PR TITLE
[Buttons] Add API to disable state-based fonts.

### DIFF
--- a/components/Buttons/src/MDCButton.h
+++ b/components/Buttons/src/MDCButton.h
@@ -193,24 +193,6 @@
 /* Convenience for `setBackgroundColor:backgroundColor forState:UIControlStateNormal`. */
 - (void)setBackgroundColor:(nullable UIColor *)backgroundColor;
 
-/**
- The font used by the button's @c title for @c state.
-
- @param state The state.
- @return The font.
- */
-- (nullable UIFont *)titleFontForState:(UIControlState)state;
-
-/**
- The font used by the button's @c title.
-
- If left unset or reset to nil for a given state, then a default font is used.
-
- @param font The font.
- @param state The state.
- */
-- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state UI_APPEARANCE_SELECTOR;
-
 /** Sets the enabled state with optional animation. */
 - (void)setEnabled:(BOOL)enabled animated:(BOOL)animated;
 
@@ -333,5 +315,39 @@
  the button directly."
  */
 + (nonnull instancetype)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
+
+#pragma mark - To Be Deprecated
+
+/**
+ Enables the state-based font behavior of the receiver.
+
+ If @c NO, then @c titleFont:forState: and @c setTitleFont:forState: have no effect.  Defaults to
+ @c YES.
+
+ @note This API will eventually be deprecated and removed.
+ */
+@property(nonatomic, assign) BOOL enableTitleFontForState;
+
+/**
+ The font used by the button's @c title.
+
+ If left unset or reset to nil for a given state, then a default font is used.
+
+ @param font The font.
+ @param state The state.
+
+ @note This API will eventually be deprecated and removed.
+ */
+- (void)setTitleFont:(nullable UIFont *)font forState:(UIControlState)state UI_APPEARANCE_SELECTOR;
+
+/**
+ The font used by the button's @c title for @c state.
+
+ @param state The state.
+ @return The font.
+
+ @note This API will eventually be deprecated and removed.
+ */
+- (nullable UIFont *)titleFontForState:(UIControlState)state;
 
 @end

--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -146,6 +146,8 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (void)commonMDCButtonInit {
+  // TODO(b/142861610): Default to `NO`, then remove once all internal usage is migrated.
+  _enableTitleFontForState = YES;
   _disabledAlpha = MDCButtonDisabledAlpha;
   _enabledAlpha = self.alpha;
   _uppercaseTitle = YES;
@@ -926,6 +928,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (void)updateTitleFont {
+  if (!self.enableTitleFontForState) {
+    return;
+  }
+
   self.titleLabel.font = [self titleFontForState:self.state];
 
   [self setNeedsLayout];

--- a/components/Buttons/tests/snapshot/MDCButtonSnapshotTests.m
+++ b/components/Buttons/tests/snapshot/MDCButtonSnapshotTests.m
@@ -48,7 +48,7 @@
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  self.recordMode = YES;
+  //  self.recordMode = YES;
 }
 
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {

--- a/components/Buttons/tests/snapshot/MDCButtonSnapshotTests.m
+++ b/components/Buttons/tests/snapshot/MDCButtonSnapshotTests.m
@@ -1,0 +1,119 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialButtons+Theming.h"
+#import "MaterialButtons.h"
+#import "MaterialContainerScheme.h"
+
+/** A tests fake class of MDCButton. */
+@interface MDCButtonSnapshotTestsFakeButton : MDCButton
+
+/** Allows overriding @c traitCollection for testing. */
+@property(nonatomic, strong) UITraitCollection *traitCollectionOverride;
+
+@end
+
+@implementation MDCButtonSnapshotTestsFakeButton
+
+- (UITraitCollection *)traitCollection {
+  return self.traitCollectionOverride ?: [super traitCollection];
+}
+
+@end
+
+/** General snapshot tests for @c MDCButton. */
+@interface MDCButtonSnapshotTests : MDCSnapshotTestCase
+
+@end
+
+@implementation MDCButtonSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+  self.recordMode = YES;
+}
+
+- (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  [view sizeToFit];
+
+  UIView *snapshotView = [view mdc_addToBackgroundView];
+  [self snapshotVerifyView:snapshotView];
+}
+
+- (void)testPreferredFontForAXXXLContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    MDCButtonSnapshotTestsFakeButton *button = [[MDCButtonSnapshotTestsFakeButton alloc] init];
+    [button applyContainedThemeWithScheme:[[MDCContainerScheme alloc] init]];
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:xsTraitCollection];
+    button.traitCollectionOverride = xsTraitCollection;
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    [button setTitle:@"Title" forState:UIControlStateNormal];
+    button.titleLabel.font = originalFont;
+    button.titleLabel.adjustsFontForContentSizeCategory = YES;
+
+    // When
+    button.enableTitleFontForState = NO;
+    button.traitCollectionOverride = aXXXLTraitCollection;
+    // Force the Dynamic Type system to update the button's font.
+    [button drawViewHierarchyInRect:button.bounds afterScreenUpdates:YES];
+
+    // Then
+    [self generateSnapshotAndVerifyForView:button];
+  }
+}
+
+- (void)testPreferredFontForXSContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    MDCButtonSnapshotTestsFakeButton *button = [[MDCButtonSnapshotTestsFakeButton alloc] init];
+    [button applyContainedThemeWithScheme:[[MDCContainerScheme alloc] init]];
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:aXXXLTraitCollection];
+    button.traitCollectionOverride = aXXXLTraitCollection;
+    [button setTitle:@"Title" forState:UIControlStateNormal];
+    button.titleLabel.font = originalFont;
+    button.titleLabel.adjustsFontForContentSizeCategory = YES;
+
+    // When
+
+    button.enableTitleFontForState = NO;
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+
+    button.traitCollectionOverride = xsTraitCollection;
+    // Force the Dynamic Type system to update the button's font.
+    [button drawViewHierarchyInRect:button.bounds afterScreenUpdates:YES];
+
+    // Then
+    [self generateSnapshotAndVerifyForView:button];
+  }
+}
+
+@end

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -590,6 +590,77 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 self.button.titleLabel.font);
 }
 
+- (void)testTitleFontForStateDisabledAfterSettingFontsPreventsFontChange {
+  // Given
+  UIFont *normalFont = [UIFont systemFontOfSize:10];
+  UIFont *selectedFont = [UIFont systemFontOfSize:40];
+  UIFont *directlyAssignedFont = [UIFont systemFontOfSize:25];
+  [self.button setTitleFont:normalFont forState:UIControlStateNormal];
+  [self.button setTitleFont:selectedFont forState:UIControlStateSelected];
+
+  // When
+  self.button.enableTitleFontForState = NO;
+  self.button.titleLabel.font = directlyAssignedFont;
+  self.button.selected = YES;
+
+  // Then
+  XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
+}
+
+- (void)testTitleFontForStateDisabledBeforeSettingFontsPreventsFontChange {
+  // Given
+  UIFont *normalFont = [UIFont systemFontOfSize:10];
+  UIFont *selectedFont = [UIFont systemFontOfSize:40];
+  UIFont *directlyAssignedFont = [UIFont systemFontOfSize:25];
+  self.button.enableTitleFontForState = NO;
+  self.button.titleLabel.font = directlyAssignedFont;
+
+  // When
+  [self.button setTitleFont:normalFont forState:UIControlStateNormal];
+  [self.button setTitleFont:selectedFont forState:UIControlStateSelected];
+  self.button.selected = YES;
+
+  // Then
+  XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
+}
+
+- (void)testTitleFontForStateReenabledDoesNotImmediatelyUpdateFont {
+  // Given
+  UIFont *normalFont = [UIFont systemFontOfSize:10];
+  UIFont *selectedFont = [UIFont systemFontOfSize:40];
+  UIFont *directlyAssignedFont = [UIFont systemFontOfSize:25];
+  self.button.enableTitleFontForState = NO;
+  [self.button setTitleFont:normalFont forState:UIControlStateNormal];
+  [self.button setTitleFont:selectedFont forState:UIControlStateSelected];
+  self.button.titleLabel.font = directlyAssignedFont;
+  self.button.selected = YES;
+
+  // When
+  self.button.enableTitleFontForState = YES;
+
+  // Then
+  XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
+}
+
+- (void)testTitleFontForStateReenabledUpdatesFontsOnNextStateChange {
+  // Given
+  UIFont *normalFont = [UIFont systemFontOfSize:10];
+  UIFont *selectedFont = [UIFont systemFontOfSize:40];
+  UIFont *directlyAssignedFont = [UIFont systemFontOfSize:25];
+  self.button.enableTitleFontForState = NO;
+  [self.button setTitleFont:normalFont forState:UIControlStateNormal];
+  [self.button setTitleFont:selectedFont forState:UIControlStateSelected];
+  self.button.titleLabel.font = directlyAssignedFont;
+  self.button.selected = YES;
+
+  // When
+  self.button.enableTitleFontForState = YES;
+  self.button.selected = NO;
+
+  // Then
+  XCTAssertEqualObjects(self.button.titleLabel.font, normalFont);
+}
+
 #pragma mark - shadowColor:forState:
 
 - (void)testRemovedShadowColorForState {

--- a/components/Buttons/tests/unit/MDCButtonTests.m
+++ b/components/Buttons/tests/unit/MDCButtonTests.m
@@ -590,6 +590,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
                 self.button.titleLabel.font);
 }
 
+/**
+ Verifies that disabling the @c titleFont:forState: APIs after setting fonts preserves the
+ directly-assigned font on the button's @c titleLabel.
+ */
 - (void)testTitleFontForStateDisabledAfterSettingFontsPreventsFontChange {
   // Given
   UIFont *normalFont = [UIFont systemFontOfSize:10];
@@ -607,6 +611,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
 }
 
+/**
+ Verifies that disabling @c titleFont:forState: APIs before setting fonts preserves the
+ directly-assigned font on the button's @c titleLabel.
+ */
 - (void)testTitleFontForStateDisabledBeforeSettingFontsPreventsFontChange {
   // Given
   UIFont *normalFont = [UIFont systemFontOfSize:10];
@@ -624,24 +632,10 @@ static NSString *controlStateDescription(UIControlState controlState) {
   XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
 }
 
-- (void)testTitleFontForStateReenabledDoesNotImmediatelyUpdateFont {
-  // Given
-  UIFont *normalFont = [UIFont systemFontOfSize:10];
-  UIFont *selectedFont = [UIFont systemFontOfSize:40];
-  UIFont *directlyAssignedFont = [UIFont systemFontOfSize:25];
-  self.button.enableTitleFontForState = NO;
-  [self.button setTitleFont:normalFont forState:UIControlStateNormal];
-  [self.button setTitleFont:selectedFont forState:UIControlStateSelected];
-  self.button.titleLabel.font = directlyAssignedFont;
-  self.button.selected = YES;
-
-  // When
-  self.button.enableTitleFontForState = YES;
-
-  // Then
-  XCTAssertEqualObjects(self.button.titleLabel.font, directlyAssignedFont);
-}
-
+/**
+ Verifies that after enabling @c titleFont:forState: APIs, that @c titleLabel.font will be
+ replaced by the next time the state is changed.
+ */
 - (void)testTitleFontForStateReenabledUpdatesFontsOnNextStateChange {
   // Given
   UIFont *normalFont = [UIFont systemFontOfSize:10];

--- a/snapshot_test_goldens/goldens_64/MDCButtonSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCButtonSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59cc867fefdc10a4cb5682ed2ba4b2532c44283e78c73a15b7bb12dffa2c4d32
+size 5309

--- a/snapshot_test_goldens/goldens_64/MDCButtonSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCButtonSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57356b0ad1252475e9c730bd08bc0092fea3d32a3ffdd31a7b835f5b626e24f0
+size 2953


### PR DESCRIPTION
Introduces a new API to disable the `titleFont:forState:` APIs. This is the
first step toward removing those APIs.

State-based fonts make it impossible to support UIContentSizeCategoryAdjusting
behavior on the button's `titleLabel`. Providing support for automatic font
resizing for Dynamic Type means removing state-based font APIs.

Part of #8595