### PR TITLE
[TextFields] Add filled style object

### DIFF
--- a/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
@@ -148,7 +148,7 @@ static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
  This method allows objects conforming to MDCTextControlStyle to apply themselves to objects
  conforming to MDCTextControl.
  */
-- (void)applyStyleToTextControl:(nonnull id<MDCTextControl>)textControl;
+- (void)applyStyleToTextControl:(nonnull UIView<MDCTextControl> *)textControl;
 /**
  This method allows objects conforming to MDCTextControlStyle to remove the styling
  previously applied to objects conforming to MDCTextControl.

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
@@ -26,7 +26,7 @@
   return font;
 }
 
-- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
 }
 
 - (void)removeStyleFrom:(id<MDCTextControl>)textControl {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
@@ -18,7 +18,8 @@
 #import "MDCTextControlLabelBehavior.h"
 #import "MDCTextControlStyleBase.h"
 
-//TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic inside it) lands there should be snapshot tests for it.
+// TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic
+// inside it) lands there should be snapshot tests for it.
 @interface MDCTextControlStyleFilled : NSObject <MDCTextControlStyle>
 - (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
 - (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
@@ -18,6 +18,7 @@
 #import "MDCTextControlLabelBehavior.h"
 #import "MDCTextControlStyleBase.h"
 
+//TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic inside it) lands there should be snapshot tests for it.
 @interface MDCTextControlStyleFilled : NSObject <MDCTextControlStyle>
 - (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
 - (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
@@ -20,10 +20,36 @@
 
 // TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic
 // inside it) lands there should be snapshot tests for it.
+/**
+This style object is used by MDCTextControls adopting the Material Filled style.
+*/
 @interface MDCTextControlStyleFilled : NSObject <MDCTextControlStyle>
