### PR TITLE
[Snackbar] Add focusOnShow API

### DIFF
--- a/components/Snackbar/examples/SnackbarSimpleExample.m
+++ b/components/Snackbar/examples/SnackbarSimpleExample.m
@@ -80,6 +80,7 @@
 - (void)showSimpleSnackbar:(id)sender {
   MDCSnackbarMessage *message = [[MDCSnackbarMessage alloc] init];
   message.text = @"Snackbar Message";
+  message.focusOnShow = YES;
   [MDCSnackbarManager showMessage:message];
 }
 

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -241,7 +241,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              if (snackbarView.accessibilityViewIsModal ||
+              if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
                   ![self isSnackbarTransient:snackbarView]) {
                 UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
                                                 snackbarView);

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -163,7 +163,7 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
  The message is announced but not focused when set to NO.
 
  Note: Setting this to YES will ensure the entire snackbar message is read during VoiceOver, and
- that the message persists until an action is made or the focus is removed.
+ that the message persists until an action is made on the message.
 
  Defaults to NO.
  */

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -162,8 +162,8 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
  Whether to focus on the Snackbar message when VoiceOver is enabled.
  The message is announced but not focused when set to NO.
 
- Note: Setting this to YES will ensure the entire snackbar message is read during VoiceOver, and that the message persists until an action
- is made or the focus is removed.
+ Note: Setting this to YES will ensure the entire snackbar message is read during VoiceOver, and
+ that the message persists until an action is made or the focus is removed.
 
  Defaults to NO.
  */

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -158,6 +158,17 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
  */
 @property(nonatomic, assign) BOOL enableRippleBehavior;
 
+/**
+ Whether to focus on the Snackbar message when VoiceOver is enabled.
+ The message is announced but not focused when set to NO.
+
+ Note: Setting this to YES will ensure the entire snackbar message is read during VoiceOver, and that the message persists until an action
+ is made or the focus is removed.
+
+ Defaults to NO.
+ */
+@property(nonatomic) BOOL focusOnShow;
+
 @end
 
 /**

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -70,6 +70,7 @@ static BOOL _usesLegacySnackbar = NO;
   copy.buttonTextColor = self.buttonTextColor;
 #pragma clang diagnostic pop
   copy.enableRippleBehavior = self.enableRippleBehavior;
+  copy.focusOnShow = self.focusOnShow;
 
   // Unfortunately there's not really a concept of 'copying' a block (in the same way you would copy
   // a string, for example). A block's pointer is immutable once it is created and copied to the

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -476,7 +476,8 @@
   // When
   [self.manager showMessage:self.message];
   XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
-  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.1 * NSEC_PER_SEC));
+  dispatch_time_t popTime =
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.1 * NSEC_PER_SEC));
   dispatch_after(popTime, dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -476,8 +476,7 @@
   // When
   [self.manager showMessage:self.message];
   XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
-  dispatch_time_t popTime =
-      dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
+  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.1 * NSEC_PER_SEC));
   dispatch_after(popTime, dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -477,7 +477,7 @@
   [self.manager showMessage:self.message];
   XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
   dispatch_time_t popTime =
-      dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.1 * NSEC_PER_SEC));
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.2 * NSEC_PER_SEC));
   dispatch_after(popTime, dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -467,4 +467,24 @@
   XCTAssertTrue(messageView.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
 }
 
+- (void)testMessageStaysWhenFocusOnShowIsEnabled {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  self.message.focusOnShow = YES;
+  self.message.duration = 0.1;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_time_t popTime =
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
+  dispatch_after(popTime, dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertFalse(self.manager.internalManager.currentSnackbar.accessibilityElementsHidden);
+}
+
 @end


### PR DESCRIPTION
This new API when set to YES allows the Snackbar to be focused and stay on screen by issuing a UIAccessibilityLayoutChangedNotification on the snackbar message view.