### PR TITLE
[TextFields] Fix minor animation glitch when opening example

### DIFF
--- a/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
+++ b/components/TextFields/src/ContainedInputView/MDCBaseTextField.m
@@ -110,7 +110,7 @@
 }
 
 - (void)setUpLabel {
-  self.label = [[UILabel alloc] initWithFrame:self.bounds];
+  self.label = [[UILabel alloc] init];
   [self addSubview:self.label];
 }
 

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
@@ -49,9 +49,9 @@
   CGAffineTransform transformNeededToMakeViewWithCurrentFrameLookLikeItHasTargetFrame =
       [self transformFromRect:currentFrame toRect:targetFrame];
 
-  BOOL didChangeFrame = !CGRectEqualToRect(currentFrame, targetFrame);
+  BOOL willChangeFrame = !CGRectEqualToRect(currentFrame, targetFrame);
   BOOL currentFrameIsCGRectZero = CGRectEqualToRect(currentFrame, CGRectZero);
-  BOOL isNormalTransition = didChangeFrame && !currentFrameIsCGRectZero;
+  BOOL isNormalTransition = willChangeFrame && !currentFrameIsCGRectZero;
   BOOL nonZeroDuration = animationDuration > 0;
   BOOL shouldPerformAnimation = nonZeroDuration && isNormalTransition;
 

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlLabelAnimation.m
@@ -49,6 +49,12 @@
   CGAffineTransform transformNeededToMakeViewWithCurrentFrameLookLikeItHasTargetFrame =
       [self transformFromRect:currentFrame toRect:targetFrame];
 
+  BOOL didChangeFrame = !CGRectEqualToRect(currentFrame, targetFrame);
+  BOOL currentFrameIsCGRectZero = CGRectEqualToRect(currentFrame, CGRectZero);
+  BOOL isNormalTransition = didChangeFrame && !currentFrameIsCGRectZero;
+  BOOL nonZeroDuration = animationDuration > 0;
+  BOOL shouldPerformAnimation = nonZeroDuration && isNormalTransition;
+
   void (^completionBlock)(BOOL finished) = ^void(BOOL finished) {
     label.transform = CGAffineTransformIdentity;
     label.frame = targetFrame;
@@ -58,7 +64,6 @@
     }
   };
 
-  BOOL shouldPerformAnimation = animationDuration > 0;
   if (shouldPerformAnimation) {
     dispatch_async(dispatch_get_main_queue(), ^{
       CAMediaTimingFunction *timingFunction =

--- a/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
+++ b/components/TextFields/src/ContainedInputView/private/MDCTextControlStyleFilled.m
@@ -153,9 +153,10 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                    state:(MDCTextControlState)state
           containerFrame:(CGRect)containerFrame
        animationDuration:(NSTimeInterval)animationDuration {
-  BOOL aBoundsChangeHasTakenPlace = NO;
+  BOOL didChangeBounds = NO;
   if (!CGRectEqualToRect(self.mostRecentBounds, view.bounds)) {
-    aBoundsChangeHasTakenPlace = YES;
+    didChangeBounds = YES;
+    self.mostRecentBounds = view.bounds;
   }
 
   self.filledSublayer.fillColor = [self.filledBackgroundColors[@(state)] CGColor];
@@ -167,8 +168,8 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                                                                    containerHeight:containerHeight];
   self.filledSublayer.path = filledSublayerBezier.CGPath;
 
-  BOOL isNotYetInTextControlLayerHierarchy = self.filledSublayer.superlayer != view.layer;
-  if (isNotYetInTextControlLayerHierarchy) {
+  BOOL styleIsNotAppliedToView = self.filledSublayer.superlayer != view.layer;
+  if (styleIsNotAppliedToView) {
     [view.layer insertSublayer:self.filledSublayer atIndex:0];
   }
 
@@ -188,7 +189,7 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
                                    underlineThickness:thinUnderlineThickness
                                        underlineWidth:viewWidth];
 
-  if (animationDuration <= 0 || isNotYetInTextControlLayerHierarchy || aBoundsChangeHasTakenPlace) {
+  if (animationDuration <= 0 || styleIsNotAppliedToView || didChangeBounds) {
     self.thinUnderlineLayer.path = targetThinUnderlineBezier.CGPath;
     self.thickUnderlineLayer.path = targetThickUnderlineBezier.CGPath;
     return;


### PR DESCRIPTION
This PR fixes a minor bug that would occur when opening the example with the textfields.

I attached some before and after videos but the effect is actually subtle enough that mov2gif doesn't really capture it haha :/

Before:
![bug](https://user-images.githubusercontent.com/8020010/68038712-f52f5e80-fca0-11e9-8510-85c5964751ee.gif)

After:
![fixed](https://user-images.githubusercontent.com/8020010/68038711-f52f5e80-fca0-11e9-90ff-f0d3e149ae6e.gif)

Related to #6942.