-- (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
+
+/**
+Sets the underline color color for a given state.
+@param underlineColor The UIColor for the given state.
+@param state The MDCTextControlState.
+*/
 - (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state;
-- (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state;
+
+/**
+Returns the underline color color for a given state.
+@param state The MDCTextControlState.
+*/
+- (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
+
+/**
+Sets the filled background color color for a given state.
+@param filledBackgroundColor The UIColor for the given state.
+@param state The MDCTextControlState.
+*/
 - (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
                         forState:(MDCTextControlState)state;
+
+/**
+Returns the filled background color for a given state.
+@param state The MDCTextControlState.
+*/
+- (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state;
+
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.h
@@ -1,0 +1,27 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextControl.h"
+#import "MDCTextControlLabelBehavior.h"
+#import "MDCTextControlStyleBase.h"
+
+@interface MDCTextControlStyleFilled : NSObject <MDCTextControlStyle>
+- (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
+- (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state;
+- (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state;
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
+                        forState:(MDCTextControlState)state;
+@end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -108,13 +108,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControl
 
-- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
-  if (![textControl isKindOfClass:[UIView class]]) {
-    [self removeStyleFrom:textControl];
-    return;
-  }
-  UIView *uiView = (UIView *)textControl;
-  [self applyStyleToView:uiView
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
+  [self applyStyleToView:textControl
                    state:textControl.textControlState
           containerFrame:textControl.containerFrame];
 }

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -1,0 +1,437 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextControlStyleFilled.h"
+
+#import <Foundation/Foundation.h>
+
+#import "MDCTextControl.h"
+#import "UIBezierPath+MDCTextControlStyle.h"
+#import "MDCTextControlVerticalPositioningReferenceFilled.h"
+
+static const CGFloat kFilledContainerStyleTopCornerRadius = (CGFloat)4.0;
+static const CGFloat kFilledContainerStyleUnderlineWidthThin = (CGFloat)1.0;
+static const CGFloat kFilledContainerStyleUnderlineWidthThick = (CGFloat)2.0;
+
+static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
+
+@interface MDCTextControlStyleFilled () <CAAnimationDelegate>
+
+@property(strong, nonatomic) CAShapeLayer *filledSublayer;
+@property(strong, nonatomic) CAShapeLayer *thinUnderlineLayer;
+@property(strong, nonatomic) CAShapeLayer *thickUnderlineLayer;
+
+@property(strong, nonatomic, readonly, class) NSString *thickUnderlineGrowKey;
+@property(strong, nonatomic, readonly, class) NSString *thickUnderlineShrinkKey;
+@property(strong, nonatomic, readonly, class) NSString *thinUnderlineGrowKey;
+@property(strong, nonatomic, readonly, class) NSString *thinUnderlineShrinkKey;
+
+@property(strong, nonatomic) NSMutableDictionary<NSNumber *, UIColor *> *underlineColors;
+@property(strong, nonatomic) NSMutableDictionary<NSNumber *, UIColor *> *filledBackgroundColors;
+
+@end
+
+@implementation MDCTextControlStyleFilled
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self commonMDCTextControlStyleFilledInit];
+  }
+  return self;
+}
+
+- (void)commonMDCTextControlStyleFilledInit {
+  [self setUpUnderlineColors];
+  [self setUpFilledBackgroundColors];
+  [self setUpSublayers];
+}
+
+- (void)setUpUnderlineColors {
+  self.underlineColors = [NSMutableDictionary new];
+  UIColor *underlineColor = [UIColor blackColor];
+  self.underlineColors[@(MDCTextControlStateNormal)] = underlineColor;
+  self.underlineColors[@(MDCTextControlStateEditing)] = underlineColor;
+  self.underlineColors[@(MDCTextControlStateDisabled)] = underlineColor;
+}
+
+- (void)setUpFilledBackgroundColors {
+  self.filledBackgroundColors = [NSMutableDictionary new];
+  UIColor *filledBackgroundColor = [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.1];
+  self.filledBackgroundColors[@(MDCTextControlStateNormal)] = filledBackgroundColor;
+  self.filledBackgroundColors[@(MDCTextControlStateEditing)] = filledBackgroundColor;
+  self.filledBackgroundColors[@(MDCTextControlStateDisabled)] = filledBackgroundColor;
+}
+
+- (void)setUpSublayers {
+  self.filledSublayer = [[CAShapeLayer alloc] init];
+  self.filledSublayer.lineWidth = 0.0;
+  self.thinUnderlineLayer = [[CAShapeLayer alloc] init];
+  [self.filledSublayer addSublayer:self.thinUnderlineLayer];
+  self.thickUnderlineLayer = [[CAShapeLayer alloc] init];
+  [self.filledSublayer addSublayer:self.thickUnderlineLayer];
+}
+
+#pragma mark Accessors
+
+- (UIColor *)underlineColorForState:(MDCTextControlState)state {
+  return self.underlineColors[@(state)];
+}
+
+- (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state {
+  self.underlineColors[@(state)] = underlineColor;
+}
+
+- (UIColor *)filledBackgroundColorForState:(MDCTextControlState)state {
+  return self.filledBackgroundColors[@(state)];
+}
+
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
+                        forState:(MDCTextControlState)state {
+  self.filledBackgroundColors[@(state)] = filledBackgroundColor;
+}
+
+- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
+  if (![textControl isKindOfClass:[UIView class]]) {
+    [self removeStyleFrom:textControl];
+    return;
+  }
+  UIView *uiView = (UIView *)textControl;
+  [self applyStyleToView:uiView
+                   state:textControl.textControlState
+          containerFrame:textControl.containerFrame];
+}
+
+- (void)removeStyleFrom:(id<MDCTextControl>)textControl {
+  [self.filledSublayer removeFromSuperlayer];
+  [self.thinUnderlineLayer removeFromSuperlayer];
+  [self.thickUnderlineLayer removeFromSuperlayer];
+}
+
+- (void)applyStyleToView:(UIView *)view
+                   state:(MDCTextControlState)state
+          containerFrame:(CGRect)containerFrame {
+  self.filledSublayer.fillColor = [self.filledBackgroundColors[@(state)] CGColor];
+  self.thinUnderlineLayer.fillColor = [self.underlineColors[@(state)] CGColor];
+  self.thickUnderlineLayer.fillColor = [self.underlineColors[@(state)] CGColor];
+
+  CGFloat containerHeight = CGRectGetMaxY(containerFrame);
+  UIBezierPath *filledSublayerBezier = [self filledSublayerPathWithTextFieldBounds:view.bounds
+                                                                   containerHeight:containerHeight];
+  self.filledSublayer.path = filledSublayerBezier.CGPath;
+  if (self.filledSublayer.superlayer != view.layer) {
+    [view.layer insertSublayer:self.filledSublayer atIndex:0];
+  }
+
+  BOOL shouldShowThickUnderline = [self shouldShowThickUnderlineWithState:state];
+  CGFloat viewWidth = CGRectGetWidth(view.bounds);
+  CGFloat thickUnderlineThickness = shouldShowThickUnderline ? viewWidth : 0;
+  UIBezierPath *targetThickUnderlineBezier =
+      [self filledSublayerUnderlinePathWithViewBounds:view.bounds
+                                      containerHeight:containerHeight
+                                   underlineThickness:kFilledContainerStyleUnderlineWidthThick
+                                       underlineWidth:thickUnderlineThickness];
+  CGFloat thinUnderlineThickness =
+      shouldShowThickUnderline ? 0 : kFilledContainerStyleUnderlineWidthThin;
+  UIBezierPath *targetThinUnderlineBezier =
+      [self filledSublayerUnderlinePathWithViewBounds:view.bounds
+                                      containerHeight:containerHeight
+                                   underlineThickness:thinUnderlineThickness
+                                       underlineWidth:viewWidth];
+
+  CABasicAnimation *preexistingThickUnderlineShrinkAnimation =
+      (CABasicAnimation *)[self.thickUnderlineLayer
+          animationForKey:self.class.thickUnderlineShrinkKey];
+  CABasicAnimation *preexistingThickUnderlineGrowAnimation =
+      (CABasicAnimation *)[self.thickUnderlineLayer
+          animationForKey:self.class.thickUnderlineGrowKey];
+
+  CABasicAnimation *preexistingThinUnderlineGrowAnimation =
+      (CABasicAnimation *)[self.thinUnderlineLayer animationForKey:self.class.thinUnderlineGrowKey];
+  CABasicAnimation *preexistingThinUnderlineShrinkAnimation =
+      (CABasicAnimation *)[self.thinUnderlineLayer
+          animationForKey:self.class.thinUnderlineShrinkKey];
+
+  [CATransaction begin];
+  {
+    if (shouldShowThickUnderline) {
+      if (preexistingThickUnderlineShrinkAnimation) {
+        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
+      }
+      BOOL needsThickUnderlineGrowAnimation = NO;
+      if (preexistingThickUnderlineGrowAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineGrowAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
+          needsThickUnderlineGrowAnimation = YES;
+          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThickUnderlineGrowAnimation = YES;
+      }
+      if (needsThickUnderlineGrowAnimation) {
+        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                        forKey:self.class.thickUnderlineGrowKey];
+      }
+
+      if (preexistingThinUnderlineGrowAnimation) {
+        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+      }
+      BOOL needsThinUnderlineShrinkAnimation = NO;
+      if (preexistingThinUnderlineShrinkAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineShrinkAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+          needsThinUnderlineShrinkAnimation = YES;
+          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThinUnderlineShrinkAnimation = YES;
+      }
+      if (needsThinUnderlineShrinkAnimation) {
+        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                       forKey:self.class.thinUnderlineShrinkKey];
+      }
+
+    } else {
+      if (preexistingThickUnderlineGrowAnimation) {
+        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
+      }
+      BOOL needsThickUnderlineShrinkAnimation = NO;
+      if (preexistingThickUnderlineShrinkAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineShrinkAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
+          needsThickUnderlineShrinkAnimation = YES;
+          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThickUnderlineShrinkAnimation = YES;
+      }
+      if (needsThickUnderlineShrinkAnimation) {
+        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                        forKey:self.class.thickUnderlineShrinkKey];
+      }
+
+      if (preexistingThinUnderlineShrinkAnimation) {
+        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+      }
+      BOOL needsThickUnderlineGrowAnimation = NO;
+      if (preexistingThinUnderlineGrowAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineGrowAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+          needsThickUnderlineGrowAnimation = YES;
+          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThickUnderlineGrowAnimation = YES;
+      }
+      if (needsThickUnderlineGrowAnimation) {
+        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                       forKey:self.class.thinUnderlineGrowKey];
+      }
+    }
+  }
+  [CATransaction commit];
+}
+
+- (CABasicAnimation *)pathAnimationTo:(UIBezierPath *)path {
+  CABasicAnimation *animation = [self basicAnimationWithKeyPath:@"path"];
+  animation.toValue = (id)(path.CGPath);
+  return animation;
+}
+
+- (CABasicAnimation *)basicAnimationWithKeyPath:(NSString *)keyPath {
+  CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:keyPath];
+  animation.duration = kMDCTextControlDefaultAnimationDuration;
+  animation.timingFunction =
+      [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+  animation.repeatCount = 0;
+  animation.removedOnCompletion = NO;
+  animation.delegate = self;
+  animation.fillMode = kCAFillModeForwards;
+  return animation;
+}
+
+- (void)animationDidStart:(CAAnimation *)anim {
+}
+
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
+  if (![anim isKindOfClass:[CABasicAnimation class]]) {
+    return;
+  }
+
+  CABasicAnimation *animation = (CABasicAnimation *)anim;
+  CGPathRef toValue = (__bridge CGPathRef)animation.toValue;
+
+  CABasicAnimation *thickGrowAnimation = (CABasicAnimation *)[self.thickUnderlineLayer
+      animationForKey:self.class.thickUnderlineGrowKey];
+  CABasicAnimation *thickShrinkAnimation = (CABasicAnimation *)[self.thickUnderlineLayer
+      animationForKey:self.class.thickUnderlineShrinkKey];
+  CABasicAnimation *thinGrowAnimation =
+      (CABasicAnimation *)[self.thinUnderlineLayer animationForKey:self.class.thinUnderlineGrowKey];
+  CABasicAnimation *thinShrinkAnimation = (CABasicAnimation *)[self.thinUnderlineLayer
+      animationForKey:self.class.thinUnderlineShrinkKey];
+
+  if (flag) {
+    if ((animation == thickGrowAnimation) || (animation == thickShrinkAnimation)) {
+      self.thickUnderlineLayer.path = toValue;
+    }
+    if ((animation == thinGrowAnimation) || (animation == thinShrinkAnimation)) {
+      self.thinUnderlineLayer.path = toValue;
+    }
+  }
+}
+
+- (BOOL)shouldShowThickUnderlineWithState:(MDCTextControlState)state {
+  BOOL shouldShow = NO;
+  switch (state) {
+    case MDCTextControlStateEditing:
+      shouldShow = YES;
+      break;
+    case MDCTextControlStateNormal:
+    case MDCTextControlStateDisabled:
+    default:
+      break;
+  }
+  return shouldShow;
+}
+
+- (UIBezierPath *)filledSublayerPathWithTextFieldBounds:(CGRect)viewBounds
+                                        containerHeight:(CGFloat)containerHeight {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat topRadius = kFilledContainerStyleTopCornerRadius;
+  CGFloat bottomRadius = 0;
+  CGFloat textFieldWidth = CGRectGetWidth(viewBounds);
+  CGFloat sublayerMinY = 0;
+  CGFloat sublayerMaxY = containerHeight;
+
+  CGPoint startingPoint = CGPointMake(topRadius, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - topRadius, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  [path addLineToPoint:topRightCornerPoint1];
+
+  CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + topRadius);
+  [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
+                           toPoint:topRightCornerPoint2
+                        withRadius:topRadius];
+  
+  CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - bottomRadius);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - bottomRadius, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
+                              toPoint:bottomRightCornerPoint2
+                           withRadius:bottomRadius];
+  
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(bottomRadius, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - bottomRadius);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
+                             toPoint:bottomLeftCornerPoint2
+                          withRadius:bottomRadius];
+  
+  CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + topRadius);
+  CGPoint topLeftCornerPoint2 = CGPointMake(topRadius, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
+                          toPoint:topLeftCornerPoint2
+                       withRadius:topRadius];
+
+  return path;
+}
+
+- (UIBezierPath *)filledSublayerUnderlinePathWithViewBounds:(CGRect)viewBounds
+                                            containerHeight:(CGFloat)containerHeight
+                                         underlineThickness:(CGFloat)underlineThickness
+                                             underlineWidth:(CGFloat)underlineWidth {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat viewWidth = CGRectGetWidth(viewBounds);
+  CGFloat halfViewWidth = (CGFloat)0.5 * viewWidth;
+  CGFloat halfUnderlineWidth = underlineWidth * (CGFloat)0.5;
+  CGFloat sublayerMinX = halfViewWidth - halfUnderlineWidth;
+  CGFloat sublayerMaxX = sublayerMinX + underlineWidth;
+  CGFloat sublayerMaxY = containerHeight;
+  CGFloat sublayerMinY = sublayerMaxY - underlineThickness;
+
+  CGPoint startingPoint = CGPointMake(sublayerMinX, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(sublayerMaxX, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  [path addLineToPoint:topRightCornerPoint1];
+
+  CGPoint topRightCornerPoint2 = CGPointMake(sublayerMaxX, sublayerMinY);
+  [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
+                                                       toPoint:topRightCornerPoint2
+                                                    withRadius:0];
+
+  CGPoint bottomRightCornerPoint1 = CGPointMake(sublayerMaxX, sublayerMaxY);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(sublayerMaxX, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
+                                                          toPoint:bottomRightCornerPoint2
+                                                       withRadius:0];
+
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(sublayerMinX, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(sublayerMinX, sublayerMaxY);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
+                                                         toPoint:bottomLeftCornerPoint2
+                                                      withRadius:0];
+
+  CGPoint topLeftCornerPoint1 = CGPointMake(sublayerMinX, sublayerMinY);
+  CGPoint topLeftCornerPoint2 = CGPointMake(sublayerMinX, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
+                                                      toPoint:topLeftCornerPoint2
+                                                   withRadius:0];
+
+  return path;
+}
+
++ (NSString *)thinUnderlineShrinkKey {
+  return @"thinUnderlineShrinkKey";
+}
++ (NSString *)thinUnderlineGrowKey {
+  return @"thinUnderlineGrowKey";
+}
++ (NSString *)thickUnderlineShrinkKey {
+  return @"thickUnderlineShrinkKey";
+}
++ (NSString *)thickUnderlineGrowKey {
+  return @"thickUnderlineGrowKey";
+}
+
+- (id<MDCTextControlVerticalPositioningReference>)
+    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
+                              normalFontLineHeight:(CGFloat)normalFontLineHeight
+                                     textRowHeight:(CGFloat)textRowHeight
+                                  numberOfTextRows:(CGFloat)numberOfTextRows
+                                           density:(CGFloat)density
+                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
+  return [[MDCTextControlVerticalPositioningReferenceFilled alloc]
+      initWithFloatingFontLineHeight:floatingLabelHeight
+                normalFontLineHeight:normalFontLineHeight
+                       textRowHeight:textRowHeight
+                    numberOfTextRows:numberOfTextRows
+                             density:density
+            preferredContainerHeight:preferredContainerHeight];
+}
+
+- (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
+  CGFloat scaleFactor = kFilledFloatingLabelScaleFactor;
+  CGFloat floatingFontSize = font.pointSize * scaleFactor;
+  return [font fontWithSize:floatingFontSize];
+}
+
+@end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -44,6 +44,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 @implementation MDCTextControlStyleFilled
 
+#pragma mark Object Lifecycle
+
 - (instancetype)init {
   self = [super init];
   if (self) {
@@ -51,6 +53,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   }
   return self;
 }
+
+#pragma mark Setup
 
 - (void)commonMDCTextControlStyleFilledInit {
   [self setUpUnderlineColors];
@@ -102,6 +106,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   self.filledBackgroundColors[@(state)] = filledBackgroundColor;
 }
 
+#pragma mark MDCTextControl
+
 - (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
   if (![textControl isKindOfClass:[UIView class]]) {
     [self removeStyleFrom:textControl];
@@ -118,6 +124,30 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   [self.thinUnderlineLayer removeFromSuperlayer];
   [self.thickUnderlineLayer removeFromSuperlayer];
 }
+
+- (id<MDCTextControlVerticalPositioningReference>)
+    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
+                              normalFontLineHeight:(CGFloat)normalFontLineHeight
+                                     textRowHeight:(CGFloat)textRowHeight
+                                  numberOfTextRows:(CGFloat)numberOfTextRows
+                                           density:(CGFloat)density
+                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
+  return [[MDCTextControlVerticalPositioningReferenceFilled alloc]
+      initWithFloatingFontLineHeight:floatingLabelHeight
+                normalFontLineHeight:normalFontLineHeight
+                       textRowHeight:textRowHeight
+                    numberOfTextRows:numberOfTextRows
+                             density:density
+            preferredContainerHeight:preferredContainerHeight];
+}
+
+- (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
+  CGFloat scaleFactor = kFilledFloatingLabelScaleFactor;
+  CGFloat floatingFontSize = font.pointSize * scaleFactor;
+  return [font fontWithSize:floatingFontSize];
+}
+
+#pragma mark Custotm Styling
 
 - (void)applyStyleToView:(UIView *)view
                    state:(MDCTextControlState)state
@@ -247,6 +277,22 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   [CATransaction commit];
 }
 
