### PR TITLE
[FeatureHighlight] Add snapshot tests for setting preferredFont with adjustsFontForContentSizeCategory

### DIFF
--- a/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
+++ b/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
@@ -17,10 +17,26 @@
 
 #import <XCTest/XCTest.h>
 
+/**
+ An MDCFeatureHighlightViewController subclass that allows the user to override the @c
+ traitCollection property.
+ */
+@interface MDCFeatureHighlightViewControllerWithCustomTraitCollection
+    : MDCFeatureHighlightViewController
+@property(nonatomic, strong) UITraitCollection *traitCollectionOverride;
+@end
+
+@implementation MDCFeatureHighlightViewControllerWithCustomTraitCollection
+- (UITraitCollection *)traitCollection {
+  return self.traitCollectionOverride ?: [super traitCollection];
+}
+@end
+
 /** Snapshot tests for MDCFeatureHighlightViewController and MDCFeatureHighlightView. */
 @interface MDCFeatureHighlightSnapshotTests : MDCSnapshotTestCase
 
-@property(nonatomic, strong) MDCFeatureHighlightViewController *featureHighlightViewController;
+@property(nonatomic, strong)
+    MDCFeatureHighlightViewControllerWithCustomTraitCollection *featureHighlightViewController;
 
 @end
 
@@ -59,8 +75,9 @@
   [currentViewController.view addSubview:highlightLabel];
   highlightLabel.center = currentViewController.view.center;
   self.featureHighlightViewController =
-      [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:highlightLabel
-                                                              completion:nil];
+      [[MDCFeatureHighlightViewControllerWithCustomTraitCollection alloc]
+          initWithHighlightedView:highlightLabel
+                       completion:nil];
   self.featureHighlightViewController.titleText = @"Feature Highlight Title";
   self.featureHighlightViewController.bodyText = @"Feature Highlight Body";
   self.featureHighlightViewController.outerHighlightColor = UIColor.blueColor;
@@ -80,6 +97,97 @@
   [self snapshotVerifyViewForIOS13:window];
 
   [highlightLabel removeFromSuperview];
+}
+
+- (void)testPreferredFontForAXXXLContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+    UIViewController *currentViewController = window.rootViewController;
+    UILabel *highlightLabel = [[UILabel alloc] init];
+    highlightLabel.text = @"Highlight";
+    [highlightLabel sizeToFit];
+    [currentViewController.view addSubview:highlightLabel];
+    highlightLabel.center = currentViewController.view.center;
+    self.featureHighlightViewController =
+        [[MDCFeatureHighlightViewControllerWithCustomTraitCollection alloc]
+            initWithHighlightedView:highlightLabel
+                         completion:nil];
+    self.featureHighlightViewController.titleText = @"Feature Highlight Title";
+    self.featureHighlightViewController.bodyText = @"Feature Highlight Body";
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:xsTraitCollection];
+    self.featureHighlightViewController.traitCollectionOverride = xsTraitCollection;
+    self.featureHighlightViewController.titleFont = originalFont;
+    self.featureHighlightViewController.bodyFont = originalFont;
+
+    // When
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    XCTestExpectation *expectation =
+        [[XCTestExpectation alloc] initWithDescription:@"Feature highlight is presented"];
+    [currentViewController
+        presentViewController:self.featureHighlightViewController
+                     animated:YES
+                   completion:^{
+                     self.featureHighlightViewController.traitCollectionOverride =
+                         aXXXLTraitCollection;
+
+                     [expectation fulfill];
+                   }];
+
+    // Then
+    [self waitForExpectations:@[ expectation ] timeout:5];
+    [self snapshotVerifyView:window];
+  }
+}
+
+- (void)testPreferredFontForXSContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+    UIViewController *currentViewController = window.rootViewController;
+    UILabel *highlightLabel = [[UILabel alloc] init];
+    highlightLabel.text = @"Highlight";
+    [highlightLabel sizeToFit];
+    [currentViewController.view addSubview:highlightLabel];
+    highlightLabel.center = currentViewController.view.center;
+    self.featureHighlightViewController =
+        [[MDCFeatureHighlightViewControllerWithCustomTraitCollection alloc]
+            initWithHighlightedView:highlightLabel
+                         completion:nil];
+    self.featureHighlightViewController.titleText = @"Feature Highlight Title";
+    self.featureHighlightViewController.bodyText = @"Feature Highlight Body";
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
+                               compatibleWithTraitCollection:aXXXLTraitCollection];
+    self.featureHighlightViewController.traitCollectionOverride = aXXXLTraitCollection;
+    self.featureHighlightViewController.titleFont = originalFont;
+    self.featureHighlightViewController.bodyFont = originalFont;
+
+    // When
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    XCTestExpectation *expectation =
+        [[XCTestExpectation alloc] initWithDescription:@"Feature highlight is presented"];
+    [currentViewController
+        presentViewController:self.featureHighlightViewController
+                     animated:YES
+                   completion:^{
+                     self.featureHighlightViewController.traitCollectionOverride =
+                         xsTraitCollection;
+                     [expectation fulfill];
+                   }];
+
+    // Then
+    [self waitForExpectations:@[ expectation ] timeout:5];
+    [self snapshotVerifyView:window];
+  }
 }
 
 @end

