### PR TITLE
[NavigationDrawer] Hide scrim when scrolled to bottom with tracking scroll view

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -377,4 +377,11 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
 }
 
+- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                            scrollViewIsScrolledToBottom:
+                                                                (BOOL)scrollViewIsScrolledToBottom {
+  self.scrimView.hidden = scrollViewIsScrolledToBottom;
+}
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -377,11 +377,13 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
 }
 
-- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
-                                                            scrollViewIsScrolledToBottom:
-                                                                (BOOL)scrollViewIsScrolledToBottom {
-  self.scrimView.hidden = scrollViewIsScrolledToBottom;
+- (void)
+    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+        (MDCBottomDrawerContainerViewController *)containerViewController
+                                                        scrollViewIsScrolledToEndOfContent:
+                                                            (BOOL)
+                                                                scrollViewIsScrolledToEndOfContent {
+  self.scrimView.hidden = scrollViewIsScrolledToEndOfContent;
 }
 
 @end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -29,12 +29,15 @@
 This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom.
 
 @param containerViewController the container view controller of the bottom drawer.
-@param scrollViewIsScrolledToBottom whether or not the scroll view is scrolled to the bottom.
+@param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of
+the content.
 */
-- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
-                                                            scrollViewIsScrolledToBottom:
-                                                                (BOOL)scrollViewIsScrolledToBottom;
+- (void)
+    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+        (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                        scrollViewIsScrolledToEndOfContent:
+                                                            (BOOL)
+                                                                scrollViewIsScrolledToEndOfContent;
 
 /**
  This method is called when the bottom drawer will change its presented state to one of the

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -24,6 +24,18 @@
  Delegate for MDCBottomDrawerContainerViewController.
  */
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
+
+/**
+This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom.
+
+@param containerViewController the container view controller of the bottom drawer.
+@param scrollViewIsScrolledToBottom whether or not the scroll view is scrolled to the bottom.
+*/
+- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                            scrollViewIsScrolledToBottom:
+                                                                (BOOL)scrollViewIsScrolledToBottom;
+
 /**
  This method is called when the bottom drawer will change its presented state to one of the
  MDCBottomDrawerState states.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -148,7 +148,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 @property(nonatomic) BOOL scrollViewIsDraggedToBottom;
 
 // The scroll view is currently scrolled completely to the bottom.
-@property(nonatomic) BOOL scrollViewIsScrolledToBottom;
+@property(nonatomic) BOOL scrollViewIsScrolledToEndOfContent;
 
 // The scroll view has started its current drag from fullscreen.
 @property(nonatomic) BOOL scrollViewBeganDraggingFromFullscreen;
@@ -302,7 +302,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
     if (CGRectGetMinY(self.trackingScrollView.bounds) < maxScrollOrigin || scrollingUpInFull) {
       // If we still didn't reach the end of the content, or if we are scrolling up after reaching
       // the end of the content.
-      self.scrollViewIsScrolledToBottom = NO;
+      self.scrollViewIsScrolledToEndOfContent = NO;
 
       // Update the drawer's scrollView's offset to be static so the content will scroll instead.
       CGRect scrollViewBounds = self.scrollView.bounds;
@@ -321,7 +321,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
       contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(CGRectGetMinY(contentViewBounds), 0));
       self.trackingScrollView.bounds = contentViewBounds;
     } else {
-      self.scrollViewIsScrolledToBottom = YES;
+      self.scrollViewIsScrolledToEndOfContent = YES;
 
       if (self.trackingScrollView.contentSize.height >=
           CGRectGetHeight(self.trackingScrollView.frame)) {
@@ -431,17 +431,19 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
   self.shadowedView.shadowLayer.shadowColor = drawerShadowColor.CGColor;
 }
 
-- (void)setScrollViewIsScrolledToBottom:(BOOL)scrollViewIsScrolledToBottom {
-  if (_scrollViewIsScrolledToBottom != scrollViewIsScrolledToBottom) {
-    _scrollViewIsScrolledToBottom = scrollViewIsScrolledToBottom;
+- (void)setScrollViewIsScrolledToEndOfContent:(BOOL)scrollViewIsScrolledToBottom {
+  if (_scrollViewIsScrolledToEndOfContent != scrollViewIsScrolledToBottom) {
+    _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToBottom;
     if ([self.delegate
             respondsToSelector:@selector
-            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-                                                                 scrollViewIsScrolledToBottom:)]) {
+            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+                                                                 scrollViewIsScrolledToEndOfContent:
+                                                                     )]) {
       [self.delegate
-          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:self
-                                                              scrollViewIsScrolledToBottom:
-                                                                  _scrollViewIsScrolledToBottom];
+          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+              self
+                                                              scrollViewIsScrolledToEndOfContent:
+                                                                  _scrollViewIsScrolledToEndOfContent];
     }
   }
 }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -147,6 +147,9 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 // The scroll view is currently being dragged towards bottom.
 @property(nonatomic) BOOL scrollViewIsDraggedToBottom;
 
+// The scroll view is currently scrolled completely to the bottom.
+@property(nonatomic) BOOL scrollViewIsScrolledToBottom;
+
 // The scroll view has started its current drag from fullscreen.
 @property(nonatomic) BOOL scrollViewBeganDraggingFromFullscreen;
 
@@ -299,6 +302,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
     if (CGRectGetMinY(self.trackingScrollView.bounds) < maxScrollOrigin || scrollingUpInFull) {
       // If we still didn't reach the end of the content, or if we are scrolling up after reaching
       // the end of the content.
+      self.scrollViewIsScrolledToBottom = NO;
 
       // Update the drawer's scrollView's offset to be static so the content will scroll instead.
       CGRect scrollViewBounds = self.scrollView.bounds;
@@ -317,6 +321,8 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
       contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(CGRectGetMinY(contentViewBounds), 0));
       self.trackingScrollView.bounds = contentViewBounds;
     } else {
+      self.scrollViewIsScrolledToBottom = YES;
+
       if (self.trackingScrollView.contentSize.height >=
           CGRectGetHeight(self.trackingScrollView.frame)) {
         // Have the drawer's scrollView's content size be static so it will bounce when reaching the
@@ -423,6 +429,21 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (void)setDrawerShadowColor:(UIColor *)drawerShadowColor {
   _drawerShadowColor = drawerShadowColor;
   self.shadowedView.shadowLayer.shadowColor = drawerShadowColor.CGColor;
+}
+
+- (void)setScrollViewIsScrolledToBottom:(BOOL)scrollViewIsScrolledToBottom {
+  if (_scrollViewIsScrolledToBottom != scrollViewIsScrolledToBottom) {
+    _scrollViewIsScrolledToBottom = scrollViewIsScrolledToBottom;
+    if ([self.delegate
+            respondsToSelector:@selector
+            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+                                                                 scrollViewIsScrolledToBottom:)]) {
+      [self.delegate
+          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:self
+                                                              scrollViewIsScrolledToBottom:
+                                                                  _scrollViewIsScrolledToBottom];
+    }
+  }
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {


### PR DESCRIPTION
This is not a great fix but if we don't have any better ideas we could possibly use it to resolve https://github.com/material-components/material-components-ios/issues/5782.

With this change the scrim is visible when it's shown at the top of the screen and at the top of the content. It's hidden when it's shown at the bottom of the screen and at the bottom of the content. In other words, the scrim is visible when it should be when hidden when it shouldn't be.

Someone who knows NavigationDrawer better would be better able to say whether this fix could cause problems.

# Before:
![Simulator Screen Shot - iPhone 7 - 2019-10-18 at 16 54 24](https://user-images.githubusercontent.com/8020010/67222959-5f701580-f3fc-11e9-81bf-500dc155b568.png)

# After:
![Simulator Screen Shot - iPhone 7 - 2019-10-18 at 16 51 48](https://user-images.githubusercontent.com/8020010/67222960-6008ac00-f3fc-11e9-9714-2cc9f011a93c.png)