+- (BOOL)shouldShowThickUnderlineWithState:(MDCTextControlState)state {
+  BOOL shouldShow = NO;
+  switch (state) {
+    case MDCTextControlStateEditing:
+      shouldShow = YES;
+      break;
+    case MDCTextControlStateNormal:
+    case MDCTextControlStateDisabled:
+    default:
+      break;
+  }
+  return shouldShow;
+}
+
+#pragma mark Animation
+
 - (CABasicAnimation *)pathAnimationTo:(UIBezierPath *)path {
   CABasicAnimation *animation = [self basicAnimationWithKeyPath:@"path"];
   animation.toValue = (id)(path.CGPath);
@@ -295,19 +341,20 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   }
 }
 
-- (BOOL)shouldShowThickUnderlineWithState:(MDCTextControlState)state {
-  BOOL shouldShow = NO;
-  switch (state) {
-    case MDCTextControlStateEditing:
-      shouldShow = YES;
-      break;
-    case MDCTextControlStateNormal:
-    case MDCTextControlStateDisabled:
-    default:
-      break;
-  }
-  return shouldShow;
++ (NSString *)thinUnderlineShrinkKey {
+  return @"thinUnderlineShrinkKey";
 }
++ (NSString *)thinUnderlineGrowKey {
+  return @"thinUnderlineGrowKey";
+}
++ (NSString *)thickUnderlineShrinkKey {
+  return @"thickUnderlineShrinkKey";
+}
++ (NSString *)thickUnderlineGrowKey {
+  return @"thickUnderlineGrowKey";
+}
+
+#pragma mark Path Drawing
 
 - (UIBezierPath *)filledSublayerPathWithTextFieldBounds:(CGRect)viewBounds
                                         containerHeight:(CGFloat)containerHeight {
@@ -395,41 +442,6 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1 toPoint:topLeftCornerPoint2 withRadius:0];
 
   return path;
-}
-
-+ (NSString *)thinUnderlineShrinkKey {
-  return @"thinUnderlineShrinkKey";
-}
-+ (NSString *)thinUnderlineGrowKey {
-  return @"thinUnderlineGrowKey";
-}
-+ (NSString *)thickUnderlineShrinkKey {
-  return @"thickUnderlineShrinkKey";
-}
-+ (NSString *)thickUnderlineGrowKey {
-  return @"thickUnderlineGrowKey";
-}
-
-- (id<MDCTextControlVerticalPositioningReference>)
-    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
-                              normalFontLineHeight:(CGFloat)normalFontLineHeight
-                                     textRowHeight:(CGFloat)textRowHeight
-                                  numberOfTextRows:(CGFloat)numberOfTextRows
-                                           density:(CGFloat)density
-                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
-  return [[MDCTextControlVerticalPositioningReferenceFilled alloc]
-      initWithFloatingFontLineHeight:floatingLabelHeight
-                normalFontLineHeight:normalFontLineHeight
-                       textRowHeight:textRowHeight
-                    numberOfTextRows:numberOfTextRows
-                             density:density
-            preferredContainerHeight:preferredContainerHeight];
-}
-
-- (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
-  CGFloat scaleFactor = kFilledFloatingLabelScaleFactor;
-  CGFloat floatingFontSize = font.pointSize * scaleFactor;
-  return [font fontWithSize:floatingFontSize];
 }
 
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -17,8 +17,8 @@
 #import <Foundation/Foundation.h>
 
 #import "MDCTextControl.h"
