### PR TITLE
[Tabs] Optimization to avoid creating unnecessary custom views.

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -208,8 +208,9 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     if ([item conformsToProtocol:@protocol(MDCTabBarItemCustomViewing)]) {
       UITabBarItem<MDCTabBarItemCustomViewing> *customItem =
           (UITabBarItem<MDCTabBarItemCustomViewing> *)item;
-      if (customItem.mdc_customView) {
-        itemView = customItem.mdc_customView;
+      UIView *customView = customItem.mdc_customView;
+      if (customView) {
+        itemView = customView;
       }
     }
     if (!itemView) {


### PR DESCRIPTION
The code, as written, was invoking the `mdc_customView` method twice per iteration. Once to check within the if-statement, and once to actually assign the view. If that method allocated a new UIView, then each of these invocations will cause new UIViews to be created.

Instead, we should call the method once and store it in a local to be used in both the if-statement and the assignment. This avoids unnecessary view creation if the implementation of `mdc_customView` allocates a new view on each call.