### PR TITLE
[ThumbTrack][Slider] Add API to control showing tick marks.

### DIFF
--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -18,6 +18,16 @@
 #import "MaterialElevation.h"
 #import "MaterialShadowElevations.h"
 
+/** The visibility of the track tick marks. */
+typedef NS_ENUM(NSUInteger, MDCSliderTrackTickVisibility) {
+  /** Track tick marks are never shown. */
+  MDCSliderTrackTickVisibilityNever = 0,
+  /** Track tick marks are only shown when the thumb is pressed or dragging. */
+  MDCSliderTrackTickVisibilityWhenDragging = 1U,
+  /** Track tick marks are always shown. */
+  MDCSliderTrackTickVisibilityAlways = 2U,
+};
+
 @protocol MDCSliderDelegate;
 
 /**
@@ -211,6 +221,16 @@ IB_DESIGNABLE
  The default value is zero.
  */
 @property(nonatomic, assign) NSUInteger numberOfDiscreteValues;
+
+/**
+ Configures the visibility of the track tick marks.
+
+ @note Unless this property is set explicitly, its value will change based on the value of
+       @c continuous. When @c continuous is @c true, @c trackTickVisibility is
+       @c MDCSliderTrackTickVisibilityNever. When @c continuous is false, @c trackTickVisibility
+       is @c MDCSliderTrackTickVisibilityWhenDragging.
+ */
+@property(nonatomic, assign) MDCSliderTrackTickVisibility trackTickVisibility;
 
 /**
  The value of the slider.

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -44,10 +44,12 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   NSMutableDictionary *_trackBackgroundColorsForState;
   NSMutableDictionary *_filledTickColorsForState;
   NSMutableDictionary *_backgroundTickColorsForState;
+  BOOL _isTrackTickVisibilityAutomatic;
 }
 
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
 @synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
+@synthesize trackTickVisibility = _trackTickVisibility;
 
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
@@ -77,7 +79,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   _thumbTrack.thumbGrowsWhenDragging = YES;
   _thumbTrack.shouldDisplayInk = NO;
   _thumbTrack.shouldDisplayRipple = YES;
-  _thumbTrack.shouldDisplayDiscreteDots = YES;
+  _thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
   _thumbTrack.shouldDisplayDiscreteValueLabel = YES;
   _thumbTrack.trackOffColor = [[self class] defaultTrackOffColor];
   _thumbTrack.thumbDisabledColor = [[self class] defaultDisabledColor];
@@ -124,6 +126,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   _shouldEnableHapticsForAllDiscreteValues = NO;
 
   _previousValue = -CGFLOAT_MAX;
+  _isTrackTickVisibilityAutomatic = YES;
 }
 
 #pragma mark - Color customization methods
@@ -278,6 +281,30 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   return _thumbTrack.numDiscreteValues;
 }
 
+- (void)setTrackTickVisibility:(MDCSliderTrackTickVisibility)trackTickVisibility {
+  _trackTickVisibility = trackTickVisibility;
+  _isTrackTickVisibilityAutomatic = NO;
+  switch (trackTickVisibility) {
+    case MDCSliderTrackTickVisibilityNever:
+      self.thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityNever;
+      break;
+    case MDCSliderTrackTickVisibilityWhenDragging:
+      self.thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
+      break;
+    case MDCSliderTrackTickVisibilityAlways:
+      self.thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityAlways;
+      break;
+  }
+}
+
+- (MDCSliderTrackTickVisibility)trackTickVisibility {
+  if (_isTrackTickVisibilityAutomatic) {
+    return self.continuous ? MDCSliderTrackTickVisibilityNever
+                           : MDCSliderTrackTickVisibilityWhenDragging;
+  }
+  return _trackTickVisibility;
+}
+
 - (UIColor *)thumbShadowColor {
   return _thumbTrack.thumbShadowColor;
 }
@@ -296,6 +323,10 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 - (void)setContinuous:(BOOL)continuous {
   _thumbTrack.continuousUpdateEvents = continuous;
+  if (_isTrackTickVisibilityAutomatic) {
+    _thumbTrack.discreteDotVisibility =
+        continuous ? MDCThumbDiscreteDotVisibilityNever : MDCThumbDiscreteDotVisibilityWhenDragging;
+  }
 }
 
 - (CGFloat)value {

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -16,9 +16,36 @@
 
 #import <UIKit/UIKit.h>
 
+#import "../../src/private/MDCSlider+Private.h"
 #import "../../src/private/MDCSlider_Subclassable.h"
 #import "MaterialSlider.h"
 #import "MaterialThumbTrack.h"
+
+/** A @c UITouch subclass where the location can be set. */
+@interface MDCSliderSnapshotTestTouchFake : UITouch
+
+/** The location of the touch in the target view. */
+@property(nonatomic, assign) CGPoint mdc_touchPoint;
+@end
+
+@implementation MDCSliderSnapshotTestTouchFake
+
+- (CGPoint)locationInView:(UIView *)view {
+  return self.mdc_touchPoint;
+}
+
+@end
+
+/** Performs a touch event on the thumb of the provided slider. */
+static void TouchThumbInSlider(MDCSlider *slider) {
+  CGRect thumbViewBounds = slider.thumbTrack.thumbView.bounds;
+  CGPoint thumbPosition = [slider.thumbTrack
+      convertPoint:CGPointMake(CGRectGetMidX(thumbViewBounds), CGRectGetMidY(thumbViewBounds))
+          fromView:slider.thumbTrack.thumbView];
+  MDCSliderSnapshotTestTouchFake *thumbTouch = [[MDCSliderSnapshotTestTouchFake alloc] init];
+  thumbTouch.mdc_touchPoint = thumbPosition;
+  [slider.thumbTrack touchesBegan:[NSSet setWithObject:thumbTouch] withEvent:nil];
+}
 
 /**
  An MDCSlider subclass that allows the user to override the @c traitCollection property.
@@ -55,7 +82,7 @@
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  // self.recordMode = YES;
+  //  self.recordMode = YES;
 
   self.slider =
       [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];
@@ -110,6 +137,90 @@
   self.slider.value = self.slider.maximumValue;
 
   // Then
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderInactiveThumbTrackTickMarksNever {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityNever;
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderActiveThumbTrackTickMarksNever {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityNever;
+  TouchThumbInSlider(self.slider);
+
+  // Then
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderInactiveThumbTrackTickMarksWhenDragging {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityWhenDragging;
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderActiveThumbTrackTickMarksWhenDragging {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityWhenDragging;
+  TouchThumbInSlider(self.slider);
+
+  // Then
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderInactiveThumbTrackTickMarksAlways {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityAlways;
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderActiveThumbTrackTickMarksAlways {
+  // Given
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+
+  // When
+  self.slider.trackTickVisibility = MDCSliderTrackTickVisibilityAlways;
+  TouchThumbInSlider(self.slider);
+
+  // Then
+  [NSRunLoop.mainRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
   [self generateSnapshotAndVerifyForView:self.slider];
 }
 

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -82,7 +82,7 @@ static void TouchThumbInSlider(MDCSlider *slider) {
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  //  self.recordMode = YES;
+  // self.recordMode = YES;
 
   self.slider =
       [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];

--- a/components/Slider/tests/unit/MDCSliderTests.m
+++ b/components/Slider/tests/unit/MDCSliderTests.m
@@ -32,14 +32,14 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
     UIImpactFeedbackGenerator *feedbackGenerator API_AVAILABLE(ios(10.0));
 @end
 
-@interface SliderTests : XCTestCase
+@interface MDCSliderTests : XCTestCase
 @property(nonatomic, nullable) MDCSlider *slider;
 @property(nonatomic, nullable) UIColor *aNonDefaultColor;
 @property(nonatomic, nullable) UIColor *defaultBlue;
 @property(nonatomic, nullable) UIColor *defaultGray;
 @end
 
-@implementation SliderTests {
+@implementation MDCSliderTests {
   MockUIImpactFeedbackGenerator *_mockFeedbackGenerator API_AVAILABLE(ios(10.0));
 }
 
@@ -889,6 +889,30 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
   XCTAssertEqualObjects(self.slider.thumbTrack.trackOffTickColor,
                         [self.slider backgroundTrackTickColorForState:UIControlStateHighlighted |
                                                                       UIControlStateSelected]);
+}
+
+#pragma mark - trackTickVisibility
+
+- (void)testTrackTickVisibilityDefaultForContinuousSlider {
+  // Given
+  MDCSlider *slider = [[MDCSlider alloc] init];
+
+  // When
+  slider.continuous = YES;
+
+  // Then
+  XCTAssertEqual(slider.trackTickVisibility, MDCSliderTrackTickVisibilityNever);
+}
+
+- (void)testTrackTickVisibilityDefaultForDiscreteSlider {
+  // Given
+  MDCSlider *slider = [[MDCSlider alloc] init];
+
+  // When
+  slider.continuous = NO;
+
+  // Then
+  XCTAssertEqual(slider.trackTickVisibility, MDCSliderTrackTickVisibilityWhenDragging);
 }
 
 #pragma mark - InkColor

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -16,6 +16,16 @@
 
 #import "MaterialShadowElevations.h"
 
+/** The visibility of the discrete dots. */
+typedef NS_ENUM(NSUInteger, MDCThumbDiscreteDotVisibility) {
+  /** Discrete dots are never shown. */
+  MDCThumbDiscreteDotVisibilityNever = 0,
+  /** Discrete dots are only shown when the thumb is pressed or dragging. */
+  MDCThumbDiscreteDotVisibilityWhenDragging = 1U,
+  /** Discrete dots are always shown. */
+  MDCThumbDiscreteDotVisibilityAlways = 2U,
+};
+
 @class MDCThumbView;
 @protocol MDCThumbTrackDelegate;
 
