### PR TITLE
[Slider] [ThumbTrack] Add Font API and Dynamic Type support

### DIFF
--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -38,7 +38,7 @@
      making the slider a snap to discrete values via @c numberOfDiscreteValues.
  */
 IB_DESIGNABLE
-@interface MDCSlider : UIControl <MDCElevatable, MDCElevationOverriding>
+@interface MDCSlider : UIControl <MDCElevatable, MDCElevationOverriding, UIContentSizeCategoryAdjusting>
 
 /** When @c YES, the forState: APIs are enabled. Defaults to @c NO. */
 @property(nonatomic, assign, getter=isStatefulAPIEnabled) BOOL statefulAPIEnabled;
@@ -366,6 +366,8 @@ IB_DESIGNABLE
  Defaults to @c NO
  */
 @property(nonatomic, assign) BOOL shouldEnableHapticsForAllDiscreteValues;
+
+@property(nonatomic, strong, null_resettable) UIFont *discreteValueLabelFont;
 
 @end
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -376,6 +376,7 @@ IB_DESIGNABLE
  @c YES.
 
  Defaults to [[MDCTypography fontLoader] regularFontOfSize:12].
+ Note: MDCTypography is planned for deprecation in the future and therefore this value may change.
  */
 @property(nonatomic, strong, null_resettable) UIFont *discreteValueLabelFont;
 

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -38,7 +38,8 @@
      making the slider a snap to discrete values via @c numberOfDiscreteValues.
  */
 IB_DESIGNABLE
-@interface MDCSlider : UIControl <MDCElevatable, MDCElevationOverriding, UIContentSizeCategoryAdjusting>
+@interface MDCSlider
+    : UIControl <MDCElevatable, MDCElevationOverriding, UIContentSizeCategoryAdjusting>
 
 /** When @c YES, the forState: APIs are enabled. Defaults to @c NO. */
 @property(nonatomic, assign, getter=isStatefulAPIEnabled) BOOL statefulAPIEnabled;

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -368,6 +368,14 @@ IB_DESIGNABLE
  */
 @property(nonatomic, assign) BOOL shouldEnableHapticsForAllDiscreteValues;
 
