### PR TITLE
[PageControl] Position active page indicator correctly after scrolling

### DIFF
--- a/components/PageControl/src/MDCPageControl.m
+++ b/components/PageControl/src/MDCPageControl.m
@@ -146,6 +146,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
 - (void)setCurrentPage:(NSInteger)currentPage animated:(BOOL)animated {
   [self setCurrentPage:currentPage animated:animated duration:0];
 }
+
 - (void)setCurrentPage:(NSInteger)currentPage
               animated:(BOOL)animated
               duration:(NSTimeInterval)duration {
@@ -192,8 +193,9 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
                                        completion:completionBlock];
   } else {
     // If not animated, simply move indicator to new position and reset track.
+    [self positionAnimatedIndicatorAtCurrentPage];
+
     CGPoint point = [_indicatorPositions[currentPage] CGPointValue];
-    [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
     [_trackLayer resetAtPoint:point];
 
     [CATransaction begin];
@@ -353,6 +355,8 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   if (sendAction) {
     [self sendActionsForControlEvents:UIControlEventValueChanged];
   }
+
+  [self positionAnimatedIndicatorAtCurrentPage];
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
@@ -361,6 +365,7 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   BOOL shouldReverse = (_currentPage > scrolledPageNumber);
   _currentPage = scrolledPageNumber;
   [self revealIndicatorsReversed:shouldReverse];
+  [self positionAnimatedIndicatorAtCurrentPage];
 }
 
 #pragma mark - Indicators
@@ -530,12 +535,16 @@ static inline CGFloat normalizeValue(CGFloat value, CGFloat minRange, CGFloat ma
   // Add animated indicator that will travel freely across the container. Its transform will be
   // updated by calling its -updateIndicatorTransformX method.
   CGPoint center = CGPointMake(radius, radius);
-  CGPoint point = [_indicatorPositions[_currentPage] CGPointValue];
   _animatedIndicator = [[MDCPageControlIndicator alloc] initWithCenter:center radius:radius];
-  [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
+  [self positionAnimatedIndicatorAtCurrentPage];
   [_containerView.layer addSublayer:_animatedIndicator];
 
   [self setNeedsLayout];
+}
+
+- (void)positionAnimatedIndicatorAtCurrentPage {
+  CGPoint point = [_indicatorPositions[_currentPage] CGPointValue];
+  [_animatedIndicator updateIndicatorTransformX:point.x - kPageControlIndicatorRadius];
 }
 
 #pragma mark - Strings


### PR DESCRIPTION
Fixes #8187 

The root of the issue being addressed is that the scrollView's page count is out of sync with the page control's `numberOfPages`, causing the active page indicator to be misplaced by scrolling. `[_pageControl scrollViewDidScroll:scrollView]` uses the scrollView’s percentage offset (`scrollView.contentOffset.x / (scrollView.contentSize.width - scrollView.frame.size.width)`) to determine where the “active” page indicator should be placed, such that it moves while scrolling. You can see a very exaggerated version of this issue in the MDC catalog by setting `_pageControl.numberOfPages = 10;` on line 80 of PageControlTypicalUseViewController.m. While this PR does not (and cannot) address the case where conflicting data is being provided to the page control, it does ensure that the active page indicator is positioned correctly once scrolling is finished. 


To demonstrate the issue being fixed, I edited `PageControlTypicalUseViewController.m` to change the number of pages to a value noticeably different than the number of pages in the scroll view

```objc
_pageControl.numberOfPages = 10;
```

Before: 
![page_control_before 2019-10-28 11_37_51](https://user-images.githubusercontent.com/581764/67693145-9e134c00-f977-11e9-9c49-11cc1e627212.gif)

After:
![page_control_after 2019-10-28 11_39_28](https://user-images.githubusercontent.com/581764/67693153-a1a6d300-f977-11e9-9ad8-d8ff6a213287.gif)
