### PR TITLE
[NavigationDrawer] Fix over scrolled bottom navigation incorrectly showing the scrim and presenting view

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -111,6 +111,7 @@ UICollectionViewDelegate, UICollectionViewDataSource {
     collectionView.delegate = self
     collectionView.dataSource = self
     collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    collectionView.backgroundColor = colorScheme.surfaceColor
     layout.minimumLineSpacing = 0
     layout.minimumInteritemSpacing = 0
     self.view.addSubview(collectionView)

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -106,6 +106,7 @@ class DrawerContentWithScrollViewController: UIViewController,
     collectionView.delegate = self
     collectionView.dataSource = self
     collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    collectionView.backgroundColor = colorScheme.surfaceColor
     layout.minimumLineSpacing = 0
     layout.minimumInteritemSpacing = 0
     self.view.addSubview(collectionView)

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -130,7 +130,7 @@
 @property(nonatomic, weak, nullable) UIScrollView *trackingScrollView;
 
 /**
- The color applied to the background scrim.
+ The color applied to the background scrim. Default is a reasonable transparent black.
  */
 @property(nonatomic, strong, nullable) UIColor *scrimColor;
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -377,4 +377,11 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
 }
 
+- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                            scrollViewIsScrolledToBottom:
+                                                                (BOOL)scrollViewIsScrolledToBottom {
+  self.scrimView.hidden = scrollViewIsScrolledToBottom;
+}
+
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -383,11 +383,12 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                                                         scrollViewIsScrolledToEndOfContent:
                                                             (BOOL)
                                                                 scrollViewIsScrolledToEndOfContent {
-  if (self.trackingScrollView){
+  if (self.trackingScrollView) {
     // This logic is to mittigate b/119714330. Dragging the drawer further up when already at the
     // bottom shows the scrim and the presenting view controller
-    self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent ?
-        self.trackingScrollView.backgroundColor : self.scrimColor;
+    self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent
+                                         ? self.trackingScrollView.backgroundColor
+                                         : self.scrimColor;
   }
 }
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -73,6 +73,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
     _drawerShadowColor = [UIColor.blackColor colorWithAlphaComponent:(CGFloat)0.2];
     _elevation = MDCShadowElevationNavDrawer;
     _dismissOnBackgroundTap = YES;
+    _scrimColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
   }
   return self;
 }
@@ -121,8 +122,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   self.bottomDrawerContainerViewController.delegate = self;
 
   self.scrimView = [[MDCBottomDrawerScrimView alloc] initWithFrame:self.containerView.bounds];
-  self.scrimView.backgroundColor =
-      self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
+  self.scrimView.backgroundColor = self.scrimColor;
   self.scrimView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.scrimView.accessibilityIdentifier = @"Close drawer";