+/**
+ The font of the discrete value label.
+
+ This font will come into effect only when @c numberOfDiscreteValues is larger than 0 and when @c shouldDisplayDiscreteValueLabel is
+ @c YES.
+
+ Defaults to [[MDCTypography fontLoader] regularFontOfSize:12].
+ */
 @property(nonatomic, strong, null_resettable) UIFont *discreteValueLabelFont;
 
 @end

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -371,7 +371,8 @@ IB_DESIGNABLE
 /**
  The font of the discrete value label.
 
- This font will come into effect only when @c numberOfDiscreteValues is larger than 0 and when @c shouldDisplayDiscreteValueLabel is
+ This font will come into effect only when @c numberOfDiscreteValues is larger than 0 and when @c
+ shouldDisplayDiscreteValueLabel is
  @c YES.
 
  Defaults to [[MDCTypography fontLoader] regularFontOfSize:12].

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -408,6 +408,22 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   return _thumbTrack.valueLabelBackgroundColor;
 }
 
+- (void)setDiscreteValueLabelFont:(UIFont *)discreteValueLabelFont {
+  _thumbTrack.discreteValueLabelFont = discreteValueLabelFont;
+}
+
+- (UIFont *)discreteValueLabelFont {
+  return _thumbTrack.discreteValueLabelFont;
+}
+
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  _thumbTrack.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
+}
+
+- (BOOL)adjustsFontForContentSizeCategory {
+  return _thumbTrack.adjustsFontForContentSizeCategory;
+}
+
 #pragma mark - MDCThumbTrackDelegate methods
 
 - (NSString *)thumbTrack:(__unused MDCThumbTrack *)thumbTrack stringForValue:(CGFloat)value {

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -215,6 +215,11 @@
         [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
                                UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
     self.slider.traitCollectionOverride = aXXXLTraitCollection;
+    // In Thumbtrack's code, there is a check for verifying that the thumbtrack's width is larger
+    // than 1 point, otherwise it won't go into the main frame adjusting logic. This is to make sure
+    // that the scale transform of the slider's view isn't at its default of 0.001. Therefore this
+    // transform adjustment was made so it can let the logic know we are actually interacting with
+    // the thumb in the test.
     UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
     valueLabel.transform = CGAffineTransformIdentity;
     [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
@@ -247,6 +252,11 @@
     UITraitCollection *xsTraitCollection = [UITraitCollection
         traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
     self.slider.traitCollectionOverride = xsTraitCollection;
+    // In Thumbtrack's code, there is a check for verifying that the thumbtrack's width is larger
+    // than 1 point, otherwise it won't go into the main frame adjusting logic. This is to make sure
+    // that the scale transform of the slider's view isn't at its default of 0.001. Therefore this
+    // transform adjustment was made so it can let the logic know we are actually interacting with
+    // the thumb in the test.
     UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
     valueLabel.transform = CGAffineTransformIdentity;
     [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -201,6 +201,10 @@
     self.slider.value =
         self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
     self.slider.shouldDisplayDiscreteValueLabel = YES;
+    UIFontMetrics *bodyMetrics = [UIFontMetrics metricsForTextStyle:UIFontTextStyleBody];
+    UIFont *originalFont = [bodyMetrics scaledFontForFont:[UIFont fontWithName:@"Zapfino" size:12]];
+    self.slider.discreteValueLabelFont = originalFont;
+    self.slider.adjustsFontForContentSizeCategory = YES;
     UITraitCollection *xsTraitCollection = [UITraitCollection
         traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
     self.slider.traitCollectionOverride = xsTraitCollection;
@@ -211,11 +215,13 @@
         [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
                                UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
     self.slider.traitCollectionOverride = aXXXLTraitCollection;
+    UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
+    valueLabel.transform = CGAffineTransformIdentity;
     [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
 
     // Then
     UIView *snapshotView =
-        [self.slider mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(30, 0, 0, 0)];
+        [self.slider mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(100, 0, 0, 0)];
     [self generateSnapshotAndVerifyForView:snapshotView];
   }
 }
@@ -227,6 +233,10 @@
     self.slider.value =
         self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
     self.slider.shouldDisplayDiscreteValueLabel = YES;
+    UIFontMetrics *bodyMetrics = [UIFontMetrics metricsForTextStyle:UIFontTextStyleBody];
+    UIFont *originalFont = [bodyMetrics scaledFontForFont:[UIFont fontWithName:@"Zapfino" size:12]];
+    self.slider.discreteValueLabelFont = originalFont;
+    self.slider.adjustsFontForContentSizeCategory = YES;
     UITraitCollection *aXXXLTraitCollection =
         [UITraitCollection traitCollectionWithPreferredContentSizeCategory:
                                UIContentSizeCategoryAccessibilityExtraExtraExtraLarge];
@@ -237,6 +247,8 @@
     UITraitCollection *xsTraitCollection = [UITraitCollection
         traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryExtraSmall];
     self.slider.traitCollectionOverride = xsTraitCollection;
+    UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
+    valueLabel.transform = CGAffineTransformIdentity;
     [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
 
     // Then

--- a/components/Slider/tests/unit/SliderTests.m
+++ b/components/Slider/tests/unit/SliderTests.m
@@ -18,6 +18,7 @@
 #import "MaterialPalettes.h"
 #import "MaterialSlider.h"
 #import "MaterialThumbTrack.h"
+#import "MaterialTypography.h"
 #import "MockUIImpactFeedbackGenerator.h"
 
 static const int kNumberOfRepeats = 20;
@@ -1378,6 +1379,24 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
   // Then
   XCTAssertFalse(blockCalled);
+}
+
+- (void)testDiscreteValueLabelFontDefaultValue {
+  // Then
+  XCTAssertEqualObjects(self.slider.discreteValueLabelFont,
+                        [[MDCTypography fontLoader] regularFontOfSize:12]);
+}
+
+- (void)testDiscreteValueLabelFontSettingToNilValue {
+  // Given
+  self.slider.discreteValueLabelFont = [UIFont systemFontOfSize:20];
+
+  // When
+  self.slider.discreteValueLabelFont = nil;
+
+  // Then
+  XCTAssertEqualObjects(self.slider.discreteValueLabelFont,
+                        [[MDCTypography fontLoader] regularFontOfSize:12]);
 }
 
 #pragma mark Private test helpers

--- a/components/private/ThumbTrack/src/MDCNumericValueLabel.h
+++ b/components/private/ThumbTrack/src/MDCNumericValueLabel.h
@@ -17,10 +17,10 @@
 @interface MDCNumericValueLabel : UIView <UIContentSizeCategoryAdjusting>
 
 /** The background color of the value label. */
