### PR TITLE
[TextFields] Add outlined textfield

### DIFF
--- a/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
+++ b/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
@@ -30,7 +30,10 @@ static CGFloat const kDefaultPadding = 15.0;
 @property(nonatomic, strong) MDCBaseTextField *baseTextField;
 
 /** The MDCFilledTextField for this example. */
-@property(nonatomic, strong) MDCBaseTextField *filledTextField;
+@property(nonatomic, strong) MDCFilledTextField *filledTextField;
+
+/** The MDCOutlinedTextField for this example. */
+@property(nonatomic, strong) MDCOutlinedTextField *outlinedTextField;
 
 /** The UIButton that makes the textfield stop being the first responder. */
 @property(nonatomic, strong) MDCButton *resignFirstResponderButton;
@@ -66,6 +69,12 @@ static CGFloat const kDefaultPadding = 15.0;
   self.filledTextField.placeholder = @"This is placeholder text";
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   [self.view addSubview:self.filledTextField];
+
+  self.outlinedTextField = [[MDCOutlinedTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
+  self.outlinedTextField.label.text = @"This is a label";
+  self.outlinedTextField.placeholder = @"This is placeholder text";
+  self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+  [self.view addSubview:self.outlinedTextField];
 }
 
 - (MDCButton *)createFirstResponderButton {
@@ -81,6 +90,7 @@ static CGFloat const kDefaultPadding = 15.0;
 - (void)resignFirstResponderButtonTapped:(UIButton *)button {
   [self.baseTextField resignFirstResponder];
   [self.filledTextField resignFirstResponder];
+  [self.outlinedTextField resignFirstResponder];
 }
 
 - (CGFloat)preferredResignFirstResponderMinY {
@@ -105,6 +115,7 @@ static CGFloat const kDefaultPadding = 15.0;
   [self.resignFirstResponderButton sizeToFit];
   [self.baseTextField sizeToFit];
   [self.filledTextField sizeToFit];
+  [self.outlinedTextField sizeToFit];
 
   self.resignFirstResponderButton.frame =
       CGRectMake(kDefaultPadding, self.preferredResignFirstResponderMinY,
@@ -115,8 +126,12 @@ static CGFloat const kDefaultPadding = 15.0;
       kDefaultPadding, CGRectGetMaxY(self.resignFirstResponderButton.frame) + kDefaultPadding,
       CGRectGetWidth(self.filledTextField.frame), CGRectGetHeight(self.filledTextField.frame));
 
-  self.baseTextField.frame = CGRectMake(
+  self.outlinedTextField.frame = CGRectMake(
       kDefaultPadding, CGRectGetMaxY(self.filledTextField.frame) + kDefaultPadding,
+      CGRectGetWidth(self.outlinedTextField.frame), CGRectGetHeight(self.outlinedTextField.frame));
+
+  self.baseTextField.frame = CGRectMake(
+      kDefaultPadding, CGRectGetMaxY(self.outlinedTextField.frame) + kDefaultPadding,
       CGRectGetWidth(self.baseTextField.frame), CGRectGetHeight(self.baseTextField.frame));
 }
 

--- a/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
+++ b/components/TextFields/examples/MDCBaseTextFieldTypicalUseExample.m
@@ -70,7 +70,8 @@ static CGFloat const kDefaultPadding = 15.0;
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   [self.view addSubview:self.filledTextField];
 
-  self.outlinedTextField = [[MDCOutlinedTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
+  self.outlinedTextField =
+      [[MDCOutlinedTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
   self.outlinedTextField.label.text = @"This is a label";
   self.outlinedTextField.placeholder = @"This is placeholder text";
   self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;

--- a/components/TextFields/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextFields/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -24,7 +24,7 @@ static CGFloat const kDefaultPadding = 15.0;
 /**
  Typical use example showing how to place an @c MDCBaseTextField in a UIViewController.
  */
-@interface MDCBaseTextFieldTypicalExampleViewController : UIViewController
+@interface MDCTextControlTextFieldTypicalUseExample : UIViewController
 
 /** The MDCBaseTextField for this example. */
 @property(nonatomic, strong) MDCBaseTextField *baseTextField;
@@ -43,7 +43,7 @@ static CGFloat const kDefaultPadding = 15.0;
 
 @end
 
-@implementation MDCBaseTextFieldTypicalExampleViewController
+@implementation MDCTextControlTextFieldTypicalUseExample
 
 - (void)viewDidLoad {
   [super viewDidLoad];
@@ -140,11 +140,11 @@ static CGFloat const kDefaultPadding = 15.0;
 
 #pragma mark - CatalogByConvention
 
-@implementation MDCBaseTextFieldTypicalExampleViewController (CatalogByConvention)
+@implementation MDCTextControlTextFieldTypicalUseExample (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {
   return @{
-    @"breadcrumbs" : @[ @"Text Field", kExampleTitle ],
+    @"breadcrumbs" : @[ @"Text Controls", kExampleTitle ],
     @"primaryDemo" : @NO,
     @"presentable" : @NO,
   };

--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -257,16 +257,6 @@
 
 #pragma mark UITextField Accessor Overrides
 
-- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
-  if ([self.containerStyle isKindOfClass:[MDCTextControlStyleBase class]]) {
-    [super setBorderStyle:borderStyle];
-  } else {
-    NSLog(@"Setting borderStyle on Material styled TextFields, such as MDCFilledTextField and "
-          @"MDCOutlinedTextFIeld, is not allowed.");
-    [super setBorderStyle:UITextBorderStyleNone];
-  }
-}
-
 - (void)setEnabled:(BOOL)enabled {
   [super setEnabled:enabled];
 

--- a/components/TextFields/src/ContainedInputView/MDCFilledTextField.h
+++ b/components/TextFields/src/ContainedInputView/MDCFilledTextField.h
@@ -36,6 +36,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDC
 /**
  Returns the filled background color for a given state.
  @param state The MDCTextControlState.
+
+ The default value is a light shade of gray.
  */
 - (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state;
 
@@ -49,6 +51,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDC
 /**
  Returns the underline color for a given state.
  @param state The MDCTextControlState.
+
+ The default values are sensible shades of black.
  */
 - (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
 

--- a/components/TextFields/src/ContainedInputView/MDCFilledTextField.h
+++ b/components/TextFields/src/ContainedInputView/MDCFilledTextField.h
@@ -22,6 +22,11 @@
 __attribute__((objc_subclassing_restricted)) @interface MDCFilledTextField : MDCBaseTextField
 
 /**
+ MDCFilledTextField does not support UITextBorderStyle borders.
+ */
+@property(nonatomic, assign) UITextBorderStyle borderStyle NS_UNAVAILABLE;
+
+/**
  Sets the filled background color for a given state.
  @param filledBackgroundColor The UIColor for the given state.
  @param state The MDCTextControlState.

--- a/components/TextFields/src/ContainedInputView/MDCFilledTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCFilledTextField.m
@@ -48,6 +48,17 @@
   self.borderStyle = UITextBorderStyleNone;
 }
 
+#pragma mark UITextField Overrides
+
+- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
+  if (borderStyle == UITextBorderStyleNone) {
+    [super setBorderStyle:borderStyle];
+  } else {
+    NSLog(@"Setting borderStyle on MDCFilledTextField is not allowed.");
+    [super setBorderStyle:UITextBorderStyleNone];
+  }
+}
+
 #pragma mark Stateful Color APIs
 
 - (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor

--- a/components/TextFields/src/ContainedInputView/MDCFilledTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCFilledTextField.m
@@ -24,6 +24,7 @@
 @end
 
 @implementation MDCFilledTextField
+@dynamic borderStyle;
 
 #pragma mark Object Lifecycle
 
@@ -45,18 +46,6 @@
 
 - (void)commonMDCFilledTextFieldInit {
   self.containerStyle = [[MDCTextControlStyleFilled alloc] init];
-  self.borderStyle = UITextBorderStyleNone;
-}
-
-#pragma mark UITextField Overrides
-
-- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
-  if (borderStyle == UITextBorderStyleNone) {
-    [super setBorderStyle:borderStyle];
-  } else {
-    NSLog(@"Setting borderStyle on MDCFilledTextField is not allowed.");
-    [super setBorderStyle:UITextBorderStyleNone];
-  }
 }
 
 #pragma mark Stateful Color APIs

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
@@ -12,8 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <UIKit/UIKit.h>
+
 #import "MDCBaseTextField.h"
-#import "MDCFilledTextField.h"
-#import "MDCOutlinedTextField.h"
-#import "MDCTextControlLabelBehavior.h"
-#import "MDCTextControlState.h"
+
+/**
+ An implementation of a Material outlined text field.
+ */
+__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCBaseTextField
+
+/**
+ Sets the outline color for a given state.
+ @param outlineColor The UIColor for the given state.
+ @param state The MDCTextControlState.
+ */
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state;
+/**
+ Returns the outline color for a given state.
+ @param state The MDCTextControlState.
+ */
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
+
+@end

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
@@ -35,6 +35,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : M
 /**
  Returns the outline color for a given state.
  @param state The MDCTextControlState.
+
+ The default values are sensible black values.
  */
 - (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
 

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.h
@@ -22,6 +22,11 @@
 __attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCBaseTextField
 
 /**
+ MDCOutlinedTextField does not support UITextBorderStyle borders.
+ */
+@property(nonatomic, assign) UITextBorderStyle borderStyle NS_UNAVAILABLE;
+
+/**
  Sets the outline color for a given state.
  @param outlineColor The UIColor for the given state.
  @param state The MDCTextControlState.

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
@@ -25,6 +25,8 @@
 
 @implementation MDCOutlinedTextField
 
+#pragma mark Object Lifecycle
+
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
@@ -46,6 +48,17 @@
   self.borderStyle = UITextBorderStyleNone;
 }
 
+#pragma mark UITextField Overrides
+
+- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
+  if (borderStyle == UITextBorderStyleNone) {
+    [super setBorderStyle:borderStyle];
+  } else {
+    NSLog(@"Setting borderStyle on MDCOutlinedTextField is not allowed.");
+    [super setBorderStyle:UITextBorderStyleNone];
+  }
+}
+
 #pragma mark Stateful Color APIs
 
 - (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state {
@@ -56,6 +69,8 @@
 - (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state {
   return [self.outlinedStyle outlineColorForState:state];
 }
+
+#pragma mark Private Helpers
 
 - (MDCTextControlStyleOutlined *)outlinedStyle {
   MDCTextControlStyleOutlined *outlinedStyle = nil;

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
@@ -24,6 +24,7 @@
 @end
 
 @implementation MDCOutlinedTextField
+@dynamic borderStyle;
 
 #pragma mark Object Lifecycle
 
@@ -45,18 +46,6 @@
 
 - (void)commonMDCOutlinedTextFieldInit {
   self.containerStyle = [[MDCTextControlStyleOutlined alloc] init];
-  self.borderStyle = UITextBorderStyleNone;
-}
-
-#pragma mark UITextField Overrides
-
-- (void)setBorderStyle:(UITextBorderStyle)borderStyle {
-  if (borderStyle == UITextBorderStyleNone) {
-    [super setBorderStyle:borderStyle];
-  } else {
-    NSLog(@"Setting borderStyle on MDCOutlinedTextField is not allowed.");
-    [super setBorderStyle:UITextBorderStyleNone];
-  }
 }
 
 #pragma mark Stateful Color APIs

--- a/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCOutlinedTextField.m
@@ -1,0 +1,68 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextField.h"
+
+#import <Foundation/Foundation.h>
+
+#import "private/MDCBaseTextField+MDCTextControl.h"
+#import "private/MDCTextControl.h"
+#import "private/MDCTextControlStyleOutlined.h"
+
+@interface MDCOutlinedTextField ()
+@end
+
+@implementation MDCOutlinedTextField
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCOutlinedTextFieldInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonMDCOutlinedTextFieldInit];
+  }
+  return self;
+}
+
+- (void)commonMDCOutlinedTextFieldInit {
+  self.containerStyle = [[MDCTextControlStyleOutlined alloc] init];
+  self.borderStyle = UITextBorderStyleNone;
+}
+
+#pragma mark Stateful Color APIs
+
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state {
+  [self.outlinedStyle setOutlineColor:outlineColor forState:state];
+  [self setNeedsLayout];
+}
+
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state {
+  return [self.outlinedStyle outlineColorForState:state];
+}
+
+- (MDCTextControlStyleOutlined *)outlinedStyle {
+  MDCTextControlStyleOutlined *outlinedStyle = nil;
+  if ([self.containerStyle isKindOfClass:[MDCTextControlStyleOutlined class]]) {
+    outlinedStyle = (MDCTextControlStyleOutlined *)self.containerStyle;
+  }
+  return outlinedStyle;
+}
+
+@end

--- a/components/TextFields/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
@@ -37,7 +37,7 @@
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
 
-//      self.recordMode = YES;
+  //      self.recordMode = YES;
 }
 
 - (void)tearDown {

--- a/components/TextFields/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
+++ b/components/TextFields/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
@@ -1,0 +1,215 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import <UIKit/UIKit.h>
+
+#import "../../src/ContainedInputView/private/MDCTextControl.h"
+#import "MDCBaseTextFieldTestsSnapshotTestHelpers.h"
+#import "MDCTextControlSnapshotTestHelpers.h"
+#import "MaterialTextFields+ContainedInputView.h"
+
+@interface MDCOutlinedTextFieldTestsSnapshotTests : MDCSnapshotTestCase
+@property(strong, nonatomic) MDCOutlinedTextField *textField;
+@property(nonatomic, assign) BOOL areAnimationsEnabled;
+@end
+
+@implementation MDCOutlinedTextFieldTestsSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.areAnimationsEnabled = UIView.areAnimationsEnabled;
+  [UIView setAnimationsEnabled:NO];
+  self.textField = [self createOutlinedTextFieldInKeyWindow];
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+
+//      self.recordMode = YES;
+}
+
+- (void)tearDown {
+  [super tearDown];
+  [self.textField removeFromSuperview];
+  self.textField = nil;
+  [UIView setAnimationsEnabled:self.areAnimationsEnabled];
+}
+
+- (MDCOutlinedTextField *)createOutlinedTextFieldInKeyWindow {
+  MDCOutlinedTextField *textField =
+      [[MDCOutlinedTextField alloc] initWithFrame:CGRectMake(0, 0, 200, 60)];
+  textField.animationDuration = 0;
+
+  // Using a dummy inputView instead of the system keyboard cuts the execution time roughly in half,
+  // at least locally.
+  UIView *dummyInputView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
+  textField.inputView = dummyInputView;
+
+  // Add the textfield to the window so it's part of a valid view hierarchy and things like
+  // `-becomeFirstResponder` work.
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  [keyWindow addSubview:textField];
+  return textField;
+}
+
+- (void)validateTextField:(MDCOutlinedTextField *)textField {
+  [MDCTextControlSnapshotTestHelpers validateTextControl:(UIView<MDCTextControl> *)textField
+                                            withTestCase:self];
+}
+
+#pragma mark - Tests
+
+- (void)testTextFieldWithText {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithLeadingView {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithLeadingView:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithLeadingViewWhileEditing {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithLeadingViewAndTextWhileEditing:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithTrailingView {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers configureTextFieldWithTrailingViewAndText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithLeadingViewAndTrailingView {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithLeadingViewAndTrailingViewAndText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithVisibleClearButton {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithVisibleClearButtonAndText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testFloatingLabelWithCustomColorWhileEditing {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureWithColoredFloatingLabelTextAndTextWhileEditing:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testDisabledTextField {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureDisabledTextFieldWithLabelTextAndText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testEditingTextFieldWithVisiblePlaceholder {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureEditingTextFieldWithVisiblePlaceholderAndLabelText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithAssistiveLabelText {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithColoredAssistiveLabelText:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithAssistiveLabelTextWhileEditing {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithColoredAssistiveLabelTextWhileEditing:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithAssistiveLabelTextWhileDisabled {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+@end

--- a/components/TextFields/tests/unit/ContainedInputView/MDCOutlinedTextFieldTests.m
+++ b/components/TextFields/tests/unit/ContainedInputView/MDCOutlinedTextFieldTests.m
@@ -23,6 +23,20 @@
 
 #pragma mark Tests
 
+- (void)testOutlineColorDefaults {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);
+  MDCOutlinedTextField *textField = [[MDCOutlinedTextField alloc] initWithFrame:textFieldFrame];
+
+  // Then
+  XCTAssertEqualObjects([UIColor blackColor],
+                        [textField outlineColorForState:MDCTextControlStateNormal]);
+  XCTAssertEqualObjects([UIColor blackColor],
+                        [textField outlineColorForState:MDCTextControlStateEditing]);
+  XCTAssertEqualObjects([[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.60],
+                        [textField outlineColorForState:MDCTextControlStateDisabled]);
+}
+
 - (void)testOutlineColorAccessors {
   // Given
   CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);

--- a/components/TextFields/tests/unit/ContainedInputView/MDCOutlinedTextFieldTests.m
+++ b/components/TextFields/tests/unit/ContainedInputView/MDCOutlinedTextFieldTests.m
@@ -1,0 +1,47 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialTextFields+ContainedInputView.h"
+
+@interface MDCOutlinedTextFieldTests : XCTestCase
+@end
+
+@implementation MDCOutlinedTextFieldTests
+
+#pragma mark Tests
+
+- (void)testOutlineColorAccessors {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);
+  MDCOutlinedTextField *textField = [[MDCOutlinedTextField alloc] initWithFrame:textFieldFrame];
+  UIColor *outlineColorNormal = [UIColor blueColor];
+  UIColor *outlineColorEditing = [UIColor greenColor];
+  UIColor *outlineColorDisabled = [UIColor purpleColor];
+
+  // When
+  [textField setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [textField setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [textField setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  // Then
+  XCTAssertEqualObjects(outlineColorNormal,
+                        [textField outlineColorForState:MDCTextControlStateNormal]);
+  XCTAssertEqualObjects(outlineColorEditing,
+                        [textField outlineColorForState:MDCTextControlStateEditing]);
+  XCTAssertEqualObjects(outlineColorDisabled,
+                        [textField outlineColorForState:MDCTextControlStateDisabled]);
+}
+
+@end

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testDisabledTextField_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testDisabledTextField_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd1246419db9f438963e9dc566943505079fb404bf4f98052ad40a99c2e9c224
+size 5667

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testEditingTextFieldWithVisiblePlaceholder_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testEditingTextFieldWithVisiblePlaceholder_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e2a0a49876e14b66f6f251addbb60e016912c889b9324f2d687dd80b2a336c6
+size 7180

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testFloatingLabelWithCustomColorWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testFloatingLabelWithCustomColorWhileEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd3028b21dcb2e95561fb25407056766b23cc08e20adf2b37a1254db25546aaf
+size 6170

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileDisabled_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileDisabled_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a963f4bcabf1a077384e54a7c6f4fe6253ebb2d744106e471796f99ed809022d
+size 15143

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelTextWhileEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:846230dd042497cca4719ec3433d944149caf6b9c6142c96b57d86d2a9eea65a
+size 15515

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithAssistiveLabelText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c152b0558440316f611701d50581b3fef4526cd95259b4996034b7736b42861
+size 15309

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewAndTrailingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewAndTrailingView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0c62fcb73ceaa4b5498ac7995d2007d6da664eb045afc26f4ef27040e3d7842
+size 4798

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewWhileEditing_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingViewWhileEditing_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81af46aaa1e3d29bf0fca77dc77a4368014212dec388485c6b0c2919521a1e48
+size 4737

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithLeadingView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b00c46eaa3712c17678e258909fd6ae351b13d6b3d822bcff07c8ff839558ce5
+size 4613

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithText_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithText_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bddb7c908cf53ab656774bae82693e954221086d58cf8ebab64f61deba5e3a7
+size 4504

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithTrailingView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithTrailingView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8cf1c4071e9eb5f36ea9d9401227b7debce946dcdd341600390c11df4176352
+size 4586

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithVisibleClearButton_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithVisibleClearButton_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55f36f923761b7d9edaeb6096cde4ea4f73721934bcb6398ca174295c32fc8ca
+size 5017


### PR DESCRIPTION
This PR adds the outlined textfields. The snapshots look a little weird because the way the snapshot tests are currently implemented they only get an image that's as big as the frame of the view. In a follow up PR I'm going to change that, so the images will have the entire floating label (which goes above the top of the view) for example.

![textfield-example](https://user-images.githubusercontent.com/8020010/67978102-ba212280-fbef-11e9-8802-7a0b230f900a.gif)


Closes #6942.