### PR TITLE
[NavigationDrawer] Remove container view when dismiss transition completes

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -207,6 +207,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
           self.bottomDrawerContainerViewController.contentViewController.view.frame);
       newFrame.size.height -= self.bottomDrawerContainerViewController.addedHeight;
       self.bottomDrawerContainerViewController.contentViewController.view.frame = newFrame;
+      [self.bottomDrawerContainerViewController willMoveToParentViewController:nil];
+      [self.bottomDrawerContainerViewController.view removeFromSuperview];
       [self.bottomDrawerContainerViewController removeFromParentViewController];
     }
     [self.scrimView removeFromSuperview];


### PR DESCRIPTION
For cases where a sheet is reused, a new container view would be created without the existing view being removed.

Closes #8659.