### PR TITLE
[TextFields] Refactor snapshots in preparation for more types of textfields

### DIFF
--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -159,6 +159,7 @@ mdc_snapshot_objc_library(
     deps = [
         ":ColorThemer",
         ":ContainedInputView",
+        ":ContainedInputViewPrivateHeaders",
         ":FontThemer",
         ":TextFields",
         ":TypographyThemer",

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -33,7 +33,7 @@
 
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
-  self.textField = [self createBaseTextField];
+  self.textField = [self createBaseTextFieldInKeyWindow];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
   //      self.recordMode = YES;
@@ -46,7 +46,7 @@
   [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
-- (MDCBaseTextField *)createBaseTextField {
+- (MDCBaseTextField *)createBaseTextFieldInKeyWindow {
   MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:CGRectMake(0, 0, 200, 60)];
   textField.borderStyle = UITextBorderStyleRoundedRect;
 

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -97,7 +97,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureTextFieldWithLeadingViewWhileEditing:textField];
+      configureTextFieldWithLeadingViewAndTextWhileEditing:textField];
 
   // Then
   [self validateTextField:textField];
@@ -108,7 +108,7 @@
   MDCBaseTextField *textField = self.textField;
 
   // When
-  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithTrailingView:textField];
+  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithTrailingViewAndText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -120,7 +120,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureTextFieldWithLeadingViewAndTrailingView:textField];
+      configureTextFieldWithLeadingViewAndTrailingViewAndText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -131,7 +131,8 @@
   MDCBaseTextField *textField = self.textField;
 
   // When
-  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithVisibleClearButton:textField];
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithVisibleClearButtonAndText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -143,7 +144,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureFloatingLabelWithCustomColorWhileEditing:textField];
+      configureWithColoredFloatingLabelTextAndTextWhileEditing:textField];
 
   // Then
   [self validateTextField:textField];
@@ -154,7 +155,8 @@
   MDCBaseTextField *textField = self.textField;
 
   // When
-  [MDCBaseTextFieldTestsSnapshotTestHelpers configureDisabledTextField:textField];
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureDisabledTextFieldWithLabelTextAndText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -166,7 +168,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureEditingTextFieldWithVisiblePlaceholder:textField];
+      configureEditingTextFieldWithVisiblePlaceholderAndLabelText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -177,7 +179,8 @@
   MDCBaseTextField *textField = self.textField;
 
   // When
-  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithAssistiveLabelText:textField];
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithColoredAssistiveLabelText:textField];
 
   // Then
   [self validateTextField:textField];
@@ -189,7 +192,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureTextFieldWithAssistiveLabelTextWhileEditing:textField];
+      configureTextFieldWithColoredAssistiveLabelTextWhileEditing:textField];
 
   // Then
   [self validateTextField:textField];
@@ -201,7 +204,7 @@
 
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
-      configureTextFieldWithAssistiveLabelTextWhileDisabled:textField];
+      configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:textField];
 
   // Then
   [self validateTextField:textField];

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -16,10 +16,10 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialTextFields+ContainedInputView.h"
+#import "../../src/ContainedInputView/private/MDCTextControl.h"
 #import "MDCBaseTextFieldTestsSnapshotTestHelpers.h"
 #import "MDCTextControlSnapshotTestHelpers.h"
-#import "../../src/ContainedInputView/private/MDCTextControl.h"
+#import "MaterialTextFields+ContainedInputView.h"
 
 @interface MDCBaseTextFieldTestsSnapshotTests : MDCSnapshotTestCase
 @property(strong, nonatomic) MDCBaseTextField *textField;
@@ -64,7 +64,7 @@
 
 - (void)validateTextField:(MDCBaseTextField *)textField {
   [MDCTextControlSnapshotTestHelpers validateTextControl:(UIView<MDCTextControl> *)textField
-                                           withTestCase:self];
+                                            withTestCase:self];
 }
 
 #pragma mark - Tests

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
@@ -19,16 +19,16 @@
 #import "../../src/ContainedInputView/MDCBaseTextField.h"
 
 @interface MDCBaseTextFieldTestsSnapshotTestHelpers : NSObject
-+ (void)configureTextFieldWithAssistiveLabelText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithColoredAssistiveLabelText:(MDCBaseTextField *)textField;
 + (void)configureTextFieldWithText:(MDCBaseTextField *)textField;
 + (void)configureTextFieldWithLeadingView:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithLeadingViewWhileEditing:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithTrailingView:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithLeadingViewAndTrailingView:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithVisibleClearButton:(MDCBaseTextField *)textField;