--- a/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
+++ b/components/FeatureHighlight/tests/snapshot/MDCFeatureHighlightSnapshotTests.m
@@ -117,9 +117,9 @@
     self.featureHighlightViewController.bodyText = @"Feature Highlight Body";
     UITraitCollection *xsTraitCollection = [UITraitCollection
         traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
-    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
-                               compatibleWithTraitCollection:xsTraitCollection];
     self.featureHighlightViewController.traitCollectionOverride = xsTraitCollection;
+    UIFontMetrics *bodyMetrics = [UIFontMetrics metricsForTextStyle:UIFontTextStyleBody];
+    UIFont *originalFont = [bodyMetrics scaledFontForFont:[UIFont fontWithName:@"Zapfino" size:20]];
     self.featureHighlightViewController.titleFont = originalFont;
     self.featureHighlightViewController.bodyFont = originalFont;
 
@@ -164,9 +164,9 @@
     UITraitCollection *aXXXLTraitCollection =
         [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
                                UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
-    UIFont *originalFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody
-                               compatibleWithTraitCollection:aXXXLTraitCollection];
     self.featureHighlightViewController.traitCollectionOverride = aXXXLTraitCollection;
+    UIFontMetrics *bodyMetrics = [UIFontMetrics metricsForTextStyle:UIFontTextStyleBody];
+    UIFont *originalFont = [bodyMetrics scaledFontForFont:[UIFont fontWithName:@"Zapfino" size:20]];
     self.featureHighlightViewController.titleFont = originalFont;
     self.featureHighlightViewController.bodyFont = originalFont;
 

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cea61ec6045c9244f99b7ca653997b2babd1acffa4fc1d4366b6c36b0948a37b
-size 58340
+oid sha256:56a64629a06866800b5a4cf795cb80251a4dbc47c2a7101be54b543c2f2e4728
+size 43336

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2bdb8a43c4f7ec045fed8c035612674efced79f8597e0689b246d5f67943660
-size 63490
+oid sha256:cea61ec6045c9244f99b7ca653997b2babd1acffa4fc1d4366b6c36b0948a37b
+size 58340

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24da8b6707ee1e1b2f1bd35b5e86b684b33e9004f918a9a569e1fb3ae6d33649
+size 44300

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24da8b6707ee1e1b2f1bd35b5e86b684b33e9004f918a9a569e1fb3ae6d33649
-size 44300
+oid sha256:d2bdb8a43c4f7ec045fed8c035612674efced79f8597e0689b246d5f67943660
+size 63490

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cea61ec6045c9244f99b7ca653997b2babd1acffa4fc1d4366b6c36b0948a37b
-size 58340
+oid sha256:56a64629a06866800b5a4cf795cb80251a4dbc47c2a7101be54b543c2f2e4728
+size 43336

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ebfaeba23020d84f67d65db813c94c0e984e0d515f84c12a3f2c1b176f2e166
+size 54453

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ebfaeba23020d84f67d65db813c94c0e984e0d515f84c12a3f2c1b176f2e166
-size 54453
+oid sha256:d2bdb8a43c4f7ec045fed8c035612674efced79f8597e0689b246d5f67943660
+size 63490

--- a/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFeatureHighlightSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2bdb8a43c4f7ec045fed8c035612674efced79f8597e0689b246d5f67943660
-size 63490
+oid sha256:cea61ec6045c9244f99b7ca653997b2babd1acffa4fc1d4366b6c36b0948a37b
+size 58340


### PR DESCRIPTION
This PR adds 2 snapshot tests to verify the behavior for setting preferredFont on FeatureHighlight's title and body text.

Closes #8630 