### PR TITLE
[FlexibleHeader] Add behavioral flag for animating shadow layer frames when tracking scroll view is changed

### DIFF
--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -133,6 +133,7 @@ mdc_snapshot_swift_library(
     name = "snapshot_test_lib_swift",
     deps = [
         ":FlexibleHeader",
+        "//components/ShadowLayer",
     ],
 )
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -368,6 +368,18 @@ IB_DESIGNABLE
 @property(nonatomic) BOOL sharedWithManyScrollViews;
 
 /**
+ Whether to allow shadow frame animations when animating changes to the tracking scroll view.
+
+ Enabling this property allows layoutSubviews to animate the shadow frames as part of the animation
+ that occurs when changing tracking scroll views.
+
+ This property will eventually be enabled by default and then deleted.
+
+ Default is NO.
+ */
+@property(nonatomic, assign) BOOL allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView;
+
+/**
  If enabled, the trackingScrollView doesn't adjust the content inset when its
  contentInsetAdjustmentBehavior is set to be UIScrollViewContentInsetAdjustmentNever.
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -191,6 +191,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   // The block executed when shadow intensity changes.
   MDCFlexibleHeaderShadowIntensityChangeBlock _shadowIntensityChangeBlock;
 
+  // Whether the flexible header is currently within an animate block for changing the tracking
+  // scroll view.
+  BOOL _isAnimatingTrackingScrollViewChange;
+
   Class _wkWebViewClass;
 
 #if DEBUG
@@ -385,8 +389,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   [self fhv_updateShadowColor];
   [self fhv_updateShadowPath];
+
   [CATransaction begin];
-  [CATransaction setDisableActions:YES];
+  BOOL allowCAActions = _isAnimatingTrackingScrollViewChange;
+  [CATransaction setDisableActions:!allowCAActions];
   _defaultShadowLayer.frame = self.bounds;
   _customShadowLayer.frame = self.bounds;
   _shadowLayer.frame = self.bounds;
@@ -1554,9 +1560,37 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   }
 
-  void (^animate)(void) = ^{
-    [self fhv_updateLayout];
-  };
+  CFTimeInterval duration = kTrackingScrollViewDidChangeAnimationDuration;
+  CAMediaTimingFunction *timingFunction =
+      [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+
+  void (^animate)(void);
+  if (self.allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView) {
+    animate = ^{
+      self->_isAnimatingTrackingScrollViewChange = YES;
+
+      [CATransaction begin];
+#if TARGET_IPHONE_SIMULATOR
+      [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
+#else
+      [CATransaction setAnimationDuration:duration];
+#endif
+      [CATransaction setAnimationTimingFunction:timingFunction];
+
+      [self fhv_updateLayout];
+
+      // Force any layout changes to be committed during this animation block.
+      [self layoutIfNeeded];
+
+      [CATransaction commit];
+
+      self->_isAnimatingTrackingScrollViewChange = NO;
+    };
+  } else {
+    animate = ^{
+      [self fhv_updateLayout];
+    };
+  }
   void (^completion)(BOOL) = ^(BOOL finished) {
     if (!finished) {
       return;
@@ -1568,7 +1602,7 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   };
   if (wasTrackingScrollView && shouldAnimate) {
-    [UIView animateWithDuration:kTrackingScrollViewDidChangeAnimationDuration
+    [UIView animateWithDuration:duration
                      animations:animate
                      completion:^(BOOL finished) {
                        [self.animationDelegate

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -1,0 +1,81 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialShadowLayer
+
+class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
+
+  func testFromExpandedToCollapsedStateAnimatesShadowPath() throws {
+    // Given
+    let window = UIWindow()
+    let fhvc = MDCFlexibleHeaderViewController()
+    let shadowLayer = MDCShadowLayer()
+    fhvc.headerView.setShadowLayer(shadowLayer) { layer, elevation in
+      guard let shadowLayer = layer as? MDCShadowLayer else {
+        return
+      }
+      shadowLayer.elevation = .init(4 * elevation)
+    }
+    fhvc.headerView.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhvc.headerView.minMaxHeightIncludesSafeArea = false
+    fhvc.headerView.sharedWithManyScrollViews = true
+    fhvc.headerView.maximumHeight = 200
+    let scrollView1 = UIScrollView()
+    let scrollView2 = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhvc.headerView.frame.width, height: 1000)
+    scrollView1.contentSize = largeScrollableArea
+    scrollView2.contentSize = largeScrollableArea
+    // Fully expanded.
+    scrollView1.contentOffset = CGPoint(x: 0, y: -200)
+    // Fully collapsed.
+    scrollView2.contentOffset = CGPoint(x: 0, y: 300)
+    // Initially fully expanded.
+    fhvc.headerView.trackingScrollView = scrollView1
+    window.rootViewController = fhvc
+    window.makeKeyAndVisible()
+    CATransaction.flush()
+
+    // When
+    // And then collapsed.
+    fhvc.headerView.trackingScrollView = scrollView2
+
+    // Then
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.size"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.origin"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "position"))
+
+    guard let animationDuration =
+        fhvc.headerView.layer.animation(forKey: "bounds.size")?.duration else {
+      XCTFail("Missing bounds.size animation")
+      return
+    }
+
+    guard let sublayers = shadowLayer.sublayers else {
+      XCTFail("Missing sublayers.")
+      return
+    }
+    XCTAssertGreaterThan(sublayers.count, 0)
+
+    for sublayer in sublayers {
+      guard let animation = sublayer.animation(forKey: "shadowPath") else {
+        XCTFail("Missing shadowPath animation.")
+        return
+      }
+      XCTAssertNotNil(animation)
+      XCTAssertEqual(animation.duration, animationDuration, accuracy: 0.001)
+    }
+  }
+}

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -71,7 +71,7 @@ class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
 
     for sublayer in sublayers {
       guard let animation = sublayer.animation(forKey: "shadowPath") else {
-        XCTFail("Missing shadowPath animation.")
+        XCTFail("Missing shadowPath animation. \(sublayer)")
         return
       }
       XCTAssertNotNil(animation)

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderTrackingScrollViewDidChangeTests.swift
@@ -33,6 +33,7 @@ class FlexibleHeaderTrackingScrollViewDidChangeTests: XCTestCase {
     fhvc.headerView.minMaxHeightIncludesSafeArea = false
     fhvc.headerView.sharedWithManyScrollViews = true
     fhvc.headerView.maximumHeight = 200
+    fhvc.headerView.allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView = true
     let scrollView1 = UIScrollView()
     let scrollView2 = UIScrollView()
     let largeScrollableArea = CGSize(width: fhvc.headerView.frame.width, height: 1000)


### PR DESCRIPTION
This is a roll-forward of https://github.com/material-components/material-components-ios/pull/8679.

This PR introduces a new behavioral flag that, if enabled, allows the flexible header to implicitly animate the frames of its shadow layers during layoutSubviews.

Part of https://github.com/material-components/material-components-ios/issues/8644