### PR TITLE
[ShadowLayer] Fix bug where headless layers would not piggyback shadowPath changes.

### DIFF
--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -446,7 +446,7 @@ static const float kAmbientShadowOpacity = (float)0.08;
     // animation created by UIKit and copy the configuration to our custom animation.
     CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
     if (!boundsAction) {
-      // Headless layers will animate bounds directly instead of the decomposing
+      // Headless layers will animate bounds directly instead of decomposing
       // bounds.size/bounds.position. A headless layer is a CALayer without a delegate (usually
       // would be a UIView).
       boundsAction = [self.animationSourceLayer animationForKey:@"bounds"];

--- a/components/ShadowLayer/src/MDCShadowLayer.m
+++ b/components/ShadowLayer/src/MDCShadowLayer.m
@@ -445,6 +445,12 @@ static const float kAmbientShadowOpacity = (float)0.08;
     // In order to synchronize our animation with UIKit animations we have to fetch the resizing
     // animation created by UIKit and copy the configuration to our custom animation.
     CAAnimation *boundsAction = [self.animationSourceLayer animationForKey:@"bounds.size"];
+    if (!boundsAction) {
+      // Headless layers will animate bounds directly instead of the decomposing
+      // bounds.size/bounds.position. A headless layer is a CALayer without a delegate (usually
+      // would be a UIView).
+      boundsAction = [self.animationSourceLayer animationForKey:@"bounds"];
+    }
     if ([boundsAction isKindOfClass:[CABasicAnimation class]]) {
       CABasicAnimation *animation = (CABasicAnimation *)[boundsAction copy];
       animation.keyPath = self.keyPath;

--- a/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimations.m
+++ b/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimations.m
@@ -16,7 +16,7 @@
 
 #import "MaterialShadowLayer.h"
 
-@interface MDCShadowLayerPiggyBackedAnimations : XCTest
+@interface MDCShadowLayerPiggyBackedAnimations : XCTestCase
 @end
 
 @implementation MDCShadowLayerPiggyBackedAnimations

--- a/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimations.m
+++ b/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimations.m
@@ -1,0 +1,60 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialShadowLayer.h"
+
+@interface MDCShadowLayerPiggyBackedAnimations : XCTest
+@end
+
+@implementation MDCShadowLayerPiggyBackedAnimations
+
+// A headless layer is a CALayer without a delegate (usually would be a UIView).
+// A mounted layer is one that has been flushed to the render server (either via a runloop pump or
+// via [CATransaction flush]).
+- (void)testMountedHeadlessLayerShadowPathAnimationPiggyBacksImplicitBoundsAnimation {
+  // Given
+  UIWindow *window = [[UIWindow alloc] init];
+  MDCShadowLayer *shadowLayer = [[MDCShadowLayer alloc] init];
+  shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectZero].CGPath;
+  [window.layer addSublayer:shadowLayer];
+  [window makeKeyAndVisible];
+  [CATransaction flush];  // Mounts the layer
+
+  // When
+  // Note: headless layers animate using the CATransaction context rather than the UIKit context.
+  [UIView animateWithDuration:0.1
+                   animations:^{
+                     [CATransaction begin];
+                     [CATransaction setAnimationDuration:0.5];
+                     shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
+                     shadowLayer.shadowPath =
+                         [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
+                     [CATransaction commit];
+                   }];
+
+  // Then
+  CAAnimation *boundsAnimation = [shadowLayer animationForKey:@"bounds"];
+  XCTAssertNotNil(boundsAnimation);
+  XCTAssertEqualWithAccuracy(boundsAnimation.duration, 0.5, 0.001);
+
+  for (CALayer *sublayer in shadowLayer.sublayers) {
+    CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
+    XCTAssertNotNil(animation);
+    XCTAssertEqualWithAccuracy(animation.duration, 0.5, 0.001);
+  }
+}
+
+@end

--- a/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimationsTests.m
+++ b/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimationsTests.m
@@ -48,12 +48,12 @@
   // Then
   CAAnimation *boundsAnimation = [shadowLayer animationForKey:@"bounds"];
   XCTAssertNotNil(boundsAnimation);
-  XCTAssertEqualWithAccuracy(boundsAnimation.duration, 0.5, 0.001);
+  CFTimeInterval boundsDuration = [shadowLayer animationForKey:@"bounds"].duration;
 
   for (CALayer *sublayer in shadowLayer.sublayers) {
     CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
     XCTAssertNotNil(animation);
-    XCTAssertEqualWithAccuracy(animation.duration, 0.5, 0.001);
+    XCTAssertEqualWithAccuracy(animation.duration, boundsDuration, 0.001);
   }
 }
 

--- a/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimationsTests.m
+++ b/components/ShadowLayer/tests/snapshot/MDCShadowLayerPiggyBackedAnimationsTests.m
@@ -16,10 +16,10 @@
 
 #import "MaterialShadowLayer.h"
 
-@interface MDCShadowLayerPiggyBackedAnimations : XCTestCase
+@interface MDCShadowLayerPiggyBackedAnimationsTests : XCTestCase
 @end
 
-@implementation MDCShadowLayerPiggyBackedAnimations
+@implementation MDCShadowLayerPiggyBackedAnimationsTests
 
 // A headless layer is a CALayer without a delegate (usually would be a UIView).
 // A mounted layer is one that has been flushed to the render server (either via a runloop pump or

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -59,17 +59,11 @@
   XCTAssertNotNil([someView.layer animationForKey:@"position"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
-  XCTAssertNil(someView.layer.superlayer);
-  XCTAssertEqualWithAccuracy(someView.layer.speed, 1, 0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"position"].duration, 0.1, 0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
-                             0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
-
+  CFTimeInterval boundsDuration = [someView.layer animationForKey:@"bounds.origin"].duration;
   for (CALayer *sublayer in someView.layer.sublayers) {
     CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
     XCTAssertNotNil(animation);
-    XCTAssertEqualWithAccuracy(animation.duration, 0.1, 0.001);
+    XCTAssertEqualWithAccuracy(animation.duration, boundsDuration, 0.001);
   }
 }
 
@@ -91,15 +85,11 @@
   // Then
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
-  XCTAssertEqualWithAccuracy(someView.layer.speed, 1, 0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
-                             0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
-
+  CFTimeInterval boundsDuration = [someView.layer animationForKey:@"bounds.origin"].duration;
   for (CALayer *sublayer in someView.layer.sublayers) {
     CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
     XCTAssertNotNil(animation);
-    XCTAssertEqualWithAccuracy(animation.duration, 0.1, 0.001);
+    XCTAssertEqualWithAccuracy(animation.duration, boundsDuration, 0.001);
   }
 }
 

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -15,7 +15,7 @@
 #import <XCTest/XCTest.h>
 #import "MaterialShadowLayer.h"
 
-@interface ShadowLayerTestsView: UIView
+@interface ShadowLayerTestsView : UIView
 @end
 
 @implementation ShadowLayerTestsView
@@ -45,20 +45,23 @@
   UIView *someView = [[ShadowLayerTestsView alloc] init];
 
   // When
-  [UIView animateWithDuration:0.1 animations:^{
-    [CATransaction begin];
-    [CATransaction setAnimationDuration:0.5];
-    someView.frame = CGRectMake(0, 0, 100, 50);
-    someView.layer.shadowPath = [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
-    [CATransaction commit];
-  }];
+  [UIView animateWithDuration:0.1
+                   animations:^{
+                     [CATransaction begin];
+                     [CATransaction setAnimationDuration:0.5];
+                     someView.frame = CGRectMake(0, 0, 100, 50);
+                     someView.layer.shadowPath =
+                         [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
+                     [CATransaction commit];
+                   }];
 
   // Then
   XCTAssertNotNil([someView.layer animationForKey:@"position"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"position"].duration, 0.1, 0.001);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1, 0.001);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
+                             0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
 
   for (CALayer *sublayer in someView.layer.sublayers) {
@@ -73,18 +76,21 @@
   UIView *someView = [[ShadowLayerTestsView alloc] init];
 
   // When
-  [UIView animateWithDuration:0.1 animations:^{
-    [CATransaction begin];
-    [CATransaction setAnimationDuration:0.5];
-    someView.bounds = CGRectMake(0, 0, 100, 50);
-    someView.layer.shadowPath = [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
-    [CATransaction commit];
-  }];
+  [UIView animateWithDuration:0.1
+                   animations:^{
+                     [CATransaction begin];
+                     [CATransaction setAnimationDuration:0.5];
+                     someView.bounds = CGRectMake(0, 0, 100, 50);
+                     someView.layer.shadowPath =
+                         [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
+                     [CATransaction commit];
+                   }];
 
   // Then
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
-  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1, 0.001);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
+                             0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
 
   for (CALayer *sublayer in someView.layer.sublayers) {
@@ -104,17 +110,19 @@
   shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectZero].CGPath;
   [window.layer addSublayer:shadowLayer];
   [window makeKeyAndVisible];
-  [CATransaction flush]; // Mounts the layer
+  [CATransaction flush];  // Mounts the layer
 
   // When
   // Note: headless layers animate using the CATransaction context rather than the UIKit context.
-  [UIView animateWithDuration:0.1 animations:^{
-    [CATransaction begin];
-    [CATransaction setAnimationDuration:0.5];
-    shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
-    shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
-    [CATransaction commit];
-  }];
+  [UIView animateWithDuration:0.1
+                   animations:^{
+                     [CATransaction begin];
+                     [CATransaction setAnimationDuration:0.5];
+                     shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
+                     shadowLayer.shadowPath =
+                         [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
+                     [CATransaction commit];
+                   }];
 
   // Then
   CAAnimation *boundsAnimation = [shadowLayer animationForKey:@"bounds"];

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -15,6 +15,17 @@
 #import <XCTest/XCTest.h>
 #import "MaterialShadowLayer.h"
 
+@interface ShadowLayerTestsView: UIView
+@end
+
+@implementation ShadowLayerTestsView
+
++ (Class)layerClass {
+  return [MDCShadowLayer class];
+}
+
+@end
+
 @interface ShadowLayerTests : XCTestCase
 @end
 
@@ -27,6 +38,94 @@
   // Then
   XCTAssertEqualWithAccuracy(shadowLayer.elevation, 0, 0.0001);
   XCTAssertTrue(shadowLayer.isShadowMaskEnabled);
+}
+
+- (void)testShadowLayerBackedViewShadowPathAnimationPiggyBacksUIKitFrameAnimation {
+  // Given
+  UIView *someView = [[ShadowLayerTestsView alloc] init];
+
+  // When
+  [UIView animateWithDuration:0.1 animations:^{
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0.5];
+    someView.frame = CGRectMake(0, 0, 100, 50);
+    someView.layer.shadowPath = [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
+    [CATransaction commit];
+  }];
+
+  // Then
+  XCTAssertNotNil([someView.layer animationForKey:@"position"]);
+  XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
+  XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"position"].duration, 0.1, 0.001);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1, 0.001);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
+
+  for (CALayer *sublayer in someView.layer.sublayers) {
+    CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
+    XCTAssertNotNil(animation);
+    XCTAssertEqualWithAccuracy(animation.duration, 0.1, 0.001);
+  }
+}
+
+- (void)testShadowLayerBackedViewShadowPathAnimationPiggyBacksUIKitBoundsAnimation {
+  // Given
+  UIView *someView = [[ShadowLayerTestsView alloc] init];
+
+  // When
+  [UIView animateWithDuration:0.1 animations:^{
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0.5];
+    someView.bounds = CGRectMake(0, 0, 100, 50);
+    someView.layer.shadowPath = [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
+    [CATransaction commit];
+  }];
+
+  // Then
+  XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
+  XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1, 0.001);
+  XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);
+
+  for (CALayer *sublayer in someView.layer.sublayers) {
+    CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
+    XCTAssertNotNil(animation);
+    XCTAssertEqualWithAccuracy(animation.duration, 0.1, 0.001);
+  }
+}
+
+// A headless layer is a CALayer without a delegate (usually would be a UIView).
+// A mounted layer is one that has been flushed to the render server (either via a runloop pump or
+// via [CATransaction flush]).
+- (void)testMountedHeadlessLayerShadowPathAnimationPiggyBacksImplicitBoundsAnimation {
+  // Given
+  UIWindow *window = [[UIWindow alloc] init];
+  MDCShadowLayer *shadowLayer = [[MDCShadowLayer alloc] init];
+  shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectZero].CGPath;
+  [window.layer addSublayer:shadowLayer];
+  [window makeKeyAndVisible];
+  [CATransaction flush]; // Mounts the layer
+
+  // When
+  // Note: headless layers animate using the CATransaction context rather than the UIKit context.
+  [UIView animateWithDuration:0.1 animations:^{
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0.5];
+    shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
+    shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
+    [CATransaction commit];
+  }];
+
+  // Then
+  CAAnimation *boundsAnimation = [shadowLayer animationForKey:@"bounds"];
+  XCTAssertNotNil(boundsAnimation);
+  XCTAssertEqualWithAccuracy(boundsAnimation.duration, 0.5, 0.001);
+
+  for (CALayer *sublayer in shadowLayer.sublayers) {
+    CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
+    XCTAssertNotNil(animation);
+    XCTAssertEqualWithAccuracy(animation.duration, 0.5, 0.001);
+  }
 }
 
 @end

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -100,40 +100,4 @@
   }
 }
 
