### PR TITLE
[TextFields] Add outlined style object

### DIFF
--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
@@ -1,0 +1,23 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "MDCTextControl.h"
+
+@interface MDCTextControlStyleOutlined : NSObject <MDCTextControlStyle>
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state;
+@end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
@@ -19,7 +19,22 @@
 
 // TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic
 // inside it) lands there should be snapshot tests for it.
+/**
+ This style object is used by MDCTextControls adopting the Material Outlined style.
+ */
 @interface MDCTextControlStyleOutlined : NSObject <MDCTextControlStyle>
-- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
+
+/**
+Sets the outline color for a given state.
+@param outlineColor The UIColor for the given state.
+@param state The MDCTextControlState.
+*/
 - (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state;
+
+/**
+Returns the outline color for a given state.
+@param state The MDCTextControlState.
+*/
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
+
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.h
@@ -17,6 +17,8 @@
 
 #import "MDCTextControl.h"
 
+// TODO: When the MDCBaseTextField subclass that makes use of this style (and the path drawing logic
+// inside it) lands there should be snapshot tests for it.
 @interface MDCTextControlStyleOutlined : NSObject <MDCTextControlStyle>
 - (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
 - (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -131,11 +131,11 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
      containerHeight:(CGFloat)containerHeight
      isLabelFloating:(BOOL)isLabelFloating
     outlineLineWidth:(CGFloat)outlineLineWidth {
-  UIBezierPath *path = [self outlinePathWithViewBounds:view.bounds
-                                            labelFrame:labelFrame
-                                       containerHeight:containerHeight
-                                             lineWidth:outlineLineWidth
-                                       isLabelFloating:isLabelFloating];
+  UIBezierPath *path = [MDCTextControlStyleOutlined outlinePathWithViewBounds:view.bounds
+                                                                   labelFrame:labelFrame
+                                                              containerHeight:containerHeight
+                                                                    lineWidth:outlineLineWidth
+                                                              isLabelFloating:isLabelFloating];
   self.outlinedSublayer.path = path.CGPath;
   self.outlinedSublayer.lineWidth = outlineLineWidth;
   if (self.outlinedSublayer.superlayer != view.layer) {
@@ -143,7 +143,7 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   }
 }
 
-- (UIBezierPath *)outlinePathWithViewBounds:(CGRect)viewBounds
++ (UIBezierPath *)outlinePathWithViewBounds:(CGRect)viewBounds
                                  labelFrame:(CGRect)labelFrame
                             containerHeight:(CGFloat)containerHeight
                                   lineWidth:(CGFloat)lineWidth

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -84,23 +84,23 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControlStyle
 
-- (void)applyStyleToTextControl:(id<MDCTextControl>)TextControl {
-  if (![TextControl isKindOfClass:[UIView class]]) {
-    [self removeStyleFrom:TextControl];
+- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
+  if (![textControl isKindOfClass:[UIView class]]) {
+    [self removeStyleFrom:textControl];
     return;
   }
-  CGRect labelFrame = TextControl.label.frame;
-  BOOL isLabelFloating = TextControl.labelState == MDCTextControlLabelStateFloating;
-  CGFloat containerHeight = CGRectGetMaxY(TextControl.containerFrame);
-  CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(TextControl.textControlState)].doubleValue;
-  UIView *uiView = (UIView *)TextControl;
+  CGRect labelFrame = textControl.label.frame;
+  BOOL isLabelFloating = textControl.labelState == MDCTextControlLabelStateFloating;
+  CGFloat containerHeight = CGRectGetMaxY(textControl.containerFrame);
+  CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(textControl.textControlState)].doubleValue;
+  UIView *uiView = (UIView *)textControl;
   [self applyStyleTo:uiView
             labelFrame:labelFrame
        containerHeight:containerHeight
        isLabelFloating:isLabelFloating
       outlineLineWidth:lineWidth];
   self.outlinedSublayer.strokeColor =
-      ((UIColor *)self.outlineColors[@(TextControl.textControlState)]).CGColor;
+      ((UIColor *)self.outlineColors[@(textControl.textControlState)]).CGColor;
 }
 
 - (UIFont *)floatingFontWithNormalFont:(UIFont *)font {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -15,8 +15,8 @@
 #import "MDCTextControlStyleOutlined.h"
 
 #import "MDCTextControl.h"
-#import "UIBezierPath+MDCTextControlStyle.h"
 #import "MDCTextControlVerticalPositioningReferenceOutlined.h"
+#import "UIBezierPath+MDCTextControlStyle.h"
 
 static const CGFloat kOutlinedContainerStyleCornerRadius = (CGFloat)4.0;
 static const CGFloat kFloatingLabelOutlineSidePadding = (CGFloat)5.0;
@@ -150,29 +150,29 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
   CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + radius);
   [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
-                                                       toPoint:topRightCornerPoint2
-                                                    withRadius:radius];
+                               toPoint:topRightCornerPoint2
+                            withRadius:radius];
 
   CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - radius);
   CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - radius, sublayerMaxY);
   [path addLineToPoint:bottomRightCornerPoint1];
   [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
-                                                          toPoint:bottomRightCornerPoint2
-                                                       withRadius:radius];
+                                  toPoint:bottomRightCornerPoint2
+                               withRadius:radius];
 
   CGPoint bottomLeftCornerPoint1 = CGPointMake(radius, sublayerMaxY);
   CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - radius);
   [path addLineToPoint:bottomLeftCornerPoint1];
   [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
-                                                         toPoint:bottomLeftCornerPoint2
-                                                      withRadius:radius];
+                                 toPoint:bottomLeftCornerPoint2
+                              withRadius:radius];
 
   CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + radius);
   CGPoint topLeftCornerPoint2 = CGPointMake(radius, sublayerMinY);
   [path addLineToPoint:topLeftCornerPoint1];
   [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
-                                                      toPoint:topLeftCornerPoint2
-                                                   withRadius:radius];
+                              toPoint:topLeftCornerPoint2
+                           withRadius:radius];
 
   return path;
 }

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -1,0 +1,196 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextControlStyleOutlined.h"
+
+#import "MDCTextControl.h"
+#import "UIBezierPath+MDCTextControlStyle.h"
+#import "MDCTextControlVerticalPositioningReferenceOutlined.h"
+
+static const CGFloat kOutlinedContainerStyleCornerRadius = (CGFloat)4.0;
+static const CGFloat kFloatingLabelOutlineSidePadding = (CGFloat)5.0;
+static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
+
+@interface MDCTextControlStyleOutlined ()
+
+@property(strong, nonatomic) CAShapeLayer *outlinedSublayer;
+@property(strong, nonatomic) NSMutableDictionary<NSNumber *, UIColor *> *outlineColors;
+@property(strong, nonatomic) NSMutableDictionary<NSNumber *, NSNumber *> *outlineLineWidths;
+
+@end
+
+@implementation MDCTextControlStyleOutlined
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self commonMDCTextControlStyleOutlinedInit];
+  }
+  return self;
+}
+
+- (void)commonMDCTextControlStyleOutlinedInit {
+  [self setUpOutlineColors];
+  [self setUpOutlineLineWidths];
+  [self setUpOutlineSublayer];
+}
+
+- (void)setUpOutlineColors {
+  self.outlineColors = [NSMutableDictionary new];
+  self.outlineColors[@(MDCTextControlStateNormal)] = [UIColor blackColor];
+  self.outlineColors[@(MDCTextControlStateEditing)] = [UIColor blackColor];
+  self.outlineColors[@(MDCTextControlStateDisabled)] =
+      [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.60];
+}
+
+- (void)setUpOutlineLineWidths {
+  self.outlineLineWidths = [NSMutableDictionary new];
+  self.outlineLineWidths[@(MDCTextControlStateNormal)] = @(1);
+  self.outlineLineWidths[@(MDCTextControlStateEditing)] = @(2);
+  self.outlineLineWidths[@(MDCTextControlStateDisabled)] = @(1);
+}
+
+- (void)setUpOutlineSublayer {
+  self.outlinedSublayer = [[CAShapeLayer alloc] init];
+  self.outlinedSublayer.fillColor = [UIColor clearColor].CGColor;
+  self.outlinedSublayer.lineWidth =
+      (CGFloat)[self.outlineLineWidths[@(MDCTextControlStateNormal)] doubleValue];
+}
+
+#pragma mark Accessors
+
+- (UIColor *)outlineColorForState:(MDCTextControlState)state {
+  return self.outlineColors[@(state)];
+}
+
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state {
+  self.outlineColors[@(state)] = outlineColor;
+}
+
+- (void)applyStyleToTextControl:(id<MDCTextControl>)TextControl {
+  if (![TextControl isKindOfClass:[UIView class]]) {
+    [self removeStyleFrom:TextControl];
+    return;
+  }
+  CGRect labelFrame = TextControl.label.frame;
+  BOOL isFloatingLabelFloating = TextControl.labelState == MDCTextControlLabelStateFloating;
+  CGFloat containerHeight = CGRectGetMaxY(TextControl.containerFrame);
+  CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(TextControl.textControlState)].doubleValue;
+  UIView *uiView = (UIView *)TextControl;
+  [self applyStyleTo:uiView
+                   labelFrame:labelFrame
+              containerHeight:containerHeight
+      isFloatingLabelFloating:isFloatingLabelFloating
+             outlineLineWidth:lineWidth];
+  self.outlinedSublayer.strokeColor =
+      ((UIColor *)self.outlineColors[@(TextControl.textControlState)]).CGColor;
+}
+
+- (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
+  CGFloat scaleFactor = kFilledFloatingLabelScaleFactor;
+  CGFloat floatingFontSize = font.pointSize * scaleFactor;
+  return [font fontWithSize:floatingFontSize];
+}
+
+- (void)removeStyleFrom:(id<MDCTextControl>)TextControl {
+  [self.outlinedSublayer removeFromSuperlayer];
+}
+
+- (void)applyStyleTo:(UIView *)view
+                 labelFrame:(CGRect)labelFrame
+            containerHeight:(CGFloat)containerHeight
+    isFloatingLabelFloating:(BOOL)isFloatingLabelFloating
+           outlineLineWidth:(CGFloat)outlineLineWidth {
+  UIBezierPath *path = [self outlinePathWithViewBounds:view.bounds
+                                            labelFrame:labelFrame
+                                       containerHeight:containerHeight
+                                             lineWidth:outlineLineWidth
+                               isFloatingLabelFloating:isFloatingLabelFloating];
+  self.outlinedSublayer.path = path.CGPath;
+  self.outlinedSublayer.lineWidth = outlineLineWidth;
+  if (self.outlinedSublayer.superlayer != view.layer) {
+    [view.layer insertSublayer:self.outlinedSublayer atIndex:0];
+  }
+}
+
+- (UIBezierPath *)outlinePathWithViewBounds:(CGRect)viewBounds
+                                 labelFrame:(CGRect)labelFrame
+                            containerHeight:(CGFloat)containerHeight
+                                  lineWidth:(CGFloat)lineWidth
+                    isFloatingLabelFloating:(BOOL)isFloatingLabelFloating {
+  UIBezierPath *path = [[UIBezierPath alloc] init];
+  CGFloat radius = kOutlinedContainerStyleCornerRadius;
+  CGFloat textFieldWidth = CGRectGetWidth(viewBounds);
+  CGFloat sublayerMinY = 0;
+  CGFloat sublayerMaxY = containerHeight;
+
+  CGPoint startingPoint = CGPointMake(radius, sublayerMinY);
+  CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - radius, sublayerMinY);
+  [path moveToPoint:startingPoint];
+  if (isFloatingLabelFloating) {
+    CGFloat leftLineBreak = CGRectGetMinX(labelFrame) - kFloatingLabelOutlineSidePadding;
+    CGFloat rightLineBreak = CGRectGetMaxX(labelFrame) + kFloatingLabelOutlineSidePadding;
+    [path addLineToPoint:CGPointMake(leftLineBreak, sublayerMinY)];
+    [path moveToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
+    [path addLineToPoint:CGPointMake(rightLineBreak, sublayerMinY)];
+  } else {
+    [path addLineToPoint:topRightCornerPoint1];
+  }
+
+  CGPoint topRightCornerPoint2 = CGPointMake(textFieldWidth, sublayerMinY + radius);
+  [path mdc_addTopRightCornerFromPoint:topRightCornerPoint1
+                                                       toPoint:topRightCornerPoint2
+                                                    withRadius:radius];
+
+  CGPoint bottomRightCornerPoint1 = CGPointMake(textFieldWidth, sublayerMaxY - radius);
+  CGPoint bottomRightCornerPoint2 = CGPointMake(textFieldWidth - radius, sublayerMaxY);
+  [path addLineToPoint:bottomRightCornerPoint1];
+  [path mdc_addBottomRightCornerFromPoint:bottomRightCornerPoint1
+                                                          toPoint:bottomRightCornerPoint2
+                                                       withRadius:radius];
+
+  CGPoint bottomLeftCornerPoint1 = CGPointMake(radius, sublayerMaxY);
+  CGPoint bottomLeftCornerPoint2 = CGPointMake(0, sublayerMaxY - radius);
+  [path addLineToPoint:bottomLeftCornerPoint1];
+  [path mdc_addBottomLeftCornerFromPoint:bottomLeftCornerPoint1
+                                                         toPoint:bottomLeftCornerPoint2
+                                                      withRadius:radius];
+
+  CGPoint topLeftCornerPoint1 = CGPointMake(0, sublayerMinY + radius);
+  CGPoint topLeftCornerPoint2 = CGPointMake(radius, sublayerMinY);
+  [path addLineToPoint:topLeftCornerPoint1];
+  [path mdc_addTopLeftCornerFromPoint:topLeftCornerPoint1
+                                                      toPoint:topLeftCornerPoint2
+                                                   withRadius:radius];
+
+  return path;
+}
+
+- (id<MDCTextControlVerticalPositioningReference>)
+    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
+                              normalFontLineHeight:(CGFloat)normalFontLineHeight
+                                     textRowHeight:(CGFloat)textRowHeight
+                                  numberOfTextRows:(CGFloat)numberOfTextRows
+                                           density:(CGFloat)density
+                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
+  return [[MDCTextControlVerticalPositioningReferenceOutlined alloc]
+      initWithFloatingFontLineHeight:floatingLabelHeight
+                normalFontLineHeight:normalFontLineHeight
+                       textRowHeight:textRowHeight
+                    numberOfTextRows:numberOfTextRows
+                             density:density
+            preferredContainerHeight:preferredContainerHeight];
+}
+
+@end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -84,16 +84,16 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControlStyle
 
