### PR TITLE
[FlexibleHeader] Remove unnecessary caching of CATransaction's disableActions.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -386,12 +386,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [self fhv_updateShadowColor];
   [self fhv_updateShadowPath];
   [CATransaction begin];
-  BOOL disableActions = [CATransaction disableActions];
   [CATransaction setDisableActions:YES];
   _defaultShadowLayer.frame = self.bounds;
   _customShadowLayer.frame = self.bounds;
   _shadowLayer.frame = self.bounds;
-  [CATransaction setDisableActions:disableActions];
   [CATransaction commit];
 }
 


### PR DESCRIPTION
CATransaction's begin/commit APIs already manage the push/pop operations of stashing CATransaction's state, so this logic is redundant.

Polish as part of https://github.com/material-components/material-components-ios/issues/8644