-// A headless layer is a CALayer without a delegate (usually would be a UIView).
-// A mounted layer is one that has been flushed to the render server (either via a runloop pump or
-// via [CATransaction flush]).
-- (void)testMountedHeadlessLayerShadowPathAnimationPiggyBacksImplicitBoundsAnimation {
-  // Given
-  UIWindow *window = [[UIWindow alloc] init];
-  MDCShadowLayer *shadowLayer = [[MDCShadowLayer alloc] init];
-  shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:CGRectZero].CGPath;
-  [window.layer addSublayer:shadowLayer];
-  [window makeKeyAndVisible];
-  [CATransaction flush];  // Mounts the layer
-
-  // When
-  // Note: headless layers animate using the CATransaction context rather than the UIKit context.
-  [UIView animateWithDuration:0.1
-                   animations:^{
-                     [CATransaction begin];
-                     [CATransaction setAnimationDuration:0.5];
-                     shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
-                     shadowLayer.shadowPath =
-                         [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
-                     [CATransaction commit];
-                   }];
-
-  // Then
-  CAAnimation *boundsAnimation = [shadowLayer animationForKey:@"bounds"];
-  XCTAssertNotNil(boundsAnimation);
-  XCTAssertEqualWithAccuracy(boundsAnimation.duration, 0.5, 0.001);
-
-  for (CALayer *sublayer in shadowLayer.sublayers) {
-    CAAnimation *animation = [sublayer animationForKey:@"shadowPath"];
-    XCTAssertNotNil(animation);
-    XCTAssertEqualWithAccuracy(animation.duration, 0.5, 0.001);
-  }
-}
-
 @end

