### PR TITLE
[bazel] Add mdc_snapshot_swift_library.

### DIFF
--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -233,6 +233,26 @@ def mdc_snapshot_objc_library(
       testonly = testonly,
       **kwargs)
 
+def mdc_snapshot_swift_library(
+    name,
+    extra_srcs = [],
+    deps = [],
+    visibility = ["//visibility:private"],
+    testonly = 1,
+    **kwargs):
+  """Declare a swift_library for snapshot test source."""
+  swift_library(
+      name = name,
+      srcs = native.glob(["tests/snapshot/*.swift"]) + extra_srcs,
+      deps = ["//components/private/Snapshot"] + deps,
+      visibility = visibility,
+      testonly = testonly,
+      copts = [
+          "-swift-version",
+          SWIFT_VERSION,
+      ],
+      **kwargs)
+
 def mdc_snapshot_test(
     name,
     deps = [],


### PR DESCRIPTION
This is being added to support Snapshot swift tests in https://github.com/material-components/material-components-ios/pull/8679

Part of https://github.com/material-components/material-components-ios/issues/8644