### PR TITLE
[Banner] Use lastBaseLineAnchor to align buttons if they are on the same line.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -78,7 +78,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintTop;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintCenterY;
-@property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintBaseLineWithTrailingButton;
+@property(nonatomic, readwrite, strong)
+    NSLayoutConstraint *leadingButtonConstraintBaseLineWithTrailingButton;
 @property(nonatomic, readwrite, strong)
     NSLayoutConstraint *leadingButtonConstraintTrailingWithTrailingButton;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *trailingButtonConstraintBottom;
@@ -276,8 +277,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
   self.leadingButtonConstraintCenterY = [self.leadingButton.centerYAnchor
       constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
-  self.leadingButtonConstraintBaseLineWithTrailingButton =
-      [self.leadingButton.lastBaselineAnchor constraintEqualToAnchor:self.trailingButton.lastBaselineAnchor];
+  self.leadingButtonConstraintBaseLineWithTrailingButton = [self.leadingButton.lastBaselineAnchor
+      constraintEqualToAnchor:self.trailingButton.lastBaselineAnchor];
   self.leadingButtonConstraintTrailingWithTrailingButton =
       [self.leadingButton.trailingAnchor constraintEqualToAnchor:self.trailingButton.leadingAnchor
                                                         constant:-kButtonHorizontalIntervalSpace];

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -78,6 +78,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintTop;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintTrailing;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintCenterY;
+@property(nonatomic, readwrite, strong) NSLayoutConstraint *leadingButtonConstraintBaseLineWithTrailingButton;
 @property(nonatomic, readwrite, strong)
     NSLayoutConstraint *leadingButtonConstraintTrailingWithTrailingButton;
 @property(nonatomic, readwrite, strong) NSLayoutConstraint *trailingButtonConstraintBottom;
@@ -275,6 +276,8 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
       constraintEqualToAnchor:self.buttonContainerView.trailingAnchor];
   self.leadingButtonConstraintCenterY = [self.leadingButton.centerYAnchor
       constraintEqualToAnchor:self.buttonContainerView.centerYAnchor];
+  self.leadingButtonConstraintBaseLineWithTrailingButton =
+      [self.leadingButton.lastBaselineAnchor constraintEqualToAnchor:self.trailingButton.lastBaselineAnchor];
   self.leadingButtonConstraintTrailingWithTrailingButton =
       [self.leadingButton.trailingAnchor constraintEqualToAnchor:self.trailingButton.leadingAnchor
                                                         constant:-kButtonHorizontalIntervalSpace];
@@ -327,6 +330,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   self.leadingButtonConstraintTop.active = NO;
   self.leadingButtonConstraintTrailing.active = NO;
   self.leadingButtonConstraintCenterY.active = NO;
+  self.leadingButtonConstraintBaseLineWithTrailingButton.active = NO;
   self.leadingButtonConstraintTrailingWithTrailingButton.active = NO;
   self.trailingButtonConstraintBottom.active = NO;
   self.trailingButtonConstraintTop.active = NO;
@@ -457,12 +461,13 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
     self.leadingButtonConstraintCenterY.active = YES;
   } else {
     if (layoutStyle == MDCBannerViewLayoutStyleMultiRowStackedButton) {
+      self.leadingButtonConstraintTop.active = YES;
       self.leadingButtonConstraintTrailing.active = YES;
       self.trailingButtonConstraintTop.active = YES;
     } else {
       self.leadingButtonConstraintTrailingWithTrailingButton.active = YES;
+      self.leadingButtonConstraintBaseLineWithTrailingButton.active = YES;
     }
-    self.leadingButtonConstraintTop.active = YES;
   }
   self.leadingButtonConstraintLeading.active = YES;
   self.trailingButtonConstraintTrailing.active = YES;


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8326.

Manual testing steps:
(1) Go to Banner 
(2) Select two long actions with icon.
(3) Rotate device to landscape and rotate it again back to portrait.

|Screenshot before|Screenshot after|
|------------ | -------------|
|![Simulator Screen Shot - iPhone Xʀ - 2019-11-07 at 11 04 49](https://user-images.githubusercontent.com/8836258/68416297-396ba480-0162-11ea-9612-0c297ca6a3e2.png)| ![Simulator Screen Shot - iPhone Xʀ - 2019-11-07 at 13 27 01](https://user-images.githubusercontent.com/8836258/68416339-4ee0ce80-0162-11ea-9f1f-7baa44450bce.png)|