-+ (void)configureFloatingLabelWithCustomColorWhileEditing:(MDCBaseTextField *)textField;
-+ (void)configureDisabledTextField:(MDCBaseTextField *)textField;
-+ (void)configureEditingTextFieldWithVisiblePlaceholder:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField;
-+ (void)configureTextFieldWithAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithLeadingViewAndTextWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithTrailingViewAndText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithLeadingViewAndTrailingViewAndText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithVisibleClearButtonAndText:(MDCBaseTextField *)textField;
++ (void)configureWithColoredFloatingLabelTextAndTextWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureDisabledTextFieldWithLabelTextAndText:(MDCBaseTextField *)textField;
++ (void)configureEditingTextFieldWithVisiblePlaceholderAndLabelText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithColoredAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField;
 @end

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
@@ -1,0 +1,34 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "../../src/ContainedInputView/MDCBaseTextField.h"
+
+@interface MDCBaseTextFieldTestsSnapshotTestHelpers : NSObject
++ (void)configureTextFieldWithAssistiveLabelText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithText:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithLeadingView:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithLeadingViewWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithTrailingView:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithLeadingViewAndTrailingView:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithVisibleClearButton:(MDCBaseTextField *)textField;
++ (void)configureFloatingLabelWithCustomColorWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureDisabledTextField:(MDCBaseTextField *)textField;
++ (void)configureEditingTextFieldWithVisiblePlaceholder:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField;
+@end

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
@@ -18,6 +18,13 @@
 
 #import "MDCBaseTextFieldTestsSnapshotTestHelpers.h"
 
+/**
+ This class puts the configuration for TextControl based TextField snapshot tests in one place so
+ that snapshot test cases for the MDCFilledTextField and MDCOutlinedTextField can test the same
+ things being tested for MDCBaseTextField. When b/133313258 is fixed this configuration code will
+ probably be moved back to a MDCBaseTextField snapshot test case that will have a subclass for each
+ MDCBaseTextField subclass.
+ */
 @implementation MDCBaseTextFieldTestsSnapshotTestHelpers
 
 #pragma mark "When" configurations

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
@@ -29,7 +29,7 @@
 
 #pragma mark "When" configurations
 
-+ (void)configureTextFieldWithAssistiveLabelText:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithColoredAssistiveLabelText:(MDCBaseTextField *)textField {
   textField.text = @"text";
   textField.leadingAssistiveLabel.text = @"leading assistive label text";
   textField.trailingAssistiveLabel.text = @"trailing assistive label text";
@@ -47,20 +47,20 @@
   textField.leadingViewMode = UITextFieldViewModeAlways;
 }
 
-+ (void)configureTextFieldWithLeadingViewWhileEditing:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithLeadingViewAndTextWhileEditing:(MDCBaseTextField *)textField {
   textField.leadingView = [self createRedSideView];
   textField.leadingViewMode = UITextFieldViewModeWhileEditing;
   textField.text = @"Text";
   [textField becomeFirstResponder];
 }
 
-+ (void)configureTextFieldWithTrailingView:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithTrailingViewAndText:(MDCBaseTextField *)textField {
   textField.text = @"Text";
   textField.trailingView = [self createBlueSideView];
   textField.trailingViewMode = UITextFieldViewModeAlways;
 }
 
-+ (void)configureTextFieldWithLeadingViewAndTrailingView:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithLeadingViewAndTrailingViewAndText:(MDCBaseTextField *)textField {
   textField.text = @"Text";
   textField.leadingView = [self createBlueSideView];
   textField.trailingView = [self createRedSideView];
@@ -68,31 +68,31 @@
   textField.leadingViewMode = UITextFieldViewModeAlways;
 }
 
-+ (void)configureTextFieldWithVisibleClearButton:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithVisibleClearButtonAndText:(MDCBaseTextField *)textField {
   textField.clearButtonMode = UITextFieldViewModeAlways;
   textField.text = @"Text";
 }
 
