### PR TITLE
[TextFields] Use preferredFonts in MDCBaseTextField

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -79,6 +79,7 @@
 #pragma mark View Setup
 
 - (void)initializeProperties {
+  self.font = [self uiTextFieldDefaultFont];
   self.labelBehavior = MDCTextControlLabelBehaviorFloats;
   self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
   self.labelState = [self determineCurrentLabelState];
@@ -496,12 +497,7 @@
 }
 
 - (UIFont *)uiTextFieldDefaultFont {
-  static dispatch_once_t onceToken;
-  static UIFont *font;
-  dispatch_once(&onceToken, ^{
-    font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
-  });
-  return font;
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 #pragma mark MDCTextControlState

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlAssistiveLabelView.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlAssistiveLabelView.m
@@ -40,9 +40,11 @@
 - (void)commonMDCTextControlAssistiveLabelViewInit {
   self.leftAssistiveLabel = [[UILabel alloc] init];
   self.leftAssistiveLabel.numberOfLines = 0;
+  self.leftAssistiveLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
   [self addSubview:self.leftAssistiveLabel];
   self.rightAssistiveLabel = [[UILabel alloc] init];
   self.rightAssistiveLabel.numberOfLines = 0;
+  self.rightAssistiveLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
   [self addSubview:self.rightAssistiveLabel];
 }
 


### PR DESCRIPTION
This PR adds `-preferredFontForTextStyle:` API calls to MDCBaseTextField.

Related to #6942.