-- (void)applyStyleToTextControl:(UIView <MDCTextControl> *)textControl {
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
   CGRect labelFrame = textControl.label.frame;
   BOOL isLabelFloating = textControl.labelState == MDCTextControlLabelStateFloating;
   CGFloat containerHeight = CGRectGetMaxY(textControl.containerFrame);
   CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(textControl.textControlState)].doubleValue;
   [self applyStyleTo:textControl
-          labelFrame:labelFrame
-     containerHeight:containerHeight
-     isLabelFloating:isLabelFloating
-    outlineLineWidth:lineWidth];
+            labelFrame:labelFrame
+       containerHeight:containerHeight
+       isLabelFloating:isLabelFloating
+      outlineLineWidth:lineWidth];
   self.outlinedSublayer.strokeColor =
       ((UIColor *)self.outlineColors[@(textControl.textControlState)]).CGColor;
 }

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -84,21 +84,16 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControlStyle
 
-- (void)applyStyleToTextControl:(id<MDCTextControl>)textControl {
-  if (![textControl isKindOfClass:[UIView class]]) {
-    [self removeStyleFrom:textControl];
-    return;
-  }
+- (void)applyStyleToTextControl:(UIView <MDCTextControl> *)textControl {
   CGRect labelFrame = textControl.label.frame;
   BOOL isLabelFloating = textControl.labelState == MDCTextControlLabelStateFloating;
   CGFloat containerHeight = CGRectGetMaxY(textControl.containerFrame);
   CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(textControl.textControlState)].doubleValue;
-  UIView *uiView = (UIView *)textControl;
-  [self applyStyleTo:uiView
-            labelFrame:labelFrame
-       containerHeight:containerHeight
-       isLabelFloating:isLabelFloating
-      outlineLineWidth:lineWidth];
+  [self applyStyleTo:textControl
+          labelFrame:labelFrame
+     containerHeight:containerHeight
+     isLabelFloating:isLabelFloating
+    outlineLineWidth:lineWidth];
   self.outlinedSublayer.strokeColor =
       ((UIColor *)self.outlineColors[@(textControl.textControlState)]).CGColor;
 }

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -32,6 +32,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 @implementation MDCTextControlStyleOutlined
 
