### PR TITLE
[WIP] [Proof of concept] hide flexible header in calls from MDCAppBarNavigationController's `-setNavigationBarHidden:animated:`

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -102,19 +102,16 @@
 }
 
 - (void)setNavigationBarHidden:(BOOL)navigationBarHidden {
-  // TODO: Consider using this API to hide the top view controller's flexible header.
-  NSAssert(navigationBarHidden, @"%@ requires that the system navigation bar remain hidden.",
-           NSStringFromClass([self class]));
-
-  [super setNavigationBarHidden:YES];
+  [self setNavigationBarHidden:YES animated:NO];
 }
 
 - (void)setNavigationBarHidden:(BOOL)navigationBarHidden animated:(BOOL)animated {
-  // TODO: Consider using this API to hide the top view controller's flexible header.
-  NSAssert(navigationBarHidden, @"%@ requires that the system navigation bar remain hidden.",
-           NSStringFromClass([self class]));
-
   [super setNavigationBarHidden:YES animated:animated];
+
+  UIViewController *child = [super childViewControllerForStatusBarStyle];
+  MDCAppBar *appBar = [self appBarForViewController:child];
+  MDCFlexibleHeaderView *headerView = appBar.appBarViewController.headerView;
+  [headerView setHidden:navigationBarHidden animated:animated];
 }
 
 #pragma mark - Private

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -302,6 +302,13 @@ IB_DESIGNABLE
  */
 @property(nonatomic) BOOL resetShadowAfterTrackingScrollViewIsReset;
 
+/**
+ This method is called from MDCAppBarNavigationController's override of
+ -setNavigationBarHidden:animated:. It hides the MDCFlexibleHeaderView with a mechanism other than
+ -setHidden:.
+ */
+- (void)setHidden:(BOOL)hidden animated:(BOOL)animated;
+
 #pragma mark Scroll View Tracking
 
 /**

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1970,20 +1970,20 @@ static BOOL isRunningiOS10_3OrAbove() {
     return;
   }
 
-  CGFloat height = 0;
-  if (isCurrentlyHidden) {
-    height = self.cachedMaxHeight + 20;
-  } else {
-    height = self.maximumHeight + 20;
-  }
-  CGAffineTransform shifted = CGAffineTransformTranslate(CGAffineTransformIdentity, 0, -1 * height);
-
   CGFloat safeArea = 0;
   if (@available(iOS 11.0, *)) {
     safeArea = self.safeAreaInsets.top;
   } else {
     safeArea = 20;
   }
+
+  CGFloat height = 0;
+  if (isCurrentlyHidden) {
+    height = self.cachedMaxHeight + safeArea;
+  } else {
+    height = self.maximumHeight + safeArea;
+  }
+  CGAffineTransform shifted = CGAffineTransformTranslate(CGAffineTransformIdentity, 0, -1 * height);
 
   CGFloat animationDuration = (CGFloat)0.15;
   if (hidden) {


### PR DESCRIPTION
I'm about 25% confident in this as a solution for #5185. There are most likely things I'm not thinking about that would render this solution ineffective. It feels very risky.

Here's a gif with a trackingScrollView:
![tracking-scroll-view](https://user-images.githubusercontent.com/8020010/68406936-b130d380-0150-11ea-82b5-4c86da5bcc37.gif)

And here's one without:
![no-tracking-scrollview](https://user-images.githubusercontent.com/8020010/68406932-b0983d00-0150-11ea-8b89-628e37057426.gif)