@@ -161,8 +171,10 @@
 /** Whether the thumb should display ripple splashes on touch. */
 @property(nonatomic, assign) BOOL shouldDisplayRipple;
 
-/** Whether or not to display dots indicating discrete locations. Default is NO. */
-@property(nonatomic, assign) BOOL shouldDisplayDiscreteDots;
+/**
+ Configures the visibility of the discrete dots.
+*/
+@property(nonatomic, assign) MDCThumbDiscreteDotVisibility discreteDotVisibility;
 
 /**
  Whether or not to show the numeric value label when dragging a discrete slider.

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -912,7 +912,7 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
  */
 - (void)updateViewsForThumbAfterMoveIsAnimated:(BOOL)animated
                                   withDuration:(NSTimeInterval)duration {
-  switch(self.discreteDotVisibility) {
+  switch (self.discreteDotVisibility) {
     case MDCThumbDiscreteDotVisibilityNever:
       _discreteDots.alpha = 0.0;
       break;

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -914,13 +914,13 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
                                   withDuration:(NSTimeInterval)duration {
   switch (self.discreteDotVisibility) {
     case MDCThumbDiscreteDotVisibilityNever:
-      _discreteDots.alpha = 0.0;
+      _discreteDots.alpha = 0;
       break;
     case MDCThumbDiscreteDotVisibilityAlways:
-      _discreteDots.alpha = 1.0;
+      _discreteDots.alpha = 1;
       break;
     case MDCThumbDiscreteDotVisibilityWhenDragging:
-      _discreteDots.alpha = (self.enabled && _isDraggingThumb) ? 1.0 : 0.0;
+      _discreteDots.alpha = (self.enabled && _isDraggingThumb) ? 1 : 0;
       break;
   }
 

--- a/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
+++ b/components/private/ThumbTrack/tests/unit/ThumbTrackTests.m
@@ -173,7 +173,7 @@
   MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
 
   // When
-  thumbTrack.shouldDisplayDiscreteDots = YES;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
   thumbTrack.trackOnTickColor = UIColor.cyanColor;
 
   // Then
@@ -186,9 +186,9 @@
   MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
 
   // When
-  thumbTrack.shouldDisplayDiscreteDots = NO;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityNever;
   thumbTrack.trackOnTickColor = UIColor.cyanColor;
-  thumbTrack.shouldDisplayDiscreteDots = YES;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
 
   // Then
   XCTAssertEqualObjects(thumbTrack.trackOnTickColor, UIColor.cyanColor);
@@ -210,7 +210,7 @@
   MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
 
   // When
-  thumbTrack.shouldDisplayDiscreteDots = YES;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
   thumbTrack.trackOffTickColor = UIColor.cyanColor;
 
   // Then
@@ -223,9 +223,9 @@
   MDCThumbTrack *thumbTrack = [[MDCThumbTrack alloc] init];
 
   // When
-  thumbTrack.shouldDisplayDiscreteDots = NO;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityNever;
   thumbTrack.trackOffTickColor = UIColor.cyanColor;
-  thumbTrack.shouldDisplayDiscreteDots = YES;
+  thumbTrack.discreteDotVisibility = MDCThumbDiscreteDotVisibilityWhenDragging;
 
   // Then
   XCTAssertEqualObjects(thumbTrack.trackOffTickColor, UIColor.cyanColor);

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksAlways_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksAlways_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25731424ba5e4c4ee3aec9ba11c439f4c62123beb36b5e71660dd3b8edcaa331
+size 3151

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksNever_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksNever_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d706c05085d95c3fbec0914db0651b1638337e07223a81b2c1eea2057e3be6b6
+size 2587

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksWhenDragging_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderActiveThumbTrackTickMarksWhenDragging_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25731424ba5e4c4ee3aec9ba11c439f4c62123beb36b5e71660dd3b8edcaa331
+size 3151

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksAlways_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksAlways_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47702ef41d821d9e4dda8fcfb510c8f6b4235690c7226fc5a855f504864b07fd
+size 2581

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksNever_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksNever_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c8df7737752099ea0e203273147f42722fc09774ed3df3ead3f9e479dab026
+size 1986

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksWhenDragging_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderInactiveThumbTrackTickMarksWhenDragging_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c8df7737752099ea0e203273147f42722fc09774ed3df3ead3f9e479dab026
+size 1986


### PR DESCRIPTION
A new API, `trackTickVisibility` is provided to control the visibility of
track tick marks. Specifically allows showing track tick marks for continuous
sliders and for discrete sliders even when the Thumb is not pressed.

Closes #8737