+#pragma mark Object Lifecycle
+
 - (instancetype)init {
   self = [super init];
   if (self) {
@@ -39,6 +41,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   }
   return self;
 }
+
+#pragma mark Setup
 
 - (void)commonMDCTextControlStyleOutlinedInit {
   [self setUpOutlineColors];
@@ -78,6 +82,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   self.outlineColors[@(state)] = outlineColor;
 }
 
+#pragma mark MDCTextControlStyle
+
 - (void)applyStyleToTextControl:(id<MDCTextControl>)TextControl {
   if (![TextControl isKindOfClass:[UIView class]]) {
     [self removeStyleFrom:TextControl];
@@ -106,6 +112,24 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 - (void)removeStyleFrom:(id<MDCTextControl>)TextControl {
   [self.outlinedSublayer removeFromSuperlayer];
 }
+
+- (id<MDCTextControlVerticalPositioningReference>)
+    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
+                              normalFontLineHeight:(CGFloat)normalFontLineHeight
+                                     textRowHeight:(CGFloat)textRowHeight
+                                  numberOfTextRows:(CGFloat)numberOfTextRows
+                                           density:(CGFloat)density
+                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
+  return [[MDCTextControlVerticalPositioningReferenceOutlined alloc]
+      initWithFloatingFontLineHeight:floatingLabelHeight
+                normalFontLineHeight:normalFontLineHeight
+                       textRowHeight:textRowHeight
+                    numberOfTextRows:numberOfTextRows
+                             density:density
+            preferredContainerHeight:preferredContainerHeight];
+}
+
+#pragma mark Internal Styling Methods
 
 - (void)applyStyleTo:(UIView *)view
           labelFrame:(CGRect)labelFrame
@@ -175,22 +199,6 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                            withRadius:radius];
 
   return path;
