### PR TITLE
[Banner] Add snapshot tests for an orientation case.

### DIFF
--- a/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
+++ b/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
@@ -89,7 +89,7 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  // self.recordMode = YES;
+   self.recordMode = YES;
 
   self.bannerView = [[MDCBannerView alloc] initWithFrame:CGRectZero];
   if (@available(iOS 11.0, *)) {
@@ -230,6 +230,24 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
   [button2 setTitleColor:UIColor.blackColor forState:UIControlStateNormal];
   button2.uppercaseTitle = YES;
   self.bannerView.imageView.hidden = YES;
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.bannerView];
+}
+
+- (void)testLongTextWithTwoActionsWithTwoOrientationChangeActions {
+  // When
+  self.bannerView.textView.text = kBannerLongText;
+  MDCButton *button1 = self.bannerView.leadingButton;
+  [button1 setTitle:@"Action1" forState:UIControlStateNormal];
+  [button1 setTitleColor:UIColor.blackColor forState:UIControlStateNormal];
+  button1.uppercaseTitle = YES;
+  MDCButton *button2 = self.bannerView.trailingButton;
+  [button2 setTitle:@"Action2" forState:UIControlStateNormal];
+  [button2 setTitleColor:UIColor.blackColor forState:UIControlStateNormal];
+  button2.uppercaseTitle = YES;
+  self.bannerView.imageView.hidden = YES;
+  XCUIDevice.sharedDevice.orientation = UIDeviceOrientationLandscapeLeft;
 
   // Then
   [self generateSnapshotAndVerifyForView:self.bannerView];

--- a/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
+++ b/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
@@ -134,8 +134,7 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
   [self generateSnapshotAndVerifyForView:view supportIOS13:NO];
 }
 
-- (void)generateSnapshotAndVerifyForView:(UIView *)view
-                            supportIOS13:(BOOL)supportIOS13 {
+- (void)generateSnapshotAndVerifyForView:(UIView *)view supportIOS13:(BOOL)supportIOS13 {
   CGSize aSize = [view sizeThatFits:CGSizeMake(350, INFINITY)];
   view.frame = CGRectMake(0, 0, aSize.width, aSize.height);
   [view layoutIfNeeded];

--- a/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
+++ b/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
@@ -89,7 +89,7 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-   self.recordMode = YES;
+  // self.recordMode = YES;
 
   self.bannerView = [[MDCBannerView alloc] initWithFrame:CGRectZero];
   if (@available(iOS 11.0, *)) {

--- a/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
+++ b/components/Banner/tests/snapshot/MDCBannerSnapshotTests.m
@@ -131,12 +131,17 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
 }
 
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  [self generateSnapshotAndVerifyForView:view supportIOS13:NO];
+}
+
+- (void)generateSnapshotAndVerifyForView:(UIView *)view
+                            supportIOS13:(BOOL)supportIOS13 {
   CGSize aSize = [view sizeThatFits:CGSizeMake(350, INFINITY)];
   view.frame = CGRectMake(0, 0, aSize.width, aSize.height);
   [view layoutIfNeeded];
 
   UIView *snapshotView = [view mdc_addToBackgroundView];
-  [self snapshotVerifyView:snapshotView];
+  [self snapshotVerifyView:snapshotView tolerance:0 supportIOS13:supportIOS13];
 }
 
 // TODO(https://github.com/material-components/material-components-ios/issues/7487):
@@ -248,9 +253,10 @@ static const CGFloat kBannerLargeContentPadding = 30.0f;
   button2.uppercaseTitle = YES;
   self.bannerView.imageView.hidden = YES;
   XCUIDevice.sharedDevice.orientation = UIDeviceOrientationLandscapeLeft;
+  XCUIDevice.sharedDevice.orientation = UIDeviceOrientationPortrait;
 
   // Then
-  [self generateSnapshotAndVerifyForView:self.bannerView];
+  [self generateSnapshotAndVerifyForView:self.bannerView supportIOS13:YES];
 }
 
 - (void)testLongTextWithTwoActionsRTLInArabic {

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9070812e9ca1329dd9f0bbbcd7f74accf023e0f549d0ccc7f6c7f1dd61cc92ae
+size 21457

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_11_2@2x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9070812e9ca1329dd9f0bbbcd7f74accf023e0f549d0ccc7f6c7f1dd61cc92ae
-size 21457

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_13_0@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_13_0@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c12a5067c63e5dd94c469b719846b2c2c5c4a52f505fd646b18b4a909fe14ab3
+size 23492

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_13_0@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testLongTextWithTwoActionsWithTwoOrientationChangeActions_13_0@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c12a5067c63e5dd94c469b719846b2c2c5c4a52f505fd646b18b4a909fe14ab3
-size 23492
+oid sha256:69012d81d1872d9d1d8dcbdd5504c12ac7727f638471815049de57baf21bc4f0
+size 21854


### PR DESCRIPTION
This test follows up the comment on https://github.com/material-components/material-components-ios/pull/8752#pullrequestreview-313547178.

The screenshot shows the change before and after https://github.com/material-components/material-components-ios/pull/8752.

<img width="918" alt="Screen Shot 2019-11-07 at 3 40 37 PM" src="https://user-images.githubusercontent.com/8836258/68425997-31693000-0175-11ea-8b7c-a33e35515d31.png">
