### PR TITLE
[Banner] stop updating custom constraints before bound size is set.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -395,8 +395,10 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 }
 
 - (void)updateConstraints {
-  MDCBannerViewLayoutStyle layoutStyle = [self layoutStyleForSizeToFit:self.bounds.size];
-  [self updateConstraintsWithLayoutStyle:layoutStyle];
+  if (!CGSizeEqualToSize(self.bounds.size, CGSizeZero)) {
+    MDCBannerViewLayoutStyle layoutStyle = [self layoutStyleForSizeToFit:self.bounds.size];
+    [self updateConstraintsWithLayoutStyle:layoutStyle];
+  }
 
   [super updateConstraints];
 }


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8678.

Custom constraints don't need to be updated unless the size of banner is specified.