### PR TITLE
[TextFields] Add animation duration property to properly snapshot test MDCBaseTextField's subclasses

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -36,6 +36,7 @@
 @property(nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 @property(nonatomic, assign) MDCTextControlState textControlState;
 @property(nonatomic, assign) MDCTextControlLabelState labelState;
+@property(nonatomic, assign) NSTimeInterval animationDuration;
 
 /**
  This property maps MDCTextControlStates as NSNumbers to
@@ -80,6 +81,7 @@
 #pragma mark View Setup
 
 - (void)initializeProperties {
+  self.animationDuration = kMDCTextControlDefaultAnimationDuration;
   self.labelBehavior = MDCTextControlLabelBehaviorFloats;
   self.layoutDirection = self.mdf_effectiveUserInterfaceLayoutDirection;
   self.labelState = [self determineCurrentLabelState];
@@ -163,8 +165,9 @@
                            normalLabelFrame:self.layout.labelFrameNormal
                          floatingLabelFrame:self.layout.labelFrameFloating
                                  normalFont:self.normalFont
-                               floatingFont:self.floatingFont];
-  [self.containerStyle applyStyleToTextControl:self];
+                               floatingFont:self.floatingFont
+                          animationDuration:self.animationDuration];
+  [self.containerStyle applyStyleToTextControl:self animationDuration:self.animationDuration];
   self.assistiveLabelView.frame = self.layout.assistiveLabelViewFrame;
   self.assistiveLabelView.layout = self.layout.assistiveLabelViewLayout;
   [self.assistiveLabelView setNeedsLayout];
@@ -412,7 +415,7 @@
     [oldStyle removeStyleFrom:self];
   }
   _containerStyle = containerStyle;
-  [_containerStyle applyStyleToTextControl:self];
+  [_containerStyle applyStyleToTextControl:self animationDuration:0];
 }
 
 - (CGRect)containerFrame {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControl.h
@@ -148,7 +148,8 @@ static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
  This method allows objects conforming to MDCTextControlStyle to apply themselves to objects
  conforming to MDCTextControl.
  */
-- (void)applyStyleToTextControl:(nonnull UIView<MDCTextControl> *)textControl;
+- (void)applyStyleToTextControl:(nonnull UIView<MDCTextControl> *)textControl
+              animationDuration:(NSTimeInterval)animationDuration;
 /**
  This method allows objects conforming to MDCTextControlStyle to remove the styling
  previously applied to objects conforming to MDCTextControl.

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
@@ -31,5 +31,6 @@
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
-          floatingFont:(nonnull UIFont *)floatingFont;
+          floatingFont:(nonnull UIFont *)floatingFont
+     animationDuration:(NSTimeInterval)animationDuration;
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
@@ -24,7 +24,8 @@
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
-          floatingFont:(nonnull UIFont *)floatingFont {
+          floatingFont:(nonnull UIFont *)floatingFont
+     animationDuration:(NSTimeInterval)animationDuration {
   UIFont *targetFont;
   CGRect targetFrame;
   if (labelState == MDCTextControlLabelStateFloating) {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
@@ -26,7 +26,8 @@
   return font;
 }
 
-- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl
+              animationDuration:(NSTimeInterval)animationDuration {
 }
 
 - (void)removeStyleFrom:(id<MDCTextControl>)textControl {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -108,10 +108,12 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControl
 
-- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl
+              animationDuration:(NSTimeInterval)animationDuration {
   [self applyStyleToView:textControl
                    state:textControl.textControlState
-          containerFrame:textControl.containerFrame];
+          containerFrame:textControl.containerFrame
+       animationDuration:animationDuration];
 }
 
 - (void)removeStyleFrom:(id<MDCTextControl>)textControl {
@@ -146,7 +148,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 - (void)applyStyleToView:(UIView *)view
                    state:(MDCTextControlState)state
-          containerFrame:(CGRect)containerFrame {
+          containerFrame:(CGRect)containerFrame
+       animationDuration:(NSTimeInterval)animationDuration {
   self.filledSublayer.fillColor = [self.filledBackgroundColors[@(state)] CGColor];
   self.thinUnderlineLayer.fillColor = [self.underlineColors[@(state)] CGColor];
   self.thickUnderlineLayer.fillColor = [self.underlineColors[@(state)] CGColor];
@@ -188,88 +191,93 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
       (CABasicAnimation *)[self.thinUnderlineLayer
           animationForKey:self.class.thinUnderlineShrinkKey];
 
-  [CATransaction begin];
-  {
-    if (shouldShowThickUnderline) {
-      if (preexistingThickUnderlineShrinkAnimation) {
-        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
-      }
-      BOOL needsThickUnderlineGrowAnimation = NO;
-      if (preexistingThickUnderlineGrowAnimation) {
-        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineGrowAnimation.toValue;
-        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
-          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
-          needsThickUnderlineGrowAnimation = YES;
-          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
-        }
-      } else {
-        needsThickUnderlineGrowAnimation = YES;
-      }
-      if (needsThickUnderlineGrowAnimation) {
-        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
-                                        forKey:self.class.thickUnderlineGrowKey];
-      }
-
-      if (preexistingThinUnderlineGrowAnimation) {
-        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
-      }
-      BOOL needsThinUnderlineShrinkAnimation = NO;
-      if (preexistingThinUnderlineShrinkAnimation) {
-        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineShrinkAnimation.toValue;
-        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
-          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
-          needsThinUnderlineShrinkAnimation = YES;
-          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
-        }
-      } else {
-        needsThinUnderlineShrinkAnimation = YES;
-      }
-      if (needsThinUnderlineShrinkAnimation) {
-        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
-                                       forKey:self.class.thinUnderlineShrinkKey];
-      }
-
-    } else {
-      if (preexistingThickUnderlineGrowAnimation) {
-        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
-      }
-      BOOL needsThickUnderlineShrinkAnimation = NO;
-      if (preexistingThickUnderlineShrinkAnimation) {
-        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineShrinkAnimation.toValue;
-        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+  if (animationDuration > 0) {
+    [CATransaction begin];
+    {
+      if (shouldShowThickUnderline) {
+        if (preexistingThickUnderlineShrinkAnimation) {
           [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
-          needsThickUnderlineShrinkAnimation = YES;
-          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
         }
-      } else {
-        needsThickUnderlineShrinkAnimation = YES;
-      }
-      if (needsThickUnderlineShrinkAnimation) {
-        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
-                                        forKey:self.class.thickUnderlineShrinkKey];
-      }
-
-      if (preexistingThinUnderlineShrinkAnimation) {
-        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
-      }
-      BOOL needsThickUnderlineGrowAnimation = NO;
-      if (preexistingThinUnderlineGrowAnimation) {
-        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineGrowAnimation.toValue;
-        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
-          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+        BOOL needsThickUnderlineGrowAnimation = NO;
+        if (preexistingThickUnderlineGrowAnimation) {
+          CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineGrowAnimation.toValue;
+          if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+            [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
+            needsThickUnderlineGrowAnimation = YES;
+            self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+          }
+        } else {
           needsThickUnderlineGrowAnimation = YES;
-          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
         }
+        if (needsThickUnderlineGrowAnimation) {
+          [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                          forKey:self.class.thickUnderlineGrowKey];
+        }
+
+        if (preexistingThinUnderlineGrowAnimation) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+        }
+        BOOL needsThinUnderlineShrinkAnimation = NO;
+        if (preexistingThinUnderlineShrinkAnimation) {
+          CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineShrinkAnimation.toValue;
+          if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+            [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+            needsThinUnderlineShrinkAnimation = YES;
+            self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+          }
+        } else {
+          needsThinUnderlineShrinkAnimation = YES;
+        }
+        if (needsThinUnderlineShrinkAnimation) {
+          [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                         forKey:self.class.thinUnderlineShrinkKey];
+        }
+
       } else {
-        needsThickUnderlineGrowAnimation = YES;
-      }
-      if (needsThickUnderlineGrowAnimation) {
-        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
-                                       forKey:self.class.thinUnderlineGrowKey];
+        if (preexistingThickUnderlineGrowAnimation) {
+          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
+        }
+        BOOL needsThickUnderlineShrinkAnimation = NO;
+        if (preexistingThickUnderlineShrinkAnimation) {
+          CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineShrinkAnimation.toValue;
+          if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+            [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
+            needsThickUnderlineShrinkAnimation = YES;
+            self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+          }
+        } else {
+          needsThickUnderlineShrinkAnimation = YES;
+        }
+        if (needsThickUnderlineShrinkAnimation) {
+          [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                          forKey:self.class.thickUnderlineShrinkKey];
+        }
+
+        if (preexistingThinUnderlineShrinkAnimation) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+        }
+        BOOL needsThickUnderlineGrowAnimation = NO;
+        if (preexistingThinUnderlineGrowAnimation) {
+          CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineGrowAnimation.toValue;
+          if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+            [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+            needsThickUnderlineGrowAnimation = YES;
+            self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+          }
+        } else {
+          needsThickUnderlineGrowAnimation = YES;
+        }
+        if (needsThickUnderlineGrowAnimation) {
+          [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                         forKey:self.class.thinUnderlineGrowKey];
+        }
       }
     }
+    [CATransaction commit];
+  } else {
+    self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+    self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
   }
-  [CATransaction commit];
 }
 
 - (BOOL)shouldShowThickUnderlineWithState:(MDCTextControlState)state {

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -178,6 +178,12 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                                    underlineThickness:thinUnderlineThickness
                                        underlineWidth:viewWidth];
 
+  if (animationDuration <= 0) {
+    self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+    self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+    return;
+  }
+
   CABasicAnimation *preexistingThickUnderlineShrinkAnimation =
       (CABasicAnimation *)[self.thickUnderlineLayer
           animationForKey:self.class.thickUnderlineShrinkKey];
@@ -191,93 +197,90 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
       (CABasicAnimation *)[self.thinUnderlineLayer
           animationForKey:self.class.thinUnderlineShrinkKey];
 
-  if (animationDuration > 0) {
-    [CATransaction begin];
-    {
-      if (shouldShowThickUnderline) {
-        if (preexistingThickUnderlineShrinkAnimation) {
-          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
-        }
-        BOOL needsThickUnderlineGrowAnimation = NO;
-        if (preexistingThickUnderlineGrowAnimation) {
-          CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineGrowAnimation.toValue;
-          if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
-            [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
-            needsThickUnderlineGrowAnimation = YES;
-            self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
-          }
-        } else {
-          needsThickUnderlineGrowAnimation = YES;
-        }
-        if (needsThickUnderlineGrowAnimation) {
-          [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
-                                          forKey:self.class.thickUnderlineGrowKey];
-        }
+  [CATransaction begin];
+  {
+    [CATransaction setAnimationDuration:animationDuration];
 
-        if (preexistingThinUnderlineGrowAnimation) {
-          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
-        }
-        BOOL needsThinUnderlineShrinkAnimation = NO;
-        if (preexistingThinUnderlineShrinkAnimation) {
-          CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineShrinkAnimation.toValue;
-          if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
-            [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
-            needsThinUnderlineShrinkAnimation = YES;
-            self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
-          }
-        } else {
-          needsThinUnderlineShrinkAnimation = YES;
-        }
-        if (needsThinUnderlineShrinkAnimation) {
-          [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
-                                         forKey:self.class.thinUnderlineShrinkKey];
-        }
-
-      } else {
-        if (preexistingThickUnderlineGrowAnimation) {
+    if (shouldShowThickUnderline) {
+      if (preexistingThickUnderlineShrinkAnimation) {
+        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
+      }
+      BOOL needsThickUnderlineGrowAnimation = NO;
+      if (preexistingThickUnderlineGrowAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineGrowAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
           [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
-        }
-        BOOL needsThickUnderlineShrinkAnimation = NO;
-        if (preexistingThickUnderlineShrinkAnimation) {
-          CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineShrinkAnimation.toValue;
-          if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
-            [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
-            needsThickUnderlineShrinkAnimation = YES;
-            self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
-          }
-        } else {
-          needsThickUnderlineShrinkAnimation = YES;
-        }
-        if (needsThickUnderlineShrinkAnimation) {
-          [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
-                                          forKey:self.class.thickUnderlineShrinkKey];
-        }
-
-        if (preexistingThinUnderlineShrinkAnimation) {
-          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
-        }
-        BOOL needsThickUnderlineGrowAnimation = NO;
-        if (preexistingThinUnderlineGrowAnimation) {
-          CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineGrowAnimation.toValue;
-          if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
-            [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
-            needsThickUnderlineGrowAnimation = YES;
-            self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
-          }
-        } else {
           needsThickUnderlineGrowAnimation = YES;
+          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
         }
-        if (needsThickUnderlineGrowAnimation) {
-          [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
-                                         forKey:self.class.thinUnderlineGrowKey];
+      } else {
+        needsThickUnderlineGrowAnimation = YES;
+      }
+      if (needsThickUnderlineGrowAnimation) {
+        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                        forKey:self.class.thickUnderlineGrowKey];
+      }
+
+      if (preexistingThinUnderlineGrowAnimation) {
+        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+      }
+      BOOL needsThinUnderlineShrinkAnimation = NO;
+      if (preexistingThinUnderlineShrinkAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineShrinkAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+          needsThinUnderlineShrinkAnimation = YES;
+          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
         }
+      } else {
+        needsThinUnderlineShrinkAnimation = YES;
+      }
+      if (needsThinUnderlineShrinkAnimation) {
+        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                       forKey:self.class.thinUnderlineShrinkKey];
+      }
+
+    } else {
+      if (preexistingThickUnderlineGrowAnimation) {
+        [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineGrowKey];
+      }
+      BOOL needsThickUnderlineShrinkAnimation = NO;
+      if (preexistingThickUnderlineShrinkAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThickUnderlineShrinkAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThickUnderlineBezier.CGPath)) {
+          [self.thickUnderlineLayer removeAnimationForKey:self.class.thickUnderlineShrinkKey];
+          needsThickUnderlineShrinkAnimation = YES;
+          self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThickUnderlineShrinkAnimation = YES;
+      }
+      if (needsThickUnderlineShrinkAnimation) {
+        [self.thickUnderlineLayer addAnimation:[self pathAnimationTo:targetThickUnderlineBezier]
+                                        forKey:self.class.thickUnderlineShrinkKey];
+      }
+
+      if (preexistingThinUnderlineShrinkAnimation) {
+        [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineShrinkKey];
+      }
+      BOOL needsThickUnderlineGrowAnimation = NO;
+      if (preexistingThinUnderlineGrowAnimation) {
+        CGPathRef toValue = (__bridge CGPathRef)preexistingThinUnderlineGrowAnimation.toValue;
+        if (!CGPathEqualToPath(toValue, targetThinUnderlineBezier.CGPath)) {
+          [self.thinUnderlineLayer removeAnimationForKey:self.class.thinUnderlineGrowKey];
+          needsThickUnderlineGrowAnimation = YES;
+          self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
+        }
+      } else {
+        needsThickUnderlineGrowAnimation = YES;
+      }
+      if (needsThickUnderlineGrowAnimation) {
+        [self.thinUnderlineLayer addAnimation:[self pathAnimationTo:targetThinUnderlineBezier]
+                                       forKey:self.class.thinUnderlineGrowKey];
       }
     }
-    [CATransaction commit];
-  } else {
-    self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
-    self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
   }
+  [CATransaction commit];
 }
 
 - (BOOL)shouldShowThickUnderlineWithState:(MDCTextControlState)state {
@@ -304,7 +307,6 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 - (CABasicAnimation *)basicAnimationWithKeyPath:(NSString *)keyPath {
   CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:keyPath];
-  animation.duration = kMDCTextControlDefaultAnimationDuration;
   animation.timingFunction =
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
   animation.repeatCount = 0;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleOutlined.m
@@ -84,7 +84,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 #pragma mark MDCTextControlStyle
 
-- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl {
+- (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl
+              animationDuration:(NSTimeInterval)animationDuration {
   CGRect labelFrame = textControl.label.frame;
   BOOL isLabelFloating = textControl.labelState == MDCTextControlLabelStateFloating;
   CGFloat containerHeight = CGRectGetMaxY(textControl.containerFrame);

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -23,7 +23,6 @@
 
 @interface MDCBaseTextFieldTestsSnapshotTests : MDCSnapshotTestCase
 @property(strong, nonatomic) MDCBaseTextField *textField;
-@property(nonatomic, assign) BOOL areAnimationsEnabled;
 @end
 
 @implementation MDCBaseTextFieldTestsSnapshotTests
@@ -31,8 +30,6 @@
 - (void)setUp {
   [super setUp];
 
-  self.areAnimationsEnabled = UIView.areAnimationsEnabled;
-  [UIView setAnimationsEnabled:NO];
   self.textField = [self createBaseTextFieldInKeyWindow];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
@@ -43,11 +40,11 @@
   [super tearDown];
   [self.textField removeFromSuperview];
   self.textField = nil;
-  [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
 - (MDCBaseTextField *)createBaseTextFieldInKeyWindow {
   MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:CGRectMake(0, 0, 200, 60)];
+  textField.animationDuration = 0;
   textField.borderStyle = UITextBorderStyleRoundedRect;
 
   // Using a dummy inputView instead of the system keyboard cuts the execution time roughly in half,

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -23,6 +23,7 @@
 
 @interface MDCBaseTextFieldTestsSnapshotTests : MDCSnapshotTestCase
 @property(strong, nonatomic) MDCBaseTextField *textField;
+@property(nonatomic, assign) BOOL areAnimationsEnabled;
 @end
 
 @implementation MDCBaseTextFieldTestsSnapshotTests
@@ -30,6 +31,8 @@
 - (void)setUp {
   [super setUp];
 
+  self.areAnimationsEnabled = UIView.areAnimationsEnabled;
+  [UIView setAnimationsEnabled:NO];
   self.textField = [self createBaseTextFieldInKeyWindow];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
@@ -40,6 +43,7 @@
   [super tearDown];
   [self.textField removeFromSuperview];
   self.textField = nil;
+  [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
 - (MDCBaseTextField *)createBaseTextFieldInKeyWindow {

--- a/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
+++ b/components/TextFields/tests/snapshot/MDCBaseTextFieldTestsSnapshotTestHelpers.h
@@ -18,6 +18,10 @@
 
 #import "../../src/ContainedInputView/MDCBaseTextField.h"
 
+@interface MDCBaseTextField (AnimationDuration)
+@property(nonatomic, assign) NSTimeInterval animationDuration;
+@end
+
 @interface MDCBaseTextFieldTestsSnapshotTestHelpers : NSObject
 + (void)configureTextFieldWithColoredAssistiveLabelText:(MDCBaseTextField *)textField;
 + (void)configureTextFieldWithText:(MDCBaseTextField *)textField;


### PR DESCRIPTION
This PR adds an `animationDuration` property to MDCBaseTextField. I'm doing this because I ran into problems snapshot testing MDCFilledTextField. Its style object uses Core Animation, so the `[UIView setAnimationsEnabled:{NO/YES}]` calls I'm making in `-setUp`/`-tearDown` don't have any effect on it. However, they do have an effect on the label animation, which uses UIView animations. This PR has no behavioral or public API changes. 

On one hand, this change goes against the idea that you shouldn't change source code for the sake of testing. On the other hand, there's nothing wrong with rewriting existing code so that it's more testable.

Related to #6942.