### PR TITLE
[TextFields] Add safety return to new multiline logic to make it fully opt-in

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -1468,7 +1468,7 @@ static UITextFieldViewMode _underlineViewModeDefault = UITextFieldViewModeWhileE
                                   givenTrailingLabel:(UILabel *)trailingLabel
                                               insets:(UIEdgeInsets)insets
                                            widthHint:(CGFloat)widthHint {
-  if (!label.text) {
+  if (!label.text || label.numberOfLines == 1) {
     return 1;
   }
   if (widthHint <= 0 && CGRectGetWidth(label.bounds) <= 0) {


### PR DESCRIPTION
If numberOfLines == 1 (which is the current default), I prefer we don't go into the logic of calculation at all, due to the recently found bug with Apple's generated attributedText removing the textAlignment Natural logic.