-@property(nonatomic, retain, nonnull) UIColor *backgroundColor;
+@property(nonatomic, strong, nonnull) UIColor *backgroundColor;
 
 /** The text color of the label. */
-@property(nonatomic, retain, null_resettable) UIColor *textColor;
+@property(nonatomic, strong, null_resettable) UIColor *textColor;
 
 /**
  The size of the value label.

--- a/components/private/ThumbTrack/src/MDCNumericValueLabel.h
+++ b/components/private/ThumbTrack/src/MDCNumericValueLabel.h
@@ -20,7 +20,7 @@
 @property(nonatomic, retain, nonnull) UIColor *backgroundColor;
 
 /** The text color of the label. */
-@property(nonatomic, retain, nonnull) UIColor *textColor;
+@property(nonatomic, retain, null_resettable) UIColor *textColor;
 
 /**
  The size of the value label.
@@ -30,7 +30,7 @@
 @property(nonatomic) CGFloat fontSize __deprecated_msg("Please use the font property instead.");
 
 /** The text to be displayed in the value label. */
-@property(nonatomic, copy, nonnull) NSString *text;
+@property(nonatomic, copy, nullable) NSString *text;
 
 /** The font of the value label. */
 @property(nonatomic, strong, null_resettable) UIFont *font;

--- a/components/private/ThumbTrack/src/MDCNumericValueLabel.h
+++ b/components/private/ThumbTrack/src/MDCNumericValueLabel.h
@@ -22,12 +22,17 @@
 /** The text color of the label. */
 @property(nonatomic, retain, nonnull) UIColor *textColor;
 
-/** The size of the value label. */
-@property(nonatomic) CGFloat fontSize __deprecated_msg("Use the font property instead.");
+/**
+ The size of the value label.
+
+ @note This property is deprecated and will be removed in an upcoming release.
+ */
+@property(nonatomic) CGFloat fontSize __deprecated_msg("Please use the font property instead.");
 
 /** The text to be displayed in the value label. */
 @property(nonatomic, copy, nonnull) NSString *text;
 
+/** The font of the value label. */
 @property(nonatomic, strong, null_resettable) UIFont *font;
 
 @end

--- a/components/private/ThumbTrack/src/MDCNumericValueLabel.h
+++ b/components/private/ThumbTrack/src/MDCNumericValueLabel.h
@@ -14,18 +14,20 @@
 
 #import <UIKit/UIKit.h>
 
-@interface MDCNumericValueLabel : UIView
+@interface MDCNumericValueLabel : UIView <UIContentSizeCategoryAdjusting>
 
 /** The background color of the value label. */
-@property(nonatomic, retain) UIColor *backgroundColor;
+@property(nonatomic, retain, nonnull) UIColor *backgroundColor;
 
 /** The text color of the label. */
-@property(nonatomic, retain) UIColor *textColor;
+@property(nonatomic, retain, nonnull) UIColor *textColor;
 
 /** The size of the value label. */
-@property(nonatomic) CGFloat fontSize;
+@property(nonatomic) CGFloat fontSize __deprecated_msg("Use the font property instead.");
 
 /** The text to be displayed in the value label. */
