### PR TITLE
[Dialogs] Remove `buttonFont` API.

### DIFF
--- a/components/Dialogs/examples/DialogsTallTextAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTallTextAlertExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import <MaterialComponents/MaterialContainerScheme.h>
 #import <MaterialComponents/MaterialDialogs+Theming.h>
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
@@ -93,7 +94,14 @@
     dialogButtonFont = [UIFont fontWithName:urduFontName size:20.0];
   }
   alert.messageFont = dialogBodyFont;
-  alert.buttonFont = dialogButtonFont;
+  for (MDCAlertAction *action in alert.actions) {
+    MDCButton *button = [alert buttonForAction:action];
+    if (button.enableTitleFontForState) {
+      [button setTitleFont:dialogButtonFont forState:UIControlStateNormal];
+    } else {
+      button.titleLabel.font = dialogButtonFont;
+    }
+  }
 
   [self presentViewController:alert animated:YES completion:nil];
 }

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -73,14 +73,6 @@
 /** The color applied to the message of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *messageColor;
 
-/**
- The font applied to the button of Alert Controller.
-
- @note This property is deprecated and will be removed in an upcoming release.
- */
-@property(nonatomic, strong, nullable)
-    UIFont *buttonFont __deprecated_msg("Please use buttonForAction: to set button properties.");
-
 // b/117717380: Will be deprecated
 /** The color applied to the button title text of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *buttonTitleColor;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -234,14 +234,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
-// b/117717380: Will be deprecated
-- (void)setButtonFont:(UIFont *)buttonFont {
-  _buttonFont = buttonFont;
-  if (self.alertView) {
-    self.alertView.buttonFont = buttonFont;
-  }
-}
-
 - (void)setTitleColor:(UIColor *)titleColor {
   _titleColor = titleColor;
   if (self.alertView) {
@@ -431,7 +423,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     // Avoid reset title color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonColor = self.buttonTitleColor;  // b/117717380: Will be deprecated
   }
-  self.alertView.buttonFont = self.buttonFont;  // b/117717380: Will be deprecated
   if (self.buttonInkColor) {
     // Avoid reset ink color to white when setting it to nil. only set it for an actual UIColor.
     self.alertView.buttonInkColor = self.buttonInkColor;  // b/117717380: Will be deprecated

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -27,7 +27,6 @@
 @property(nonatomic, strong, nullable) UIColor *messageColor UI_APPEARANCE_SELECTOR;
 
 // b/117717380: Will be deprecated (x3)
-@property(nonatomic, strong, nullable) UIFont *buttonFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *buttonColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *buttonInkColor UI_APPEARANCE_SELECTOR;
 

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerCustomTraitCollectionTests.m
@@ -18,6 +18,7 @@
 #import <UIKit/UIKit.h>
 
 #import "../../src/private/MDCDialogShadowedView.h"
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialColor.h"
 #import "MaterialDialogs.h"
 #import "MaterialTypography.h"
@@ -91,7 +92,15 @@
   UIFont *buttonFont = [UIFont systemFontOfSize:15];
   buttonFont = [buttonFontScaler scaledFontWithFont:buttonFont];
   buttonFont = [buttonFont mdc_scaledFontAtDefaultSize];
-  self.alertController.buttonFont = buttonFont;
+  for (MDCAlertAction *action in _alertController.actions) {
+    MDCButton *button = [_alertController buttonForAction:action];
+    if (button.enableTitleFontForState) {
+      [button setTitleFont:buttonFont forState:UIControlStateNormal];
+    } else {
+      button.titleLabel.font = buttonFont;
+    }
+  }
+
   self.alertController.view.bounds = CGRectMake(0, 0, 300, 300);
 }
 

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
@@ -15,6 +15,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <UIKit/UIKit.h>
 
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialDialogs.h"
 #import "MaterialSnapshot.h"
 
@@ -92,7 +93,6 @@ static NSString *const kActionLowUrdu = @"کم";
     dialogButtonFont = [UIFont fontWithName:urduFontName size:26.0];
   }
   self.alertController.messageFont = dialogBodyFont;
-  self.alertController.buttonFont = dialogButtonFont;
   MDCAlertAction *actionLow = [MDCAlertAction actionWithTitle:kActionLowUrdu
                                                      emphasis:MDCActionEmphasisLow
                                                       handler:nil];
@@ -102,8 +102,28 @@ static NSString *const kActionLowUrdu = @"کم";
   [self.alertController addAction:actionLow];
   [self.alertController addAction:actionMedium];
 
-  [self changeToRTL:self.alertController];
+  for (MDCAlertAction *action in self.alertController.actions) {
+    MDCButton *button = [self.alertController buttonForAction:action];
+    if (button.enableTitleFontForState) {
+      [button setTitleFont:dialogButtonFont forState:UIControlStateNormal];
+    } else {
+      button.titleLabel.font = dialogButtonFont;
+    }
+  }
+
+  // This is the same Dialog as DialogsTallTextAlertExampleViewController, but due to the artificial
+  // environment of snapshot/unit testing, an extra layout pass is required for the AlertView to
+  // update its `preferredContentSize`.
+  // Importantly, MDCAlertController assumes that the `preferredContentSize` is based on the current
+  // bounds of the alert view. Any layout pass must first set the bounds to what the
+  // `preferredContentSize` might be so that the controller's logic
   CGSize preferredContentSize = self.alertController.preferredContentSize;
+  self.alertController.view.bounds =
+      CGRectMake(0, 0, preferredContentSize.width, preferredContentSize.height);
+  [self.alertController.view layoutIfNeeded];
+
+  [self changeToRTL:self.alertController];
+  preferredContentSize = self.alertController.preferredContentSize;
   self.alertController.view.bounds =
       CGRectMake(0, 0, preferredContentSize.width, preferredContentSize.height);
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerLayoutTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerLayoutTests.m
@@ -14,6 +14,7 @@
 
 #import "MaterialDialogs.h"
 
+#import "MDCAlertController+ButtonForAction.h"
 #import "MDCAlertControllerView+Private.h"
 
 #import <XCTest/XCTest.h>
@@ -51,12 +52,19 @@ static const CGFloat kFourInchLandscapeWidth = 568.0;
     dialogButtonFont = [UIFont systemFontOfSize:26.0];
   }
   _alertController.messageFont = dialogBodyFont;
-  _alertController.buttonFont = dialogButtonFont;
 
   MDCAlertAction *retryAction = [MDCAlertAction actionWithTitle:@"دوبارہ کوشش کریں" handler:nil];
   MDCAlertAction *cancelAction = [MDCAlertAction actionWithTitle:@"منسوخ کریں" handler:nil];
   [_alertController addAction:retryAction];
   [_alertController addAction:cancelAction];
+  for (MDCAlertAction *action in _alertController.actions) {
+    MDCButton *button = [_alertController buttonForAction:action];
+    if (button.enableTitleFontForState) {
+      [button setTitleFont:dialogButtonFont forState:UIControlStateNormal];
+    } else {
+      button.titleLabel.font = dialogButtonFont;
+    }
+  }
 }
 
 - (void)tearDown {

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -68,22 +68,18 @@
   XCTAssertEqualObjects(self.alert.message, @"message");
 }
 
-- (void)testAlertControllerTyphography {
+- (void)testAlertControllerTypography {
   // Given
   UIFont *testFont = [UIFont boldSystemFontOfSize:30];
 
   // When
   self.alert.titleFont = testFont;
   self.alert.messageFont = testFont;
-  self.alert.buttonFont = testFont;
 
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
   XCTAssertEqualObjects(view.titleLabel.font, testFont);
   XCTAssertEqualObjects(view.messageLabel.font, testFont);
-  for (UIButton *button in view.actionManager.buttonsInActionOrder) {
-    XCTAssertEqualObjects(button.titleLabel.font, testFont);
-  }
 }
 
 - (void)testAlertControllerColorSetting {
@@ -208,10 +204,8 @@
   self.alert.buttonInkColor = testColor;
   self.alert.titleFont = [UIFont systemFontOfSize:12];
   self.alert.messageFont = [UIFont systemFontOfSize:14];
-  self.alert.buttonFont = [UIFont systemFontOfSize:10];
-  [self.alert addAction:[MDCAlertAction actionWithTitle:@"test"
-                                                handler:^(MDCAlertAction *_Nonnull action){
-                                                }]];
+  [self.alert addAction:[MDCAlertAction actionWithTitle:@"test" handler:nil]];
+
   XCTAssertFalse(self.alert.isViewLoaded);
 }
 
@@ -358,12 +352,15 @@
   self.alert.titleFont = fakeTitleFont;
   UIFont *fakeMessageFont = [UIFont systemFontOfSize:50];
   self.alert.messageFont = fakeMessageFont;
-  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo"
-                                                       handler:^(MDCAlertAction *action){
-                                                       }];
+  MDCAlertAction *fakeAction = [MDCAlertAction actionWithTitle:@"Foo" handler:nil];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
-  self.alert.buttonFont = fakeButtonFont;
+  MDCButton *button = [self.alert buttonForAction:fakeAction];
+  if (button.enableTitleFontForState) {
+    [button setTitleFont:fakeButtonFont forState:UIControlStateNormal];
+  } else {
+    button.titleLabel.font = fakeButtonFont;
+  }
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = NO;
 
   // When
@@ -375,10 +372,14 @@
                 view.titleLabel.font, fakeTitleFont);
   XCTAssertTrue([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont],
                 @"%@ is not equal to %@", view.messageLabel.font, fakeMessageFont);
-  MDCButton *button = [self.alert buttonForAction:fakeAction];
-  XCTAssertTrue([[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
-                @"%@ is not equal to %@", [button titleFontForState:UIControlStateNormal],
-                fakeButtonFont);
+  if (button.enableTitleFontForState) {
+    XCTAssertTrue(
+        [[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
+        @"%@ is not equal to %@", [button titleFontForState:UIControlStateNormal], fakeButtonFont);
+  } else {
+    XCTAssertTrue([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
+                  @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
+  }
 }
 
 - (void)testDynamicTypeEnabledAndLegacyEnabledUpdatesTheFonts {
@@ -392,7 +393,12 @@
                                                        }];
   [self.alert addAction:fakeAction];
   UIFont *fakeButtonFont = [UIFont systemFontOfSize:45];
-  self.alert.buttonFont = fakeButtonFont;
+  MDCButton *button = [self.alert buttonForAction:fakeAction];
+  if (button.enableTitleFontForState) {
+    [button setTitleFont:fakeButtonFont forState:UIControlStateNormal];
+  } else {
+    button.titleLabel.font = fakeButtonFont;
+  }
   self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 
   // When
@@ -404,10 +410,14 @@
                  view.titleLabel.font, fakeTitleFont);
   XCTAssertFalse([view.messageLabel.font mdc_isSimplyEqual:fakeMessageFont], @"%@ is equal to %@",
                  view.messageLabel.font, fakeMessageFont);
-  MDCButton *button = [self.alert buttonForAction:fakeAction];
-  XCTAssertFalse([[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
-                 @"%@ is equal to %@", [button titleFontForState:UIControlStateNormal],
-                 fakeButtonFont);
+  if (button.enableTitleFontForState) {
+    XCTAssertFalse(
+        [[button titleFontForState:UIControlStateNormal] mdc_isSimplyEqual:fakeButtonFont],
+        @"%@ is not equal to %@", [button titleFontForState:UIControlStateNormal], fakeButtonFont);
+  } else {
+    XCTAssertFalse([button.titleLabel.font mdc_isSimplyEqual:fakeButtonFont],
+                   @"%@ is not equal to %@", button.titleLabel.font, fakeButtonFont);
+  }
 }
 
 - (void)testTraitCollectionDidChangeBlockCalledWithExpectedParameters {


### PR DESCRIPTION
The `buttonFont` was deprecated and has no internal usage. It is being removed
so clients can customize the button font directly.

Part of #5418