### PR TITLE
[Dialogs] Mark `buttonFont` deprecated.

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -73,9 +73,13 @@
 /** The color applied to the message of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *messageColor;
 
-// b/117717380: Will be deprecated
-/** The font applied to the button of Alert Controller.*/
-@property(nonatomic, strong, nullable) UIFont *buttonFont;
+/**
+ The font applied to the button of Alert Controller.
+
+ @note This property is deprecated and will be removed in an upcoming release.
+ */
+@property(nonatomic, strong, nullable)
+    UIFont *buttonFont __deprecated_msg("Please use buttonForAction: to set button properties.");
 
 // b/117717380: Will be deprecated
 /** The color applied to the button title text of Alert Controller.*/


### PR DESCRIPTION
There is no internal usage of the API, so it is being deprecated and removed.
Users should instead use `buttonForAction:` to set button properties directly.

Part of #5418