### PR TITLE
[TextFields] Change base textfield floating label scale factor.

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -263,6 +263,14 @@
 
 #pragma mark UITextField Accessor Overrides
 
+- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
+  if ([self.containerStyle isKindOfClass:[MDCTextControlStyleBase class]]) {
+    [super setBorderStyle:borderStyle];
+  } else {
+    [super setBorderStyle:UITextBorderStyleNone];
+  }
+}
+
 - (void)setEnabled:(BOOL)enabled {
   [super setEnabled:enabled];
 

--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -267,6 +267,8 @@
   if ([self.containerStyle isKindOfClass:[MDCTextControlStyleBase class]]) {
     [super setBorderStyle:borderStyle];
   } else {
+    NSLog(@"Setting borderStyle on Material styled TextFields, such as MDCFilledTextField and "
+          @"MDCOutlinedTextFIeld, is not allowed.");
     [super setBorderStyle:UITextBorderStyleNone];
   }
 }

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
@@ -20,10 +20,14 @@
 #import "MDCTextControl.h"
 #import "MDCTextControlVerticalPositioningReferenceBase.h"
 
+static const CGFloat kBaseFloatingLabelScaleFactor = 0.8;
+
 @implementation MDCTextControlStyleBase
 
 - (UIFont *)floatingFontWithNormalFont:(UIFont *)font {
-  return font;
+  CGFloat scaleFactor = kBaseFloatingLabelScaleFactor;
+  CGFloat floatingFontSize = font.pointSize * scaleFactor;
+  return [font fontWithSize:floatingFontSize];
 }
 
 - (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleBase.m
@@ -20,7 +20,7 @@
 #import "MDCTextControl.h"
 #import "MDCTextControlVerticalPositioningReferenceBase.h"
 
-static const CGFloat kBaseFloatingLabelScaleFactor = 0.8;
+static const CGFloat kBaseFloatingLabelScaleFactor = (CGFloat)0.8;
 
 @implementation MDCTextControlStyleBase
 

--- a/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldTests.m
+++ b/components/TextFields/tests/unit/ContainedInputView/MDCBaseTextFieldTests.m
@@ -184,7 +184,7 @@
   [textField layoutIfNeeded];
 
   // Then
-  CGRect expectedClearButtonFrame = CGRectMake(99, 22, 19, 19);
+  CGRect expectedClearButtonFrame = CGRectMake(99, 20, 19, 19);
   CGRect actualClearButtonFrame = [textField clearButtonRectForBounds:textFieldFrame];
   XCTAssertTrue(CGRectEqualToRect(actualClearButtonFrame, expectedClearButtonFrame));
 }
@@ -305,7 +305,7 @@
 
   // Then
   CGSize newSize = textField.frame.size;
-  CGSize correctSize = CGSizeMake(130, 63);
+  CGSize correctSize = CGSizeMake(130, 59);
   XCTAssertTrue(CGSizeEqualToSize(newSize, correctSize));
 }
 

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testDisabledTextField_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testDisabledTextField_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:918c9fc6b785caf3ba3edd5e4e5073df7acf5821a4cd2eb6c72ddeeaeb03bfba
-size 8387
+oid sha256:da140e109597f12e90894c595d48158898ee1b7aaf32d7c35491bd9014d34dad
+size 7518

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testEditingTextFieldWithVisiblePlaceholder_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testEditingTextFieldWithVisiblePlaceholder_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32586ad66ec53b05a7eea24575b61c699316a6a0a44d8a64c639f46459a8f6dd
-size 9938
+oid sha256:6828147168f51e9ed9f370248d1cf528b7a55a98c85f7b37fbd4350890f3349a
+size 9085

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testFloatingLabelWithCustomColorWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testFloatingLabelWithCustomColorWhileEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02945baaa9c7706d90c5c5cb87da8aacb0ce9def5d8c353d240d616b10d4d4a9
-size 8906
+oid sha256:1139bc63ea03c91d410e84a447219274dd75c232e60bd435e774e2993f493935
+size 8047

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileDisabled_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e3e0aea120538ee22f2379309f1c5899ca19e55c416aaf4ffd2ede6a03b46b3
-size 16231
+oid sha256:5e0b1748e74cf8874369de8c026ca928acdcc9be8d74ffff8db75d40e47167d8
+size 15641

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb758e4ca9eb9cdd3eed67149141ead5e992d485ffa90ab639c8d190e119b6cc
-size 14384
+oid sha256:f294e9438765680d1b98b2187d5f909b6a23b7970ef45047584fc558ae0cc19c
+size 13849

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10c14e762690e672b910be95ea51f7b60386b9f3aaf329aa68eae3d9a2b980f9
-size 14166
+oid sha256:3924a2d9cf4ec714bd2688e57e40ba45c3d571fa456983a218849ec59c54c2f2
+size 13628

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewAndTrailingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewAndTrailingView_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8f1f628fe71ca3104fb2d64484f87171152b711de2d1a030e33db4110a3add2
-size 4884
+oid sha256:3e500a1275a5f67d97e8bb9399db4e813e688f3446fdb0e71c47111d16430a26
+size 4779

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewWhileEditing_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9b63e629ac81ebaa0c3ea1846efa077b4346f6a5c753ebab29934ea7a83d50e
-size 4844
+oid sha256:e94f034c37e55ffa17bd6f4b55292f2c01b46da2122f1eaca41d6ca02ede4611
+size 4740

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithLeadingView_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3cc60f3c4abfae1bd95c2e4417c625605513c4d77050b6d3619b804509d8274
-size 4706
+oid sha256:486524a87f486ed087b001ba88ecd3691586aab6704f5d465a10594ea3961fbc
+size 4601

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithText_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:afb53f2a1390ff0c3e4c72a33df7f9d1ae02dff0fcb01a5c0dfc5137cfbd7556
-size 4604
+oid sha256:676fe90081327e54e27f431b12945ee1d8013b5491c13669d6d22c833c2d3c28
+size 4482

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithTrailingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithTrailingView_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6845bfca6712eb2d0c6f27c42b1e7ceee00ee0e83c12bc973991e748b065e788
-size 4677
+oid sha256:37381d046273e243e451ea31fb02ab5e022649d09c7556177163cebb5aa7b001
+size 4589

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithVisibleClearButton_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithVisibleClearButton_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7084af904dd780c03979b9f6c0c0b548a99bacf0b6cb56782582ce7ccf9a830c
-size 5110
+oid sha256:527935b1bb8c062a609fa73b1015ce542991a3d3e282e1d4630b3dd74792d328
+size 4994


### PR DESCRIPTION
In a recent PR I made the floating label the same size as the non-floating label because I thought it brought the MDCBaseTextField closer to being the "absence of style." In this PR I make it smaller again because I decided I think it just looks bad.

I also added an override for `-setBorderStyle:` that will prevent non-base textfields from having border styles like `.roundedRect`.

Related to #6942.