-@property(nonatomic, copy) NSString *text;
+@property(nonatomic, copy, nonnull) NSString *text;
+
+@property(nonatomic, strong, null_resettable) UIFont *font;
 
 @end

--- a/components/private/ThumbTrack/src/MDCNumericValueLabel.m
+++ b/components/private/ThumbTrack/src/MDCNumericValueLabel.m
@@ -41,7 +41,6 @@ static const CGFloat kLabelInsetSize = 6;
     _label = [[UILabel alloc] init];
     _label.textAlignment = NSTextAlignmentCenter;
     _label.textColor = [UIColor whiteColor];  // Default text color, override by setting textColor
-    _label.font = [MDCTypography body1Font];  // Default font size, override by setting fontSize
     _label.adjustsFontSizeToFitWidth = YES;
     _label.minimumScaleFactor = (CGFloat)0.7;
     [self addSubview:_label];
@@ -113,6 +112,11 @@ static const CGFloat kLabelInsetSize = 6;
   _label.frame = CGRectInset(CGRectMake(0, 0, width, width), kLabelInsetSize, kLabelInsetSize);
 }
 
+- (CGSize)sizeThatFits:(CGSize)size {
+  CGSize labelSize = [_label sizeThatFits:size];
+  return CGSizeMake(labelSize.width + kLabelInsetSize, labelSize.height + kLabelInsetSize);
+}
+
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
   _backgroundColor = backgroundColor;
   _marker.fillColor = _backgroundColor.CGColor;
@@ -140,6 +144,22 @@ static const CGFloat kLabelInsetSize = 6;
 
 - (void)setText:(NSString *)text {
   _label.text = text;
+}
+
+- (UIFont *)font {
+  return _label.font;
+}
+
+- (void)setFont:(UIFont *)font {
+  _label.font = font;
+}
+
+- (BOOL)adjustsFontForContentSizeCategory {
+  return _label.adjustsFontForContentSizeCategory;
+}
+
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  _label.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory;
 }
 
 @end

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -229,7 +229,8 @@
 /**
  The font of the discrete value label.
 
- This font will come into effect only when @c numDiscreteValues is larger than 0 and when @c shouldDisplayDiscreteValueLabel is
+ This font will come into effect only when @c numDiscreteValues is larger than 0 and when @c
+ shouldDisplayDiscreteValueLabel is
  @c YES.
 
  Defaults to [[MDCTypography fontLoader] regularFontOfSize:12].

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -226,6 +226,14 @@
  */
 @property(nonatomic, assign) BOOL tapsAllowedOnThumb;
 
+/**
+ The font of the discrete value label.
+
+ This font will come into effect only when @c numDiscreteValues is larger than 0 and when @c shouldDisplayDiscreteValueLabel is
+ @c YES.
+
+ Defaults to [[MDCTypography fontLoader] regularFontOfSize:12].
+ */
 @property(nonatomic, strong, null_resettable) UIFont *discreteValueLabelFont;
 
 /**

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -19,7 +19,7 @@
 @class MDCThumbView;
 @protocol MDCThumbTrackDelegate;
 
-@interface MDCThumbTrack : UIControl
+@interface MDCThumbTrack : UIControl <UIContentSizeCategoryAdjusting>
 
 /** The delegate for the thumb track. */
 @property(nullable, nonatomic, weak) id<MDCThumbTrackDelegate> delegate;
@@ -225,6 +225,8 @@
  The default value of this property is NO.
  */
 @property(nonatomic, assign) BOOL tapsAllowedOnThumb;