-}
-
-- (id<MDCTextControlVerticalPositioningReference>)
-    positioningReferenceWithFloatingFontLineHeight:(CGFloat)floatingLabelHeight
-                              normalFontLineHeight:(CGFloat)normalFontLineHeight
-                                     textRowHeight:(CGFloat)textRowHeight
-                                  numberOfTextRows:(CGFloat)numberOfTextRows
-                                           density:(CGFloat)density
-                          preferredContainerHeight:(CGFloat)preferredContainerHeight {
-  return [[MDCTextControlVerticalPositioningReferenceOutlined alloc]
-      initWithFloatingFontLineHeight:floatingLabelHeight
-                normalFontLineHeight:normalFontLineHeight
-                       textRowHeight:textRowHeight
-                    numberOfTextRows:numberOfTextRows
-                             density:density
-            preferredContainerHeight:preferredContainerHeight];
 }
 
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -84,15 +84,15 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
     return;
   }
   CGRect labelFrame = TextControl.label.frame;
-  BOOL isFloatingLabelFloating = TextControl.labelState == MDCTextControlLabelStateFloating;
+  BOOL isLabelFloating = TextControl.labelState == MDCTextControlLabelStateFloating;
   CGFloat containerHeight = CGRectGetMaxY(TextControl.containerFrame);
   CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(TextControl.textControlState)].doubleValue;
   UIView *uiView = (UIView *)TextControl;
   [self applyStyleTo:uiView
-                   labelFrame:labelFrame
-              containerHeight:containerHeight
-      isFloatingLabelFloating:isFloatingLabelFloating
-             outlineLineWidth:lineWidth];
+            labelFrame:labelFrame
+       containerHeight:containerHeight
+       isLabelFloating:isLabelFloating
+      outlineLineWidth:lineWidth];
   self.outlinedSublayer.strokeColor =
       ((UIColor *)self.outlineColors[@(TextControl.textControlState)]).CGColor;
 }
