### PR TITLE
[Chips] Add snapshot tests for setting preferredFont with adjustsFontForContentSizeCategory

### DIFF
--- a/components/Chips/tests/snapshot/MDCChipViewCustomTraitCollectionSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewCustomTraitCollectionSnapshotTests.m
@@ -47,7 +47,7 @@
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  //          self.recordMode = YES;
+  //            self.recordMode = YES;
 
   self.chip = [[MDCChipViewWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 80, 80)];
   self.containerScheme = [[MDCContainerScheme alloc] init];
@@ -65,6 +65,10 @@
 #pragma mark - Helpers
 
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  CGSize aSize = [view sizeThatFits:CGSizeMake(300, INFINITY)];
+  view.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [view layoutIfNeeded];
+
   UIView *snapshotView = [view mdc_addToBackgroundView];
   [self snapshotVerifyView:snapshotView];
 }
@@ -114,6 +118,59 @@
     [self snapshotVerifyViewForIOS13:snapshotView];
   }
 #endif
+}
+
+- (void)testPreferredFontForAXXXLContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    [self.chip applyThemeWithScheme:self.containerScheme];
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:xsTraitCollection];
+    self.chip.traitCollectionOverride = xsTraitCollection;
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    self.chip.titleLabel.text = @"Title";
+    self.chip.titleLabel.font = originalFont;
+    self.chip.titleLabel.adjustsFontForContentSizeCategory = YES;
+
+    // When
+    self.chip.traitCollectionOverride = aXXXLTraitCollection;
+    // Force the Dynamic Type system to update the button's font.
+    [self.chip drawViewHierarchyInRect:self.chip.bounds afterScreenUpdates:YES];
+
+    // Then
+    [self generateSnapshotAndVerifyForView:self.chip];
+  }
+}
+
+- (void)testPreferredFontForXSContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    [self.chip applyThemeWithScheme:self.containerScheme];
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:aXXXLTraitCollection];
+    self.chip.traitCollectionOverride = aXXXLTraitCollection;
+    self.chip.titleLabel.text = @"Title";
+    self.chip.titleLabel.font = originalFont;
+    self.chip.titleLabel.adjustsFontForContentSizeCategory = YES;
+
+    // When
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+
+    self.chip.traitCollectionOverride = xsTraitCollection;
+    // Force the Dynamic Type system to update the button's font.
+    [self.chip drawViewHierarchyInRect:self.chip.bounds afterScreenUpdates:YES];
+
+    // Then
+    [self generateSnapshotAndVerifyForView:self.chip];
+  }
 }
 
 @end

--- a/components/Chips/tests/snapshot/MDCChipViewCustomTraitCollectionSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewCustomTraitCollectionSnapshotTests.m
@@ -47,7 +47,7 @@
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  //            self.recordMode = YES;
+  //          self.recordMode = YES;
 
   self.chip = [[MDCChipViewWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 80, 80)];
   self.containerScheme = [[MDCContainerScheme alloc] init];

--- a/snapshot_test_goldens/goldens_64/MDCChipViewCustomTraitCollectionSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewCustomTraitCollectionSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e47daa51866ea71276082e8be64c3de3fa982c1a7a916cd875e76085fff83230
+size 6138

--- a/snapshot_test_goldens/goldens_64/MDCChipViewCustomTraitCollectionSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewCustomTraitCollectionSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:769b8be7ee973ad5f9c3128663064ac11c8b5912ef8e3106b537cf70871858b1
+size 2454


### PR DESCRIPTION
This PR adds 2 snapshot tests to verify the behavior for setting preferredFont on Chip's text elements when adjustsFontForContentSizeCategory is set to YES.

Closes #8625