### PR TITLE
[FlexibleHeader] Add an animateWithAnimations:completion: API.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -170,6 +170,24 @@ IB_DESIGNABLE
  */
 - (void)changeContentInsets:(nonnull MDCFlexibleHeaderChangeContentInsetsBlock)block;
 
+#pragma mark - Animating changes to the header
+
+/**
+ Animates any changes resulting from executing the animations block.
+
+ Use this method to animate changes alongside animations to the flexible header.
+
+ The following occurs when this method is invoked:
+
+ 1. The provided `animations` block is invoked within a `[UIView animate...:]` block.
+ 2. Within that same animation block and after invoking `animations`, the flexible header updates
+    any relevant aspects of its layout including its height, offset, and shadow layer frames.
+ 3. Upon completion of the resulting animation, the provided completion block is invoked if one was
+    provided.
+ */
+- (void)animateWithAnimations:(void (^_Nonnull)(void))animations
+                   completion:(void (^_Nullable)(BOOL))completion;
+
 #pragma mark Forwarding Touch Events
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -173,14 +173,14 @@ IB_DESIGNABLE
 #pragma mark - Animating changes to the header
 
 /**
- Animates any changes resulting from executing the animations block.
+ Animates any changes resulting from executing the @c animations block.
 
  Use this method to animate changes alongside animations to the flexible header.
 
  The following occurs when this method is invoked:
 
- 1. The provided `animations` block is invoked within a `[UIView animate...:]` block.
- 2. Within that same animation block and after invoking `animations`, the flexible header updates
+ 1. The provided @c animations block is invoked within a @code [UIView animate...:] @endcode block.
+ 2. Within that same animation block and after invoking @c animations, the flexible header updates
     any relevant aspects of its layout including its height, offset, and shadow layer frames.
  3. Upon completion of the resulting animation, the provided completion block is invoked if one was
     provided.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -193,7 +193,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
   // Whether the flexible header is currently within an animate block for changing the tracking
   // scroll view.
-  BOOL _isAnimatingTrackingScrollViewChange;
+  BOOL _isAnimatingLayoutUpdate;
 
   Class _wkWebViewClass;
 
@@ -391,7 +391,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   [self fhv_updateShadowPath];
 
   [CATransaction begin];
-  BOOL allowCAActions = _isAnimatingTrackingScrollViewChange;
+  BOOL allowCAActions = _isAnimatingLayoutUpdate;
   [CATransaction setDisableActions:!allowCAActions];
   _defaultShadowLayer.frame = self.bounds;
   _customShadowLayer.frame = self.bounds;
@@ -1560,37 +1560,9 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   }
 
-  CFTimeInterval duration = kTrackingScrollViewDidChangeAnimationDuration;
-  CAMediaTimingFunction *timingFunction =
-      [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
-
-  void (^animate)(void);
-  if (self.allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView) {
-    animate = ^{
-      self->_isAnimatingTrackingScrollViewChange = YES;
-
-      [CATransaction begin];
-#if TARGET_IPHONE_SIMULATOR
-      [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
-#else
-      [CATransaction setAnimationDuration:duration];
-#endif
-      [CATransaction setAnimationTimingFunction:timingFunction];
-
-      [self fhv_updateLayout];
-
-      // Force any layout changes to be committed during this animation block.
-      [self layoutIfNeeded];
-
-      [CATransaction commit];
-
-      self->_isAnimatingTrackingScrollViewChange = NO;
-    };
-  } else {
-    animate = ^{
-      [self fhv_updateLayout];
-    };
-  }
+  void (^animations)(void) = ^{
+    [self fhv_updateLayout];
+  };
   void (^completion)(BOOL) = ^(BOOL finished) {
     if (!finished) {
       return;
@@ -1601,16 +1573,21 @@ static BOOL isRunningiOS10_3OrAbove() {
       [self fhv_accumulatorDidChange];
     }
   };
+
   if (wasTrackingScrollView && shouldAnimate) {
-    [UIView animateWithDuration:duration
-                     animations:animate
-                     completion:^(BOOL finished) {
-                       [self.animationDelegate
-                           flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
-                       completion(finished);
-                     }];
+    void (^completionWithDelegate)(BOOL) = ^(BOOL finished) {
+      [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+      completion(finished);
+    };
+    if (self.allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView) {
+      [self animateWithAnimations:animations completion:completionWithDelegate];
+    } else {
+      [UIView animateWithDuration:kTrackingScrollViewDidChangeAnimationDuration
+                       animations:animations
+                       completion:completionWithDelegate];
+    }
   } else {
-    animate();
+    animations();
     completion(YES);
   }
 }
@@ -1929,6 +1906,42 @@ static BOOL isRunningiOS10_3OrAbove() {
   // Translucent content means that the status bar shifter should not use snapshotting. Otherwise,
   // stale visual content under the status bar region may be snapshotted.
   _statusBarShifter.snapshottingEnabled = !contentIsTranslucent;
+}
+
+- (void)animateWithAnimations:(void (^_Nonnull)(void))animations
+                   completion:(void (^_Nullable)(BOOL))completion {
+  NSTimeInterval duration = kTrackingScrollViewDidChangeAnimationDuration;
+
+  // Note: this should match the easing curve passed to UIView's animateWithDuration:... below.
+  CAMediaTimingFunction *timingFunction =
+      [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+  [UIView animateWithDuration:duration
+                        delay:0.f
+                        // Note: this should match the timing function above.
+                      options:UIViewAnimationOptionCurveEaseInOut
+                   animations:^{
+    self->_isAnimatingLayoutUpdate = YES;
+
+    [CATransaction begin];
+  #if TARGET_IPHONE_SIMULATOR
+    [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
+  #else
+    [CATransaction setAnimationDuration:duration];
+  #endif
+    [CATransaction setAnimationTimingFunction:timingFunction];
+
+    animations();
+
+    [self fhv_updateLayout];
+
+    // Force any layout changes to be committed during this animation block.
+    [self layoutIfNeeded];
+
+    [CATransaction commit];
+
+    self->_isAnimatingLayoutUpdate = NO;
+  }
+                   completion:completion];
 }
 
 #pragma mark - MDCElevation

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1917,30 +1917,30 @@ static BOOL isRunningiOS10_3OrAbove() {
       [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
   [UIView animateWithDuration:duration
                         delay:0.f
-                        // Note: this should match the timing function above.
+                      // Note: this should match the timing function above.
                       options:UIViewAnimationOptionCurveEaseInOut
                    animations:^{
-    self->_isAnimatingLayoutUpdate = YES;
+                     self->_isAnimatingLayoutUpdate = YES;
 
-    [CATransaction begin];
-  #if TARGET_IPHONE_SIMULATOR
-    [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
-  #else
-    [CATransaction setAnimationDuration:duration];
-  #endif
-    [CATransaction setAnimationTimingFunction:timingFunction];
+                     [CATransaction begin];
+#if TARGET_IPHONE_SIMULATOR
+                     [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
+#else
+        [CATransaction setAnimationDuration:duration];
+#endif
+                     [CATransaction setAnimationTimingFunction:timingFunction];
 
-    animations();
+                     animations();
 
-    [self fhv_updateLayout];
+                     [self fhv_updateLayout];
 
-    // Force any layout changes to be committed during this animation block.
-    [self layoutIfNeeded];
+                     // Force any layout changes to be committed during this animation block.
+                     [self layoutIfNeeded];
 
-    [CATransaction commit];
+                     [CATransaction commit];
 
-    self->_isAnimatingLayoutUpdate = NO;
-  }
+                     self->_isAnimatingLayoutUpdate = NO;
+                   }
                    completion:completion];
 }
 

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1926,7 +1926,10 @@ static BOOL isRunningiOS10_3OrAbove() {
 #if TARGET_IPHONE_SIMULATOR
                      [CATransaction setAnimationDuration:duration * [self fhv_dragCoefficient]];
 #else
-        [CATransaction setAnimationDuration:duration];
+        // clang-format is trying to indent this line too far to the left.
+        // clang-format off
+                     [CATransaction setAnimationDuration:duration];
+    // clang-format on
 #endif
                      [CATransaction setAnimationTimingFunction:timingFunction];
 

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
@@ -1,0 +1,65 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialShadowLayer
+
+class FlexibleHeaderAnimateTests: XCTestCase {
+
+  func testAnimatingMaximumHeightAnimatesHeight() throws {
+    // Given
+    let window = UIWindow()
+    let fhvc = MDCFlexibleHeaderViewController()
+    let shadowLayer = MDCShadowLayer()
+    fhvc.headerView.setShadowLayer(shadowLayer) { layer, elevation in
+      guard let shadowLayer = layer as? MDCShadowLayer else {
+        return
+      }
+      shadowLayer.elevation = .init(4 * elevation)
+    }
+    fhvc.headerView.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhvc.headerView.minMaxHeightIncludesSafeArea = false
+    fhvc.headerView.maximumHeight = 200
+    let scrollView = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhvc.headerView.frame.width, height: 1000)
+    scrollView.contentSize = largeScrollableArea
+    scrollView.contentOffset = CGPoint(x: 0, y: -200)
+    fhvc.headerView.trackingScrollView = scrollView
+    window.rootViewController = fhvc
+    window.makeKeyAndVisible()
+    CATransaction.flush()
+
+    // When
+    fhvc.headerView.animate(animations: {
+      scrollView.contentOffset = CGPoint(x: 0, y: -100)
+      fhvc.headerView.maximumHeight = 100
+    })
+
+    // Then
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.size"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "bounds.origin"))
+    XCTAssertNotNil(fhvc.headerView.layer.animation(forKey: "position"))
+
+    guard let sizeAnimation =
+        fhvc.headerView.layer.animation(forKey: "bounds.size") as? CABasicAnimation else {
+      XCTFail("Missing bounds.size animation")
+      return
+    }
+
+    XCTAssertTrue(sizeAnimation.isAdditive)
+    XCTAssertEqual(sizeAnimation.fromValue as! CGSize, CGSize(width: 0, height: 100))
+    XCTAssertEqual(sizeAnimation.toValue as! CGSize, CGSize(width: 0, height: 0))
+  }
+}

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
@@ -48,7 +48,7 @@ class FlexibleHeaderAnimateTests: XCTestCase {
 
     guard let sizeAnimation =
         fhvc.headerView.layer.animation(forKey: "bounds.size") as? CABasicAnimation else {
-      XCTFail("Missing bounds.size animation")
+      XCTFail("bounds.size animation is not a CABasicAnimation")
       return
     }
 

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderAnimateTests.swift
@@ -20,15 +20,7 @@ class FlexibleHeaderAnimateTests: XCTestCase {
 
   func testAnimatingMaximumHeightAnimatesHeight() throws {
     // Given
-    let window = UIWindow()
     let fhvc = MDCFlexibleHeaderViewController()
-    let shadowLayer = MDCShadowLayer()
-    fhvc.headerView.setShadowLayer(shadowLayer) { layer, elevation in
-      guard let shadowLayer = layer as? MDCShadowLayer else {
-        return
-      }
-      shadowLayer.elevation = .init(4 * elevation)
-    }
     fhvc.headerView.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
     fhvc.headerView.minMaxHeightIncludesSafeArea = false
     fhvc.headerView.maximumHeight = 200
@@ -37,6 +29,8 @@ class FlexibleHeaderAnimateTests: XCTestCase {
     scrollView.contentSize = largeScrollableArea
     scrollView.contentOffset = CGPoint(x: 0, y: -200)
     fhvc.headerView.trackingScrollView = scrollView
+
+    let window = UIWindow()
     window.rootViewController = fhvc
     window.makeKeyAndVisible()
     CATransaction.flush()


### PR DESCRIPTION
This API can be used to animate changes to the flexible header.

Part of https://github.com/material-components/material-components-ios/issues/8644

Originally authored by @jpsachse and ported to this PR by @jverkoey.