--- a/components/ShadowLayer/tests/unit/ShadowLayerTests.m
+++ b/components/ShadowLayer/tests/unit/ShadowLayerTests.m
@@ -59,6 +59,8 @@
   XCTAssertNotNil([someView.layer animationForKey:@"position"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
+  XCTAssertNil(someView.layer.superlayer);
+  XCTAssertEqualWithAccuracy(someView.layer.speed, 1, 0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"position"].duration, 0.1, 0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
                              0.001);
@@ -89,6 +91,7 @@
   // Then
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.origin"]);
   XCTAssertNotNil([someView.layer animationForKey:@"bounds.size"]);
+  XCTAssertEqualWithAccuracy(someView.layer.speed, 1, 0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.origin"].duration, 0.1,
                              0.001);
   XCTAssertEqualWithAccuracy([someView.layer animationForKey:@"bounds.size"].duration, 0.1, 0.001);


### PR DESCRIPTION
Definitions:

- Headless layer: a CALayer without a delegate.
- Mounted layer: a CALayer that has been flushed to the render server either via a runloop pump or via `[CATransaction flush]`.

Context:

MDCShadowLayer includes some logic for animating shadowPath changes alongside corresponding bounds animations. The intent is that, if `shadowPath` is changed then it attempts to inherit any animation traits from existing bounds-related animations, if they exist. This behavior was added in https://github.com/material-components/material-components-ios/pull/2523. This behavior enables changes to shadowPath (which are not animatable by UIView-based animations) to inherit existing UIView-based animations.

Prior to this change, only bounds.size would be inspected for this piggy-backing behavior. While this works for UIView-based animations, which decompose `.frame` and `.bounds` animations into `bounds.size` and `bounds.origin`, this does not work for headless layers which directly animate the `bounds` property. E.g. the following snippet would piggy back as expected:

```objc
[UIView animateWithDuration:0.1 animations:^{
  someView.frame = CGRectMake(0, 0, 100, 50);
  someView.layer.shadowPath = [UIBezierPath bezierPathWithRect:someView.bounds].CGPath;
}];
```

But the following would not:

```objc
[CATransaction begin];
[CATransaction setAnimationDuration:0.5];
shadowLayer.bounds = CGRectMake(0, 0, 100, 50);
shadowLayer.shadowPath = [UIBezierPath bezierPathWithRect:shadowLayer.bounds].CGPath;
[CATransaction commit];
```

After this change, MDCShadowLayer will check for animations to `bounds` as well, increasing the likelihood that the shadowPath is able to piggy-back existing animations.

This change is part of addressing https://github.com/material-components/material-components-ios/issues/8644