-+ (void)configureFloatingLabelWithCustomColorWhileEditing:(MDCBaseTextField *)textField {
++ (void)configureWithColoredFloatingLabelTextAndTextWhileEditing:(MDCBaseTextField *)textField {
   textField.label.text = @"Floating label text";
   textField.text = @"Text";
   [textField setFloatingLabelColor:[UIColor purpleColor] forState:MDCTextControlStateEditing];
   [textField becomeFirstResponder];
 }
 
-+ (void)configureDisabledTextField:(MDCBaseTextField *)textField {
++ (void)configureDisabledTextFieldWithLabelTextAndText:(MDCBaseTextField *)textField {
   textField.label.text = @"Floating label text";
   textField.text = @"Text";
   textField.enabled = NO;
 }
 
-+ (void)configureEditingTextFieldWithVisiblePlaceholder:(MDCBaseTextField *)textField {
++ (void)configureEditingTextFieldWithVisiblePlaceholderAndLabelText:(MDCBaseTextField *)textField {
   textField.label.text = @"Floating label text";
   textField.placeholder = @"Placeholder";
   [textField becomeFirstResponder];
 }
 
-+ (void)configureTextFieldWithAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithColoredAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField {
   textField.text = @"text";
   textField.leadingAssistiveLabel.text = @"leading assistive label text";
   textField.trailingAssistiveLabel.text = @"trailing assistive label text";
@@ -101,7 +101,7 @@
   [textField becomeFirstResponder];
 }
 
-+ (void)configureTextFieldWithAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField {
++ (void)configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField {
   textField.text = @"text";
   textField.leadingAssistiveLabel.text = @"leading assistive label text";
   textField.trailingAssistiveLabel.text = @"trailing assistive label text";

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.m
@@ -1,0 +1,124 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "MDCBaseTextFieldTestsSnapshotTestHelpers.h"
+
+@implementation MDCBaseTextFieldTestsSnapshotTestHelpers
+
+#pragma mark "When" configurations
+
++ (void)configureTextFieldWithAssistiveLabelText:(MDCBaseTextField *)textField {
+  textField.text = @"text";
+  textField.leadingAssistiveLabel.text = @"leading assistive label text";
+  textField.trailingAssistiveLabel.text = @"trailing assistive label text";
+  [textField setLeadingAssistiveLabelColor:[UIColor blueColor] forState:MDCTextControlStateNormal];
+  [textField setTrailingAssistiveLabelColor:[UIColor redColor] forState:MDCTextControlStateNormal];
+}
+
++ (void)configureTextFieldWithText:(MDCBaseTextField *)textField {
+  textField.text = @"Text";
+}
+
++ (void)configureTextFieldWithLeadingView:(MDCBaseTextField *)textField {
+  textField.text = @"Text";
+  textField.leadingView = [self createRedSideView];
+  textField.leadingViewMode = UITextFieldViewModeAlways;
+}
+
++ (void)configureTextFieldWithLeadingViewWhileEditing:(MDCBaseTextField *)textField {
+  textField.leadingView = [self createRedSideView];
+  textField.leadingViewMode = UITextFieldViewModeWhileEditing;
+  textField.text = @"Text";
+  [textField becomeFirstResponder];
+}
+
++ (void)configureTextFieldWithTrailingView:(MDCBaseTextField *)textField {
+  textField.text = @"Text";
+  textField.trailingView = [self createBlueSideView];
+  textField.trailingViewMode = UITextFieldViewModeAlways;
+}
+
++ (void)configureTextFieldWithLeadingViewAndTrailingView:(MDCBaseTextField *)textField {
+  textField.text = @"Text";
+  textField.leadingView = [self createBlueSideView];
+  textField.trailingView = [self createRedSideView];
+  textField.trailingViewMode = UITextFieldViewModeAlways;
+  textField.leadingViewMode = UITextFieldViewModeAlways;
+}
+
++ (void)configureTextFieldWithVisibleClearButton:(MDCBaseTextField *)textField {
+  textField.clearButtonMode = UITextFieldViewModeAlways;
+  textField.text = @"Text";
+}
+
++ (void)configureFloatingLabelWithCustomColorWhileEditing:(MDCBaseTextField *)textField {
+  textField.label.text = @"Floating label text";
+  textField.text = @"Text";
+  [textField setFloatingLabelColor:[UIColor purpleColor] forState:MDCTextControlStateEditing];
+  [textField becomeFirstResponder];
+}
+
++ (void)configureDisabledTextField:(MDCBaseTextField *)textField {
+  textField.label.text = @"Floating label text";
+  textField.text = @"Text";
+  textField.enabled = NO;
+}
+
++ (void)configureEditingTextFieldWithVisiblePlaceholder:(MDCBaseTextField *)textField {
+  textField.label.text = @"Floating label text";
+  textField.placeholder = @"Placeholder";
+  [textField becomeFirstResponder];
+}
+
++ (void)configureTextFieldWithAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField {
+  textField.text = @"text";
+  textField.leadingAssistiveLabel.text = @"leading assistive label text";
+  textField.trailingAssistiveLabel.text = @"trailing assistive label text";
+  [textField setLeadingAssistiveLabelColor:[UIColor blueColor] forState:MDCTextControlStateEditing];
+  [textField setTrailingAssistiveLabelColor:[UIColor redColor] forState:MDCTextControlStateEditing];
+  [textField becomeFirstResponder];
+}
+
++ (void)configureTextFieldWithAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField {
+  textField.text = @"text";
+  textField.leadingAssistiveLabel.text = @"leading assistive label text";
+  textField.trailingAssistiveLabel.text = @"trailing assistive label text";
+  [textField setLeadingAssistiveLabelColor:[UIColor blueColor]
+                                  forState:MDCTextControlStateDisabled];
+  [textField setTrailingAssistiveLabelColor:[UIColor redColor]
+                                   forState:MDCTextControlStateDisabled];
+  textField.enabled = NO;
+}
+
+#pragma mark Helpers
+
++ (UIView *)createBlueSideView {
+  return [MDCBaseTextFieldTestsSnapshotTestHelpers createSideViewWithColor:[UIColor blueColor]];
+}
+
++ (UIView *)createRedSideView {
+  return [MDCBaseTextFieldTestsSnapshotTestHelpers createSideViewWithColor:[UIColor redColor]];
+}
+
++ (UIView *)createSideViewWithColor:(UIColor *)color {
+  UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
+  view.backgroundColor = color;
+  return view;
+}
+
+@end

--- a/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.h
+++ b/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.h
@@ -1,0 +1,24 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "../../src/ContainedInputView/private/MDCTextControl.h"
+
+@interface MDCTextControlSnapshotTestHelpers : NSObject
++ (void)validateTextControl:(UIView<MDCTextControl> *)textControl
+               withTestCase:(MDCSnapshotTestCase *)testCase;
+@end

--- a/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.m
+++ b/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.m
@@ -1,0 +1,59 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "MDCTextControlSnapshotTestHelpers.h"
+
+// This timeout value is intended to be temporary. These snapshot tests currently take longer than
+// we'd want them to. They don't come close to 30 seconds.
+static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
+
+@implementation MDCTextControlSnapshotTestHelpers
+
+#pragma mark Validation
+
++ (void)validateTextControl:(UIView<MDCTextControl> *)textControl
+               withTestCase:(MDCSnapshotTestCase *)testCase {
+  [MDCTextControlSnapshotTestHelpers forceLayoutOfTextControl:textControl];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"text_control_validation_expectation"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    // We take a snapshot of the text control so we don't have to remove it from the app
+    // host's key window. Removing the text control from the app host's key window
+    // before validation can affect the textt control's editing behavior, which has a
+    // large effect on the appearance of the text control.
+    UIView *textControlSnapshot = [textControl snapshotViewAfterScreenUpdates:YES];
+    [MDCTextControlSnapshotTestHelpers generateSnapshotAndVerifyForView:textControlSnapshot
+                                                          withTestCase:testCase];
+    [expectation fulfill];
+  });
+  [testCase waitForExpectations:@[ expectation ] timeout:kTextFieldValidationAnimationTimeout];
+}
+
++ (void)forceLayoutOfTextControl:(UIView<MDCTextControl> *)textControl {
+  [textControl sizeToFit];
+  [textControl setNeedsLayout];
+  [textControl layoutIfNeeded];
+}
+
++ (void)generateSnapshotAndVerifyForView:(UIView *)view
+                            withTestCase:(MDCSnapshotTestCase *)testCase {
+  UIView *snapshotView = [view mdc_addToBackgroundView];
+  [testCase snapshotVerifyView:snapshotView];
+}
+
+@end

--- a/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.m
+++ b/components/TextFields/tests/snapshot/MDCTextControlSnapshotTestHelpers.m
@@ -38,7 +38,7 @@ static const NSTimeInterval kTextFieldValidationAnimationTimeout = 30.0;
     // large effect on the appearance of the text control.
     UIView *textControlSnapshot = [textControl snapshotViewAfterScreenUpdates:YES];
     [MDCTextControlSnapshotTestHelpers generateSnapshotAndVerifyForView:textControlSnapshot
-                                                          withTestCase:testCase];
+                                                           withTestCase:testCase];
     [expectation fulfill];
   });
   [testCase waitForExpectations:@[ expectation ] timeout:kTextFieldValidationAnimationTimeout];


### PR DESCRIPTION
TL;DR -- This PR results in less duplication than if I were to just rewrite the same snapshot tests for MDCBaseTextField, MDCFilledTextField, and MDCOutlinedTextField, but there is still more duplication than I would like for there to be because of a bug that makes inheritance based snapshot tests not workable internally.

Before bringing over MDCFilledTextField and MDCOutlinedTextField I wanted to have some way to try to reduce code duplication in the snapshot tests for the three textfields. The snapshot tests for MDCTextField make use of inheritance to achieve this. I eventually want to do something similar, but I want to wait until [b/133313258](http://b/133313258) is resolved before I do that, because I want for the snapshot tests to be able to run internally. Until then, I suggest we have something like this. There's a little less duplication than if we just wrote the same snapshot test "the old fashioned way" for each textfield class, and there is some shared infrastructure, like in `MDCTextControlSnapshotTestHelpers`. In the future, if/when other MDCTextControls are brought into the library, they can also use of things like this.

I want to stress that this is not supposed to be the final state of snapshot testing for the new textfields. It's just one step closer. I'm still figuring it out.

Related to #6942.