-#import "UIBezierPath+MDCTextControlStyle.h"
 #import "MDCTextControlVerticalPositioningReferenceFilled.h"
+#import "UIBezierPath+MDCTextControlStyle.h"
 
 static const CGFloat kFilledContainerStyleTopCornerRadius = (CGFloat)4.0;
 static const CGFloat kFilledContainerStyleUnderlineWidthThin = (CGFloat)1.0;
@@ -325,29 +325,29 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
   CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + topRadius);
   [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
-                           toPoint:topRightCornerPoint2
-                        withRadius:topRadius];
-  
+                               toPoint:topRightCornerPoint2
+                            withRadius:topRadius];
+
   CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - bottomRadius);
   CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - bottomRadius, sublayerMaxY);
   [path addLineToPoint:bottomRightCornerPoint1];
   [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
-                              toPoint:bottomRightCornerPoint2
-                           withRadius:bottomRadius];
-  
+                                  toPoint:bottomRightCornerPoint2
+                               withRadius:bottomRadius];
+
   CGPoint bottomLeftCornerPoint1 = CGPointMake(bottomRadius, sublayerMaxY);
   CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - bottomRadius);
   [path addLineToPoint:bottomLeftCornerPoint1];
   [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
-                             toPoint:bottomLeftCornerPoint2
-                          withRadius:bottomRadius];
-  
+                                 toPoint:bottomLeftCornerPoint2
+                              withRadius:bottomRadius];
+
   CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + topRadius);
   CGPoint topLeftCornerPoint2 = CGPointMake(topRadius, sublayerMinY);
   [path addLineToPoint:topLeftCornerPoint1];
   [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
-                          toPoint:topLeftCornerPoint2
-                       withRadius:topRadius];
+                              toPoint:topLeftCornerPoint2
+                           withRadius:topRadius];
 
   return path;
 }
