### PR TITLE
[FlexibleHeader] Expose an animation delegate on MDCFlexibleHeaderView.

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -19,6 +19,7 @@ load(
     "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
+    "mdc_snapshot_swift_library",
     "mdc_snapshot_test",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
@@ -128,7 +129,17 @@ mdc_snapshot_objc_library(
     ],
 )
 
+mdc_snapshot_swift_library(
+    name = "snapshot_test_lib_swift",
+    deps = [
+        ":FlexibleHeader",
+    ],
+)
+
 mdc_snapshot_test(
     name = "snapshot_tests",
-    deps = [":snapshot_test_lib"],
+    deps = [
+        ":snapshot_test_lib",
+        ":snapshot_test_lib_swift",
+    ],
 )

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, MDCFlexibleHeaderScrollPhase) {
   MDCFlexibleHeaderScrollPhaseOverExtending,
 };
 
+@protocol MDCFlexibleHeaderViewAnimationDelegate;
 @protocol MDCFlexibleHeaderViewDelegate;
 
 /**
@@ -376,10 +377,13 @@ IB_DESIGNABLE
     BOOL disableContentInsetAdjustmentWhenContentInsetAdjustmentBehaviorIsNever API_AVAILABLE(
         ios(11.0), tvos(11.0));
 
-#pragma mark Header View Delegate
+#pragma mark Delegation
 
 /** The delegate for this header view. */
 @property(nonatomic, weak, nullable) id<MDCFlexibleHeaderViewDelegate> delegate;
+
+/** The animation delegate will be notified of any animations to the flexible header view. */
+@property(nonatomic, weak, nullable) id<MDCFlexibleHeaderViewAnimationDelegate> animationDelegate;
 
 /**
  A block that is invoked when the FlexibleHeaderView receives a call to @c
@@ -419,6 +423,22 @@ IB_DESIGNABLE
  is in.
  */
 - (void)flexibleHeaderViewFrameDidChange:(nonnull MDCFlexibleHeaderView *)headerView;
+
+@end
+
+/**
+ An object may conform to this protocol in order to receive animation events caused by a
+ MDCFlexibleHeaderView.
+ */
+@protocol MDCFlexibleHeaderViewAnimationDelegate <NSObject>
+@required
+
+/**
+ Informs the receiver that the flexible header view's animation changing to a new tracking scroll
+ view has completed.
+ */
+- (void)flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:
+    (nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
 
 @end
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -436,6 +436,8 @@ IB_DESIGNABLE
 /**
  Informs the receiver that the flexible header view's animation changing to a new tracking scroll
  view has completed.
+
+ Only invoked if an animation occurred when the tracking scroll view was changed.
  */
 - (void)flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:
     (nonnull MDCFlexibleHeaderView *)flexibleHeaderView;

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1570,7 +1570,10 @@ static BOOL isRunningiOS10_3OrAbove() {
   if (wasTrackingScrollView && shouldAnimate) {
     [UIView animateWithDuration:kTrackingScrollViewDidChangeAnimationDuration
                      animations:animate
-                     completion:completion];
+                     completion:^(BOOL finished) {
+      [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+      completion(finished);
+    }];
   } else {
     animate();
     completion(YES);

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1571,9 +1571,10 @@ static BOOL isRunningiOS10_3OrAbove() {
     [UIView animateWithDuration:kTrackingScrollViewDidChangeAnimationDuration
                      animations:animate
                      completion:^(BOOL finished) {
-      [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
-      completion(finished);
-    }];
+                       [self.animationDelegate
+                           flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+                       completion(finished);
+                     }];
   } else {
     animate();
     completion(YES);

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
@@ -1,0 +1,97 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+
+private class MockMDCFlexibleHeaderViewAnimationDelegate: NSObject, MDCFlexibleHeaderViewAnimationDelegate {
+  var didCompleteExpectation: XCTestExpectation
+  init(didCompleteExpectation: XCTestExpectation) {
+    self.didCompleteExpectation = didCompleteExpectation
+
+    super.init()
+  }
+
+  func flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete(_ flexibleHeaderView: MDCFlexibleHeaderView) {
+    didCompleteExpectation.fulfill()
+  }
+}
+
+class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
+
+  func testCompletionCallbackIsNotInvokedWhenSettingTheInitialTrackingScrollView() {
+    // Given
+    let window = UIWindow()
+    let fhv = MDCFlexibleHeaderView()
+    fhv.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhv.minMaxHeightIncludesSafeArea = false
+    fhv.sharedWithManyScrollViews = true
+    fhv.maximumHeight = 200
+    let scrollView = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhv.frame.width, height: 1000)
+    scrollView.contentSize = largeScrollableArea
+    // Fully expanded.
+    scrollView.contentOffset = CGPoint(x: 0, y: -200)
+    window.addSubview(fhv)
+    window.makeKeyAndVisible()
+    window.layer.speed = 100000
+    CATransaction.flush()
+
+    let mockDelegate = MockMDCFlexibleHeaderViewAnimationDelegate(didCompleteExpectation:
+        expectation(description: "didComplete"))
+    fhv.animationDelegate = mockDelegate
+
+    // When
+    fhv.trackingScrollView = scrollView
+
+    // Then
+    let waiter = XCTWaiter()
+    let result = waiter.wait(for: [mockDelegate.didCompleteExpectation], timeout: 0.01)
+    XCTAssertEqual(result, .timedOut)
+  }
+
+  func testCompletionCallbackIsInvokedWhenTheTrackingScrollViewIsChanged() {
+    // Given
+    let window = UIWindow()
+    let fhv = MDCFlexibleHeaderView()
+    fhv.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhv.minMaxHeightIncludesSafeArea = false
+    fhv.sharedWithManyScrollViews = true
+    fhv.maximumHeight = 200
+    let scrollView1 = UIScrollView()
+    let scrollView2 = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhv.frame.width, height: 1000)
+    scrollView1.contentSize = largeScrollableArea
+    scrollView2.contentSize = largeScrollableArea
+    // Fully expanded.
+    scrollView1.contentOffset = CGPoint(x: 0, y: -200)
+    // Fully collapsed.
+    scrollView2.contentOffset = CGPoint(x: 0, y: 300)
+    window.addSubview(fhv)
+    window.makeKeyAndVisible()
+    window.layer.speed = 100000
+    CATransaction.flush()
+
+    let mockDelegate = MockMDCFlexibleHeaderViewAnimationDelegate(didCompleteExpectation:
+        expectation(description: "didComplete"))
+    fhv.animationDelegate = mockDelegate
+
+    // When
+    fhv.trackingScrollView = scrollView1
+    fhv.trackingScrollView = scrollView2
+
+    // Then
+    wait(for: [mockDelegate.didCompleteExpectation], timeout: 0.1)
+  }
+}


### PR DESCRIPTION
This delegate allows clients to react to animations of the flexible header's height when switching tabs.

Part of https://github.com/material-components/material-components-ios/issues/8644