### PR TITLE
[Dialogs] Remove uncontrolled snapshot tests.

### DIFF
--- a/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
@@ -288,38 +288,6 @@
   [self generateSnapshotAndVerifyForView:self.alertController.view];
 }
 
-- (void)testScaledFontDynamicTypeForContentSizeCategoryExtraSmallAndLegacyEnabled {
-  // Given
-  [self setAlertControllerContentSizeCategory:UIContentSizeCategoryExtraSmall];
-  self.alertController.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-
-  // When
-  self.alertController.mdc_adjustsFontForContentSizeCategory = YES;
-  [NSNotificationCenter.defaultCenter
-      postNotificationName:UIContentSizeCategoryDidChangeNotification
-                    object:nil];
-
-  // Then
-  [self generateSnapshotAndVerifyForView:self.alertController.view];
-}
-
-- (void)
-    testScaledFontDynamicTypeForContentSizeCategoryAccessibilityExtraExtraExtraLargeAndLegacyEnabled {
-  // Given
-  [self
-      setAlertControllerContentSizeCategory:UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
-  self.alertController.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-
-  // When
-  self.alertController.mdc_adjustsFontForContentSizeCategory = YES;
-  [NSNotificationCenter.defaultCenter
-      postNotificationName:UIContentSizeCategoryDidChangeNotification
-                    object:nil];
-
-  // Then
-  [self generateSnapshotAndVerifyForView:self.alertController.view];
-}
-
 - (void)testDynamicColorSupport {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerCustomTraitCollectionTests/testScaledFontDynamicTypeForContentSizeCategoryAccessibilityExtraExtraExtraLargeAndLegacyEnabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerCustomTraitCollectionTests/testScaledFontDynamicTypeForContentSizeCategoryAccessibilityExtraExtraExtraLargeAndLegacyEnabled_11_2@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cd77c0c221a9eaf151ce76369dd3b6c0a90f1c8c684b645d069d6e99246f0e6
-size 65298

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerCustomTraitCollectionTests/testScaledFontDynamicTypeForContentSizeCategoryExtraSmallAndLegacyEnabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerCustomTraitCollectionTests/testScaledFontDynamicTypeForContentSizeCategoryExtraSmallAndLegacyEnabled_11_2@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cd77c0c221a9eaf151ce76369dd3b6c0a90f1c8c684b645d069d6e99246f0e6
-size 65298


### PR DESCRIPTION
These two "legacy" snapshot tests do not receive input from the test
environment.  They depend on the state of the simulator and can give false
failure/success depending on the simulator's UIContentSizeCategory value.