@@ -372,29 +372,27 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
   CGPoint topRightCornerPoint2 = CGPointMake(sublayerMaxX, sublayerMinY);
   [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
-                                                       toPoint:topRightCornerPoint2
-                                                    withRadius:0];
+                               toPoint:topRightCornerPoint2
+                            withRadius:0];
 
   CGPoint bottomRightCornerPoint1 = CGPointMake(sublayerMaxX, sublayerMaxY);
   CGPoint bottomRightCornerPoint2 = CGPointMake(sublayerMaxX, sublayerMaxY);
   [path addLineToPoint:bottomRightCornerPoint1];
   [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
-                                                          toPoint:bottomRightCornerPoint2
-                                                       withRadius:0];
+                                  toPoint:bottomRightCornerPoint2
+                               withRadius:0];
 
   CGPoint bottomLeftCornerPoint1 = CGPointMake(sublayerMinX, sublayerMaxY);
   CGPoint bottomLeftCornerPoint2 = CGPointMake(sublayerMinX, sublayerMaxY);
   [path addLineToPoint:bottomLeftCornerPoint1];
   [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
-                                                         toPoint:bottomLeftCornerPoint2
-                                                      withRadius:0];
+                                 toPoint:bottomLeftCornerPoint2
+                              withRadius:0];
 
   CGPoint topLeftCornerPoint1 = CGPointMake(sublayerMinX, sublayerMinY);
   CGPoint topLeftCornerPoint2 = CGPointMake(sublayerMinX, sublayerMinY);
   [path addLineToPoint:topLeftCornerPoint1];
-  [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
-                                                      toPoint:topLeftCornerPoint2
-                                                   withRadius:0];
+  [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1 toPoint:topLeftCornerPoint2 withRadius:0];
 
   return path;
 }


### PR DESCRIPTION
This PR adds the filled style object. Once this is PR is merged we can open one for the MDCFilledTextField. At that point, we can snapshot test the textfield that results from this style object, as well as the filled positioning reference object that landed in https://github.com/material-components/material-components-ios/pull/8627.

This is what the filled textfield ultimately looks like:
<img width="392" alt="Screen Shot 2019-10-25 at 12 22 18 PM" src="https://user-images.githubusercontent.com/8020010/67587617-43cd7d80-f722-11e9-8c53-96a4a56ea5ee.png">

Related to #6942.