### PR TITLE
[FlexibleHeader] Fix bug where shadowPath did not animate when using MDCShadowLayer.

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -19,6 +19,7 @@ load(
     "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
+    "mdc_snapshot_swift_library",
     "mdc_snapshot_test",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
@@ -128,7 +129,18 @@ mdc_snapshot_objc_library(
     ],
 )
 
+mdc_snapshot_swift_library(
+    name = "snapshot_test_lib_swift",
+    deps = [
+        ":FlexibleHeader",
+        "//components/ShadowLayer",
+    ],
+)
+
 mdc_snapshot_test(
     name = "snapshot_tests",
-    deps = [":snapshot_test_lib"],
+    deps = [
+        ":snapshot_test_lib",
+        "snapshot_test_lib_swift"
+    ],
 )

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -141,6 +141,6 @@ mdc_snapshot_test(
     name = "snapshot_tests",
     deps = [
         ":snapshot_test_lib",
-        "snapshot_test_lib_swift"
+        ":snapshot_test_lib_swift"
     ],
 )

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -182,6 +182,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // layout guide. Once we drop iOS 8 support this can be changed to a UILayoutGuide instead.
   UIView *_topSafeAreaGuide;
 
+  // Whether the flexible header is currently within an animate block for changing the tracking
+  // scroll view.
+  BOOL _isAnimatingTrackingScrollViewChange;
+
   MDCStatusBarShifter *_statusBarShifter;
 
   // Layers for header shadows.
@@ -385,8 +389,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   [self fhv_updateShadowColor];
   [self fhv_updateShadowPath];
+
   [CATransaction begin];
-  [CATransaction setDisableActions:YES];
+  BOOL allowCAActions = _isAnimatingTrackingScrollViewChange;
+  [CATransaction setDisableActions:!allowCAActions];
   _defaultShadowLayer.frame = self.bounds;
   _customShadowLayer.frame = self.bounds;
   _shadowLayer.frame = self.bounds;
@@ -1554,8 +1560,29 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   }
 
+  CFTimeInterval duration = kTrackingScrollViewDidChangeAnimationDuration;
+  CAMediaTimingFunction *timingFunction =
+      [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+
   void (^animate)(void) = ^{
+    self->_isAnimatingTrackingScrollViewChange = YES;
+
+    [CATransaction begin];
+#if TARGET_IPHONE_SIMULATOR
+    [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
+#else
+    [CATransaction setAnimationDuration:duration];
+#endif
+    [CATransaction setAnimationTimingFunction:timingFunction];
+
     [self fhv_updateLayout];
+
+    // Force any layout changes to be committed during this animation block.
+    [self layoutIfNeeded];
+
+    [CATransaction commit];
+
+    self->_isAnimatingTrackingScrollViewChange = NO;
   };
   void (^completion)(BOOL) = ^(BOOL finished) {
     if (!finished) {
@@ -1568,9 +1595,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   };
   if (wasTrackingScrollView && shouldAnimate) {
-    [UIView animateWithDuration:kTrackingScrollViewDidChangeAnimationDuration
-                     animations:animate
-                     completion:completion];
+    [UIView animateWithDuration:duration animations:animate completion:completion];
   } else {
     animate();
     completion(YES);

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -57,14 +57,20 @@ class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
     XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.origin"))
     XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "position"))
 
-    let animationDuration =
-        try XCTUnwrap(fhvc.headerView.layer.animation(forKey: "bounds.size")?.duration)
+    guard let animationDuration =
+        fhvc.headerView.layer.animation(forKey: "bounds.size")?.duration else {
+      XCTFail("Missing bounds.size animation")
+    }
 
-    let sublayers = try XCTUnwrap(shadowLayer.sublayers)
+    guard let sublayers = shadowLayer.sublayers else {
+      XCTFail("Missing sublayers.")
+    }
     XCTAssertGreaterThan(sublayers.count, 0)
 
     for sublayer in sublayers {
-      let animation = try XCTUnwrap(sublayer.animation(forKey: "shadowPath"))
+      guard let animation = sublayer.animation(forKey: "shadowPath") else {
+        XCTFail("Missing shadowPath animation.")
+      }
       XCTAssertNotNil(animation)
       XCTAssertEqual(animation.duration, animationDuration, accuracy: 0.001)
     }

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -1,0 +1,72 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialShadowLayer
+
+class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
+
+  func testFromExpandedToCollapsedStateAnimatesShadowPath() throws {
+    // Given
+    let window = UIWindow()
+    let fhvc = MDCFlexibleHeaderViewController()
+    let shadowLayer = MDCShadowLayer()
+    fhvc.headerView.setShadowLayer(shadowLayer) { layer, elevation in
+      guard let shadowLayer = layer as? MDCShadowLayer else {
+        return
+      }
+      shadowLayer.elevation = .init(4 * elevation)
+    }
+    fhvc.headerView.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhvc.headerView.minMaxHeightIncludesSafeArea = false
+    fhvc.headerView.sharedWithManyScrollViews = true
+    fhvc.headerView.maximumHeight = 200
+    let scrollView1 = UIScrollView()
+    let scrollView2 = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhvc.headerView.frame.width, height: 1000)
+    scrollView1.contentSize = largeScrollableArea
+    scrollView2.contentSize = largeScrollableArea
+    // Fully expanded.
+    scrollView1.contentOffset = CGPoint(x: 0, y: -200)
+    // Fully collapsed.
+    scrollView2.contentOffset = CGPoint(x: 0, y: 300)
+    // Initially fully expanded.
+    fhvc.headerView.trackingScrollView = scrollView1
+    window.rootViewController = fhvc
+    window.makeKeyAndVisible()
+    CATransaction.flush()
+
+    // When
+    // And then collapsed.
+    fhvc.headerView.trackingScrollView = scrollView2
+
+    // Then
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.size"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.origin"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "position"))
+
+    let animationDuration =
+        try XCTUnwrap(fhvc.headerView.layer.animation(forKey: "bounds.size")?.duration)
+
+    let sublayers = try XCTUnwrap(shadowLayer.sublayers)
+    XCTAssertGreaterThan(sublayers.count, 0)
+
+    for sublayer in sublayers {
+      let animation = try XCTUnwrap(sublayer.animation(forKey: "shadowPath"))
+      XCTAssertNotNil(animation)
+      XCTAssertEqual(animation.duration, animationDuration, accuracy: 0.001)
+    }
+  }
+}

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -60,16 +60,19 @@ class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
     guard let animationDuration =
         fhvc.headerView.layer.animation(forKey: "bounds.size")?.duration else {
       XCTFail("Missing bounds.size animation")
+      return
     }
 
     guard let sublayers = shadowLayer.sublayers else {
       XCTFail("Missing sublayers.")
+      return
     }
     XCTAssertGreaterThan(sublayers.count, 0)
 
     for sublayer in sublayers {
       guard let animation = sublayer.animation(forKey: "shadowPath") else {
         XCTFail("Missing shadowPath animation.")
+        return
       }
       XCTAssertNotNil(animation)
       XCTAssertEqual(animation.duration, animationDuration, accuracy: 0.001)


### PR DESCRIPTION
This change relies on https://github.com/material-components/material-components-ios/pull/8666.

Prior to this change, `setTrackingScrollView:`'s tab-change collapse animation would not animate the shadow if using an MDCShadowLayer.

After this change, the animation will animate the shadow.

The added test fails without the src/ changes and passes with them.

Closes https://github.com/material-components/material-components-ios/issues/8644