@@ -108,15 +108,15 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 }
 
 - (void)applyStyleTo:(UIView *)view
-                 labelFrame:(CGRect)labelFrame
-            containerHeight:(CGFloat)containerHeight
-    isFloatingLabelFloating:(BOOL)isFloatingLabelFloating
-           outlineLineWidth:(CGFloat)outlineLineWidth {
+          labelFrame:(CGRect)labelFrame
+     containerHeight:(CGFloat)containerHeight
+     isLabelFloating:(BOOL)isLabelFloating
+    outlineLineWidth:(CGFloat)outlineLineWidth {
   UIBezierPath *path = [self outlinePathWithViewBounds:view.bounds
                                             labelFrame:labelFrame
                                        containerHeight:containerHeight
                                              lineWidth:outlineLineWidth
-                               isFloatingLabelFloating:isFloatingLabelFloating];
+                                       isLabelFloating:isLabelFloating];
   self.outlinedSublayer.path = path.CGPath;
   self.outlinedSublayer.lineWidth = outlineLineWidth;
   if (self.outlinedSublayer.superlayer != view.layer) {
@@ -128,7 +128,7 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                                  labelFrame:(CGRect)labelFrame
                             containerHeight:(CGFloat)containerHeight
                                   lineWidth:(CGFloat)lineWidth
-                    isFloatingLabelFloating:(BOOL)isFloatingLabelFloating {
+                            isLabelFloating:(BOOL)isLabelFloating {
   UIBezierPath *path = [[UIBezierPath alloc] init];
   CGFloat radius = kOutlinedContainerStyleCornerRadius;
   CGFloat textFieldWidth = CGRectGetWidth(viewBounds);
@@ -138,7 +138,7 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   CGPoint startingPoint = CGPointMake(radius, sublayerMinY);
   CGPoint topRightCornerPoint1 = CGPointMake(textFieldWidth - radius, sublayerMinY);
   [path moveToPoint:startingPoint];
-  if (isFloatingLabelFloating) {
+  if (isLabelFloating) {
     CGFloat leftLineBreak = CGRectGetMinX(labelFrame) - kFloatingLabelOutlineSidePadding;
     CGFloat rightLineBreak = CGRectGetMaxX(labelFrame) + kFloatingLabelOutlineSidePadding;
     [path addLineToPoint:CGPointMake(leftLineBreak, sublayerMinY)];


### PR DESCRIPTION
This PR adds the outlined style object. Once this is PR is merged we can open one for the MDCOutlinedTextField. At that point, we can snapshot test the textfield that results from this style object, as well as the outlined positioning reference object that landed in https://github.com/material-components/material-components-ios/pull/8627.

This is what the outlined textfield ultimately looks like:
<img width="396" alt="Screen Shot 2019-10-25 at 12 22 25 PM" src="https://user-images.githubusercontent.com/8020010/67587616-43cd7d80-f722-11e9-8597-918f5d2e875d.png">

Related to #6942.