### PR TITLE
[TextFields] Change label animation again

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -564,6 +564,8 @@
                            animationDuration:self.animationDuration
                                   completion:^(BOOL finished) {
                                     if (finished) {
+                                      // Ensure that the label position is correct in case of
+                                      // competing animations.
                                       [weakSelf positionLabel];
                                     }
                                   }];

--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -160,19 +160,13 @@
 
 - (void)postLayoutSubviews {
   self.label.hidden = self.labelState == MDCTextControlLabelStateNone;
-  [MDCTextControlLabelAnimation layOutLabel:self.label
-                                      state:self.labelState
-                           normalLabelFrame:self.layout.labelFrameNormal
-                         floatingLabelFrame:self.layout.labelFrameFloating
-                                 normalFont:self.normalFont
-                               floatingFont:self.floatingFont
-                          animationDuration:self.animationDuration];
-  [self.containerStyle applyStyleToTextControl:self animationDuration:self.animationDuration];
   self.assistiveLabelView.frame = self.layout.assistiveLabelViewFrame;
   self.assistiveLabelView.layout = self.layout.assistiveLabelViewLayout;
   [self.assistiveLabelView setNeedsLayout];
   self.leftView.hidden = self.layout.leftViewHidden;
   self.rightView.hidden = self.layout.rightViewHidden;
+  [self.containerStyle applyStyleToTextControl:self animationDuration:self.animationDuration];
+  [self animateLabel];
 }
 
 - (CGRect)textRectFromLayout:(MDCBaseTextFieldLayout *)layout
@@ -558,6 +552,35 @@
 }
 
 #pragma mark Label
+
+- (void)animateLabel {
+  __weak MDCBaseTextField *weakSelf = self;
+  [MDCTextControlLabelAnimation animateLabel:self.label
+                                       state:self.labelState
+                            normalLabelFrame:self.layout.labelFrameNormal
+                          floatingLabelFrame:self.layout.labelFrameFloating
+                                  normalFont:self.normalFont
+                                floatingFont:self.floatingFont
+                           animationDuration:self.animationDuration
+                                  completion:^(BOOL finished) {
+                                    if (finished) {
+                                      [weakSelf positionLabel];
+                                    }
+                                  }];
+}
+
+- (void)positionLabel {
+  if (self.labelState == MDCTextControlLabelStateFloating) {
+    self.label.frame = self.layout.labelFrameFloating;
+    self.label.hidden = NO;
+  } else if (self.labelState == MDCTextControlLabelStateNormal) {
+    self.label.frame = self.layout.labelFrameNormal;
+    self.label.hidden = NO;
+  } else {
+    self.label.frame = CGRectZero;
+    self.label.hidden = YES;
+  }
+}
 
 - (BOOL)canLabelFloat {
   return self.labelBehavior == MDCTextControlLabelBehaviorFloats;

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
@@ -26,11 +26,12 @@
  This method lays out the label in an animated fashion, often from normal position to the floating
  position, and vice versa.
  */
-+ (void)layOutLabel:(nonnull UILabel *)floatingLabel
++ (void)animateLabel:(nonnull UILabel *)label
                  state:(MDCTextControlLabelState)labelState
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
           floatingFont:(nonnull UIFont *)floatingFont
-     animationDuration:(NSTimeInterval)animationDuration;
+     animationDuration:(NSTimeInterval)animationDuration
+            completion:(void (^__nullable)(BOOL))completion;
 @end

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.h
@@ -25,6 +25,10 @@
 /**
  This method lays out the label in an animated fashion, often from normal position to the floating
  position, and vice versa.
+
+ This method does not attempt an animation and passes @c NO to the completion block if an animation
+ is already in progress. It does the animation and passes @c YES to the completion block if there is
+ no animation in progress.
  */
 + (void)animateLabel:(nonnull UILabel *)label
                  state:(MDCTextControlLabelState)labelState

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
@@ -27,7 +27,8 @@
           floatingFont:(nonnull UIFont *)floatingFont
      animationDuration:(NSTimeInterval)animationDuration
             completion:(void (^__nullable)(BOOL))completion {
-  if (label.layer.animationKeys.count > 0) {
+  BOOL isAnimationInProgress = label.layer.animationKeys.count > 0;
+  if (isAnimationInProgress) {
     if (completion) {
       completion(NO);
     }
@@ -57,7 +58,8 @@
     }
   };
 
-  if (animationDuration > 0) {
+  BOOL shouldPerformAnimation = animationDuration > 0;
+  if (shouldPerformAnimation) {
     dispatch_async(dispatch_get_main_queue(), ^{
       CAMediaTimingFunction *timingFunction =
           [CAMediaTimingFunction mdc_functionWithType:MDCAnimationTimingFunctionStandard];


### PR DESCRIPTION
There's been this bug for a long time now with the floating label animation (only on simulators using below iOS 13, and not on devices, for some reason) where the animation is sometimes skipped entirely. I thought I had a fix for it with #8700, but when I started preparing the PR for the outlined textfields (which is blocked on #8674) I noticed that it was still a problem for them, for some reason. This PR I _think_ fixes it for everything though, despite being more complicated than I'd like.

Related to #6942.