### PR TITLE
[Slider] Add snapshot tests for setting preferredFont with adjustsFontForContentSizeCategory

### DIFF
--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -87,6 +87,7 @@ mdc_snapshot_objc_library(
     name = "snapshot_test_lib",
     deps = [
         ":Slider",
+        ":private",
     ],
 )
 

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -73,6 +73,7 @@ mdc_unit_test_objc_library(
         ":ColorThemer",
         ":Slider",
         ":private",
+        "//components/private/ThumbTrack",
     ],
 )
 

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -16,7 +16,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MDCSlider_Subclassable.h"
+#import "../../src/private/MDCSlider_Subclassable.h"
 #import "MaterialSlider.h"
 #import "MaterialThumbtrack.h"
 

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -18,7 +18,7 @@
 
 #import "../../src/private/MDCSlider_Subclassable.h"
 #import "MaterialSlider.h"
-#import "MaterialThumbtrack.h"
+#import "MaterialThumbTrack.h"
 
 /**
  An MDCSlider subclass that allows the user to override the @c traitCollection property.

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialSlider.h"
 #import "MDCSlider_Subclassable.h"
+#import "MaterialSlider.h"
 #import "MaterialThumbtrack.h"
 
 /**
@@ -227,8 +227,9 @@
     self.slider.value =
         self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
     self.slider.shouldDisplayDiscreteValueLabel = YES;
-    UITraitCollection *aXXXLTraitCollection = [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
-    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
     self.slider.traitCollectionOverride = aXXXLTraitCollection;
     // Cannot set font, nor adjustsFontForContentSizeCategory for the thumbtrack label.
 

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -17,9 +17,35 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialSlider.h"
+#import "MDCSlider_Subclassable.h"
+#import "MaterialThumbtrack.h"
+
+/**
+ An MDCSlider subclass that allows the user to override the @c traitCollection property.
+ */
+@interface MDCSliderWithCustomTraitCollection : MDCSlider
+@property(nonatomic, strong) UITraitCollection *traitCollectionOverride;
+@property(nonatomic, strong) MDCThumbTrack *thumbTrack;
+
+@end
+
+@implementation MDCSliderWithCustomTraitCollection
+
+- (MDCThumbTrack *)thumbTrack {
+  return _thumbTrack;
+}
+
+- (void)setThumbTrack:(MDCThumbTrack *)thumbTrack {
+  _thumbTrack = thumbTrack;
+}
+
+- (UITraitCollection *)traitCollection {
+  return self.traitCollectionOverride ?: [super traitCollection];
+}
+@end
 
 @interface MDCSliderSnapshotTests : MDCSnapshotTestCase
-@property(nonatomic, strong) MDCSlider *slider;
+@property(nonatomic, strong) MDCSliderWithCustomTraitCollection *slider;
 @end
 
 @implementation MDCSliderSnapshotTests
@@ -31,7 +57,8 @@
   // test you wish to recreate the golden for).
   // self.recordMode = YES;
 
-  self.slider = [[MDCSlider alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];
+  self.slider =
+      [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];
   self.slider.statefulAPIEnabled = YES;
   self.slider.minimumValue = -10;
   self.slider.maximumValue = 10;
@@ -165,6 +192,57 @@
     [self snapshotVerifyViewForIOS13:snapshotView];
   }
 #endif
+}
+
+- (void)testPreferredFontForAXXXLContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    [self makeSliderDiscrete:self.slider];
+    self.slider.value =
+        self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+    self.slider.shouldDisplayDiscreteValueLabel = YES;
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    self.slider.traitCollectionOverride = xsTraitCollection;
+    // Cannot set font, nor adjustsFontForContentSizeCategory for the thumbtrack label.
+
+    // When
+    UITraitCollection *aXXXLTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+                               UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    self.slider.traitCollectionOverride = aXXXLTraitCollection;
+    [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
+
+    // Then
+    UIView *snapshotView =
+        [self.slider mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(30, 0, 0, 0)];
+    [self generateSnapshotAndVerifyForView:snapshotView];
+  }
+}
+
+- (void)testPreferredFontForXSContentSizeCategory {
+  if (@available(iOS 11.0, *)) {
+    // Given
+    [self makeSliderDiscrete:self.slider];
+    self.slider.value =
+        self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+    self.slider.shouldDisplayDiscreteValueLabel = YES;
+    UITraitCollection *aXXXLTraitCollection = [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
+    self.slider.traitCollectionOverride = aXXXLTraitCollection;
+    // Cannot set font, nor adjustsFontForContentSizeCategory for the thumbtrack label.
+
+    // When
+    UITraitCollection *xsTraitCollection = [UITraitCollection
+        traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
+    self.slider.traitCollectionOverride = xsTraitCollection;
+    [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
+
+    // Then
+    UIView *snapshotView =
+        [self.slider mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(30, 0, 0, 0)];
+    [self generateSnapshotAndVerifyForView:snapshotView];
+  }
 }
 
 @end

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8485d495e26e3583c896d6a00254c5670959bba201dbe294213a805fd5d7bd7e
+size 4541

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8485d495e26e3583c896d6a00254c5670959bba201dbe294213a805fd5d7bd7e
+size 4541


### PR DESCRIPTION
This PR adds 2 snapshot tests to verify the behavior for setting preferredFont on the Banner's text elements when adjustsFontForContentSizeCategory is set to YES.

It is important to note that Slider currently doesn't expose any font property nor allows setting adjustsFontForContentSizeCategory on the label of the thumbtrack. These snapshot tests allow us to verify once we provide these APIs to see the changes to the font size.
Opened b/143287831 for tracking.

Closes #8643 