+
+@property(nonatomic, strong, null_resettable) UIFont *discreteValueLabelFont;
 
 /**
  Initialize an instance with a particular frame and color group.

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -843,9 +843,11 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
       _valueLabel.text = [_delegate thumbTrack:self stringForValue:_value];
       if (CGRectGetWidth(_valueLabel.frame) > 1) {
         CGFloat scale = UIScreen.mainScreen.scale;
-        _valueLabelHeight = MAX(kValueLabelHeight, MDCCeil(_valueLabel.font.lineHeight * scale) / scale);
-        CGFloat valueLabelWidth = MAX((CGFloat)0.81 * _valueLabelHeight,
-                                      [_valueLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, _valueLabelHeight)].height);
+        _valueLabelHeight =
+            MAX(kValueLabelHeight, MDCCeil(_valueLabel.font.lineHeight * scale) / scale);
+        CGFloat valueLabelWidth =
+            MAX((CGFloat)0.81 * _valueLabelHeight,
+                [_valueLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, _valueLabelHeight)].height);
         // Reset the size prior to pixel alignement since previous alignement likely increased it
         CGRect valueLabelFrame = CGRectMake(_valueLabel.frame.origin.x, _valueLabel.frame.origin.y,
                                             valueLabelWidth, _valueLabelHeight);

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -842,7 +842,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
     if ([_delegate respondsToSelector:@selector(thumbTrack:stringForValue:)]) {
       _valueLabel.text = [_delegate thumbTrack:self stringForValue:_value];
       if (CGRectGetWidth(_valueLabel.frame) > 1) {
-        CGFloat scale = UIScreen.mainScreen.scale;
+        CGFloat scale = self.window.screen.scale > 0 ?: UIScreen.mainScreen.scale;
         _valueLabelHeight =
             MAX(kValueLabelHeight, MDCCeil(_valueLabel.font.lineHeight * scale) / scale);
         CGFloat valueLabelWidth =

--- a/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
+++ b/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
@@ -15,6 +15,7 @@
 #import <XCTest/XCTest.h>
 #import "../../src/private/MDCThumbTrack+Private.h"
 #import "MaterialThumbTrack.h"
+#import "MaterialTypography.h"
 
 @interface ThumbTrackTests : XCTestCase
 
@@ -359,6 +360,28 @@
 
   // Then
   XCTAssertEqualObjects(thumbTrack.numericValueLabel.backgroundColor, UIColor.cyanColor);
+}
+
+- (void)testDiscreteValueLabelFontDefaultValue {
+  // Given
+  MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
+
+  // Then
+  XCTAssertEqualObjects(thumbTrack.discreteValueLabelFont,
+                        [[MDCTypography fontLoader] regularFontOfSize:12]);
+}
+
+- (void)testDiscreteValueLabelFontSettingToNilValue {
+  // Given
+  MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
+  thumbTrack.discreteValueLabelFont = [UIFont systemFontOfSize:20];
+
+  // When
+  thumbTrack.discreteValueLabelFont = nil;
+
+  // Then
+  XCTAssertEqualObjects(thumbTrack.discreteValueLabelFont,
+                        [[MDCTypography fontLoader] regularFontOfSize:12]);
 }
 
 @end

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForAXXXLContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8485d495e26e3583c896d6a00254c5670959bba201dbe294213a805fd5d7bd7e
-size 4541
+oid sha256:cfa64054b7ef8ace1cc5a547b281f2f94f5ac0704ef11ce6bf034627d1e51407
+size 10862

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testPreferredFontForXSContentSizeCategory_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8485d495e26e3583c896d6a00254c5670959bba201dbe294213a805fd5d7bd7e
-size 4541
+oid sha256:6e7a990418704be35521fe0df350a1470ba54cc355dcb62c0cf332408bed255a
+size 4894


### PR DESCRIPTION
In this PR the main goal is to add Dynamic Type support. As part of this support I am doing the following:

1. Adding a Font API to ThumbTrack and Slider to be able to set the font of the discrete label to a scalable font.
2. Deprecating the old fontSize API (which isn't used internally).
3. Adding adjustsFontForContentSizeCategory APIs to Slider and ThumbTrack.
4. Resizing the ThumbTrack view accordingly based on the font size instead of having it static.

The snapshot tests in place allow me to present the new support for dynamic type and custom fonts.

Closes #8646 