@@ -383,8 +383,12 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                                                         scrollViewIsScrolledToEndOfContent:
                                                             (BOOL)
                                                                 scrollViewIsScrolledToEndOfContent {
-  UIColor *normalScrimColor = self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
-  self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent ? self.trackingScrollView.backgroundColor : normalScrimColor;
+  if (self.trackingScrollView){
+    // This logic is to mittigate b/119714330. Dragging the drawer further up when already at the
+    // bottom shows the scrim and the presenting view controller
+    self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent ?
+        self.trackingScrollView.backgroundColor : self.scrimColor;
+  }
 }
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -382,7 +382,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                              scrollViewIsScrolledToEndOfContent:
                                  (BOOL)scrollViewIsScrolledToEndOfContent {
   if (self.trackingScrollView) {
-    // This logic is to mittigate b/119714330. Dragging the drawer further up when already at the
+    // This logic is to mitigate b/119714330. Dragging the drawer further up when already at the
     // bottom shows the scrim and the presenting view controller
     self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent
                                          ? self.trackingScrollView.backgroundColor

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -383,7 +383,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
                                                         scrollViewIsScrolledToEndOfContent:
                                                             (BOOL)
                                                                 scrollViewIsScrolledToEndOfContent {
-  self.scrimView.hidden = scrollViewIsScrolledToEndOfContent;
+  UIColor *normalScrimColor = self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
+  self.scrimView.backgroundColor = scrollViewIsScrolledToEndOfContent ? self.trackingScrollView.backgroundColor : normalScrimColor;
 }
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -377,12 +377,10 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
 }
 
-- (void)
-    bottomDrawerContainerViewControllerDidReachEndOfContent:
-        (MDCBottomDrawerContainerViewController *)containerViewController
-                                                        scrollViewIsScrolledToEndOfContent:
-                                                            (BOOL)
-                                                                scrollViewIsScrolledToEndOfContent {
+- (void)bottomDrawerContainerViewControllerDidReachEndOfContent:
+            (MDCBottomDrawerContainerViewController *)containerViewController
+                             scrollViewIsScrolledToEndOfContent:
+                                 (BOOL)scrollViewIsScrolledToEndOfContent {
   if (self.trackingScrollView) {
     // This logic is to mittigate b/119714330. Dragging the drawer further up when already at the
     // bottom shows the scrim and the presenting view controller

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -377,11 +377,13 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
 }
 
-- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
-                                                            scrollViewIsScrolledToBottom:
-                                                                (BOOL)scrollViewIsScrolledToBottom {
-  self.scrimView.hidden = scrollViewIsScrolledToBottom;
+- (void)
+    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+        (MDCBottomDrawerContainerViewController *)containerViewController
+                                                        scrollViewIsScrolledToEndOfContent:
+                                                            (BOOL)
+                                                                scrollViewIsScrolledToEndOfContent {
+  self.scrimView.hidden = scrollViewIsScrolledToEndOfContent;
 }
 
 @end

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -378,7 +378,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 }
 
 - (void)
-    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+    bottomDrawerContainerViewControllerDidReachEndOfContent:
         (MDCBottomDrawerContainerViewController *)containerViewController
                                                         scrollViewIsScrolledToEndOfContent:
                                                             (BOOL)

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -29,12 +29,15 @@
 This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom.
 
 @param containerViewController the container view controller of the bottom drawer.
-@param scrollViewIsScrolledToBottom whether or not the scroll view is scrolled to the bottom.
+@param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of
+the content.
 */
-- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
-                                                            scrollViewIsScrolledToBottom:
-                                                                (BOOL)scrollViewIsScrolledToBottom;
+- (void)
+    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+        (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                        scrollViewIsScrolledToEndOfContent:
+                                                            (BOOL)
+                                                                scrollViewIsScrolledToEndOfContent;
 
 /**
  This method is called when the bottom drawer will change its presented state to one of the

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -33,7 +33,7 @@ This method is called when the bottom drawer updates its value for scrollViewIsS
 the content.
 */
 - (void)
-    bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+    bottomDrawerContainerViewControllerDidReachEndOfContent:
         (nonnull MDCBottomDrawerContainerViewController *)containerViewController
                                                         scrollViewIsScrolledToEndOfContent:
                                                             (BOOL)

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -26,7 +26,8 @@
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
 
 /**
-This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom when a trackingScrollView is used.
+This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom when
+a trackingScrollView is used.
 
 @param containerViewController the container view controller of the bottom drawer.
 @param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -26,7 +26,7 @@
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
 
 /**
-This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom.
+This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom when a trackingScrollView is used.
 
 @param containerViewController the container view controller of the bottom drawer.
 @param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -27,7 +27,7 @@
 
 /**
 This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom when
-a trackingScrollView is used.
+a trackingScrollView is set.
 
 @param containerViewController the container view controller of the bottom drawer.
 @param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -32,12 +32,10 @@ This method is called when the bottom drawer updates its value for scrollViewIsS
 @param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of
 the content.
 */
-- (void)
-    bottomDrawerContainerViewControllerDidReachEndOfContent:
-        (nonnull MDCBottomDrawerContainerViewController *)containerViewController
-                                                        scrollViewIsScrolledToEndOfContent:
-                                                            (BOOL)
-                                                                scrollViewIsScrolledToEndOfContent;
+- (void)bottomDrawerContainerViewControllerDidReachEndOfContent:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                             scrollViewIsScrolledToEndOfContent:
+                                 (BOOL)scrollViewIsScrolledToEndOfContent;
 
 /**
  This method is called when the bottom drawer will change its presented state to one of the

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -26,7 +26,7 @@
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
 
 /**
-This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom when
+This method is called when the bottom drawer updates its value for scrollViewIsScrolledToEndOfContent when
 a trackingScrollView is set.
 
 @param containerViewController the container view controller of the bottom drawer.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -24,6 +24,18 @@
  Delegate for MDCBottomDrawerContainerViewController.
  */
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
+
+/**
+This method is called when the bottom drawer updates its value for scrollViewIsScrolledToBottom.
+
+@param containerViewController the container view controller of the bottom drawer.
+@param scrollViewIsScrolledToBottom whether or not the scroll view is scrolled to the bottom.
+*/
+- (void)bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+            (nonnull MDCBottomDrawerContainerViewController *)containerViewController
+                                                            scrollViewIsScrolledToBottom:
+                                                                (BOOL)scrollViewIsScrolledToBottom;
+
 /**
  This method is called when the bottom drawer will change its presented state to one of the
  MDCBottomDrawerState states.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -26,8 +26,8 @@
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
 
 /**
-This method is called when the bottom drawer updates its value for scrollViewIsScrolledToEndOfContent when
-a trackingScrollView is set.
+This method is called when the bottom drawer updates its value for
+scrollViewIsScrolledToEndOfContent when a trackingScrollView is set.
 
 @param containerViewController the container view controller of the bottom drawer.
 @param scrollViewIsScrolledToEndOfContent whether or not the scroll view is scrolled to the end of

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -436,11 +436,11 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
     _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToBottom;
     if ([self.delegate
             respondsToSelector:@selector
-            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+            (bottomDrawerContainerViewControllerDidReachEndOfContent:
                                                                  scrollViewIsScrolledToEndOfContent:
                                                                      )]) {
       [self.delegate
-          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+          bottomDrawerContainerViewControllerDidReachEndOfContent:
               self
                                                               scrollViewIsScrolledToEndOfContent:
                                                                   _scrollViewIsScrolledToEndOfContent];

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -434,16 +434,12 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (void)setScrollViewIsScrolledToEndOfContent:(BOOL)scrollViewIsScrolledToBottom {
   if (_scrollViewIsScrolledToEndOfContent != scrollViewIsScrolledToBottom) {
     _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToBottom;
-    if ([self.delegate
-            respondsToSelector:@selector
-            (bottomDrawerContainerViewControllerDidReachEndOfContent:
-                                                                 scrollViewIsScrolledToEndOfContent:
-                                                                     )]) {
-      [self.delegate
-          bottomDrawerContainerViewControllerDidReachEndOfContent:
-              self
-                                                              scrollViewIsScrolledToEndOfContent:
-                                                                  _scrollViewIsScrolledToEndOfContent];
+    if ([self.delegate respondsToSelector:@selector
+                       (bottomDrawerContainerViewControllerDidReachEndOfContent:
+                                             scrollViewIsScrolledToEndOfContent:)]) {
+      [self.delegate bottomDrawerContainerViewControllerDidReachEndOfContent:self
+                                          scrollViewIsScrolledToEndOfContent:
+                                              _scrollViewIsScrolledToEndOfContent];
     }
   }
 }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -148,7 +148,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 @property(nonatomic) BOOL scrollViewIsDraggedToBottom;
 
 // The scroll view is currently scrolled completely to the bottom.
-@property(nonatomic) BOOL scrollViewIsScrolledToBottom;
+@property(nonatomic) BOOL scrollViewIsScrolledToEndOfContent;
 
 // The scroll view has started its current drag from fullscreen.
 @property(nonatomic) BOOL scrollViewBeganDraggingFromFullscreen;
@@ -302,7 +302,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
     if (CGRectGetMinY(self.trackingScrollView.bounds) < maxScrollOrigin || scrollingUpInFull) {
       // If we still didn't reach the end of the content, or if we are scrolling up after reaching
       // the end of the content.
-      self.scrollViewIsScrolledToBottom = NO;
+      self.scrollViewIsScrolledToEndOfContent = NO;
 
       // Update the drawer's scrollView's offset to be static so the content will scroll instead.
       CGRect scrollViewBounds = self.scrollView.bounds;
@@ -321,7 +321,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
       contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(CGRectGetMinY(contentViewBounds), 0));
       self.trackingScrollView.bounds = contentViewBounds;
     } else {
-      self.scrollViewIsScrolledToBottom = YES;
+      self.scrollViewIsScrolledToEndOfContent = YES;
 
       if (self.trackingScrollView.contentSize.height >=
           CGRectGetHeight(self.trackingScrollView.frame)) {
@@ -431,17 +431,19 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
   self.shadowedView.shadowLayer.shadowColor = drawerShadowColor.CGColor;
 }
 
-- (void)setScrollViewIsScrolledToBottom:(BOOL)scrollViewIsScrolledToBottom {
-  if (_scrollViewIsScrolledToBottom != scrollViewIsScrolledToBottom) {
-    _scrollViewIsScrolledToBottom = scrollViewIsScrolledToBottom;
+- (void)setScrollViewIsScrolledToEndOfContent:(BOOL)scrollViewIsScrolledToBottom {
+  if (_scrollViewIsScrolledToEndOfContent != scrollViewIsScrolledToBottom) {
+    _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToBottom;
     if ([self.delegate
             respondsToSelector:@selector
-            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
-                                                                 scrollViewIsScrolledToBottom:)]) {
+            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+                                                                 scrollViewIsScrolledToEndOfContent:
+                                                                     )]) {
       [self.delegate
-          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:self
-                                                              scrollViewIsScrolledToBottom:
-                                                                  _scrollViewIsScrolledToBottom];
+          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToEndOfContent:
+              self
+                                                              scrollViewIsScrolledToEndOfContent:
+                                                                  _scrollViewIsScrolledToEndOfContent];
     }
   }
 }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -431,9 +431,9 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
   self.shadowedView.shadowLayer.shadowColor = drawerShadowColor.CGColor;
 }
 
-- (void)setScrollViewIsScrolledToEndOfContent:(BOOL)scrollViewIsScrolledToBottom {
-  if (_scrollViewIsScrolledToEndOfContent != scrollViewIsScrolledToBottom) {
-    _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToBottom;
+- (void)setScrollViewIsScrolledToEndOfContent:(BOOL)scrollViewIsScrolledToEndOfContent {
+  if (_scrollViewIsScrolledToEndOfContent != scrollViewIsScrolledToEndOfContent) {
+    _scrollViewIsScrolledToEndOfContent = scrollViewIsScrolledToEndOfContent;
     if ([self.delegate respondsToSelector:@selector
                        (bottomDrawerContainerViewControllerDidReachEndOfContent:
                                              scrollViewIsScrolledToEndOfContent:)]) {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -147,6 +147,9 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 // The scroll view is currently being dragged towards bottom.
 @property(nonatomic) BOOL scrollViewIsDraggedToBottom;
 
+// The scroll view is currently scrolled completely to the bottom.
+@property(nonatomic) BOOL scrollViewIsScrolledToBottom;
+
 // The scroll view has started its current drag from fullscreen.
 @property(nonatomic) BOOL scrollViewBeganDraggingFromFullscreen;
 
@@ -299,6 +302,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
     if (CGRectGetMinY(self.trackingScrollView.bounds) < maxScrollOrigin || scrollingUpInFull) {
       // If we still didn't reach the end of the content, or if we are scrolling up after reaching
       // the end of the content.
+      self.scrollViewIsScrolledToBottom = NO;
 
       // Update the drawer's scrollView's offset to be static so the content will scroll instead.
       CGRect scrollViewBounds = self.scrollView.bounds;
@@ -317,6 +321,8 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
       contentViewBounds.origin.y = MIN(maxScrollOrigin, MAX(CGRectGetMinY(contentViewBounds), 0));
       self.trackingScrollView.bounds = contentViewBounds;
     } else {
+      self.scrollViewIsScrolledToBottom = YES;
+
       if (self.trackingScrollView.contentSize.height >=
           CGRectGetHeight(self.trackingScrollView.frame)) {
         // Have the drawer's scrollView's content size be static so it will bounce when reaching the
@@ -423,6 +429,21 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (void)setDrawerShadowColor:(UIColor *)drawerShadowColor {
   _drawerShadowColor = drawerShadowColor;
   self.shadowedView.shadowLayer.shadowColor = drawerShadowColor.CGColor;
+}
+
+- (void)setScrollViewIsScrolledToBottom:(BOOL)scrollViewIsScrolledToBottom {
+  if (_scrollViewIsScrolledToBottom != scrollViewIsScrolledToBottom) {
+    _scrollViewIsScrolledToBottom = scrollViewIsScrolledToBottom;
+    if ([self.delegate
+            respondsToSelector:@selector
+            (bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:
+                                                                 scrollViewIsScrolledToBottom:)]) {
+      [self.delegate
+          bottomDrawerContainerViewControllerDidUpdateValueForScrollViewIsScrolledToBottom:self
+                                                              scrollViewIsScrolledToBottom:
+                                                                  _scrollViewIsScrolledToBottom];
+    }
+  }
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {


### PR DESCRIPTION
Fixes the over-scroll of the bottom navigation drawer so that it does not show the scrim and presenting view controller when over-scrolling the content.

We do this by setting the color of the scrim to the background color of the tracking scroll view.

The default scrim color is now exposed.

Before:
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-21 at 16 36 06](https://user-images.githubusercontent.com/943565/67241188-f3ec6f00-f420-11e9-9b60-dcb57c06dbd8.png)


after:
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-21 at 16 33 16](https://user-images.githubusercontent.com/943565/67240972-87717000-f420-11e9-8c03-de59039be43d.png)
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-21 at 16 33 11](https://user-images.githubusercontent.com/943565/67240994-93f5c880-f420-11e9-8500-17359551cd37.png)


This work started with @andrewoverton's https://github.com/material-components/material-components-ios/pull/8612