### PR TITLE
[ActionSheet] Fix crash in example

### DIFF
--- a/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExampleViewController.m
@@ -126,7 +126,10 @@
                                                         style:UIAlertActionStyleDefault
                                                       handler:nil];
   [alertController addAction:emailAction];
-
+  if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    alertController.modalPresentationStyle = UIModalPresentationPopover;
+    alertController.popoverPresentationController.sourceView = self.showUIKitButton;
+  }
   [self presentViewController:alertController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
Currently the "Material : UIKit comparison" example crashes if open on iPad. This change updates it so that the UIKit ActionSheet is then a popover on iPad.

Closes #8730 