### PR TITLE
[FlexibleHeader] Add a flexibleHeaderView:didChangeTrackingScrollViewAnimated: event to MDCFlexibleHeaderViewAnimationDelegate.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -461,7 +461,17 @@ IB_DESIGNABLE
  MDCFlexibleHeaderView.
  */
 @protocol MDCFlexibleHeaderViewAnimationDelegate <NSObject>
-@required
+@optional
+
+/**
+ Informs the receiver that the flexible header view's tracking scroll view has changed.
+
+ @param animated If YES, then this method is being invoked from within an animation block. Changes
+ made to the flexible header as a result of this invocation will be animated alongside the header's
+ animation.
+ */
+- (void)flexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView
+    didChangeTrackingScrollViewAnimated:(BOOL)animated;
 
 /**
  Informs the receiver that the flexible header view's animation changing to a new tracking scroll

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1563,7 +1563,8 @@ static BOOL isRunningiOS10_3OrAbove() {
   BOOL animated = wasTrackingScrollView && shouldAnimate;
 
   void (^animations)(void) = ^{
-    if ([self.animationDelegate respondsToSelector:@selector(flexibleHeaderView:didChangeTrackingScrollViewAnimated:)]) {
+    if ([self.animationDelegate respondsToSelector:@selector(flexibleHeaderView:
+                                                       didChangeTrackingScrollViewAnimated:)]) {
       [self.animationDelegate flexibleHeaderView:self didChangeTrackingScrollViewAnimated:animated];
     }
     [self fhv_updateLayout];
@@ -1581,8 +1582,11 @@ static BOOL isRunningiOS10_3OrAbove() {
 
   if (animated) {
     void (^completionWithDelegate)(BOOL) = ^(BOOL finished) {
-      if ([self.animationDelegate respondsToSelector:@selector(flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:)]) {
-        [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+      if ([self.animationDelegate
+              respondsToSelector:@selector
+              (flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:)]) {
+        [self.animationDelegate
+            flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
       }
       completion(finished);
     };

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1560,7 +1560,12 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   }
 
+  BOOL animated = wasTrackingScrollView && shouldAnimate;
+
   void (^animations)(void) = ^{
+    if ([self.animationDelegate respondsToSelector:@selector(flexibleHeaderView:didChangeTrackingScrollViewAnimated:)]) {
+      [self.animationDelegate flexibleHeaderView:self didChangeTrackingScrollViewAnimated:animated];
+    }
     [self fhv_updateLayout];
   };
   void (^completion)(BOOL) = ^(BOOL finished) {
@@ -1574,9 +1579,11 @@ static BOOL isRunningiOS10_3OrAbove() {
     }
   };
 
-  if (wasTrackingScrollView && shouldAnimate) {
+  if (animated) {
     void (^completionWithDelegate)(BOOL) = ^(BOOL finished) {
-      [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+      if ([self.animationDelegate respondsToSelector:@selector(flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:)]) {
+        [self.animationDelegate flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete:self];
+      }
       completion(finished);
     };
     if (self.allowShadowLayerFrameAnimationsWhenChangingTrackingScrollView) {

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
@@ -16,9 +16,9 @@ import XCTest
 import MaterialComponents.MaterialFlexibleHeader
 
 private class MockMDCFlexibleHeaderViewAnimationDelegate: NSObject, MDCFlexibleHeaderViewAnimationDelegate {
-  var didChangeAnimatedExpectation: XCTestExpectation?
-  var didChangeNotAnimatedExpectation: XCTestExpectation?
-  var didCompleteExpectation: XCTestExpectation?
+  let didChangeAnimatedExpectation: XCTestExpectation?
+  let didChangeNotAnimatedExpectation: XCTestExpectation?
+  let didCompleteExpectation: XCTestExpectation?
   init(didChangeAnimatedExpectation: XCTestExpectation?,
        didChangeNotAnimatedExpectation: XCTestExpectation?,
        didCompleteExpectation: XCTestExpectation?) {

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
@@ -118,7 +118,7 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
     wait(for: [didCompleteExpectation], timeout: 0.1)
   }
 
-  func testAnimationCallbackIsInvokedNotAnimatedWhenTheTrackingScrollViewIsChanged() {
+  func testAnimationCallbackIsInvokedWithAnimatedYesWhenTheTrackingScrollViewIsChanged() {
     // Given
     let fhv = MDCFlexibleHeaderView()
     fhv.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
@@ -142,7 +142,7 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
     window.layer.speed = 100000
     CATransaction.flush()
 
-    let didChangeAnimatedExpectation = expectation(description: "didComplete")
+    let didChangeAnimatedExpectation = expectation(description: "didChangeAnimated")
     let mockDelegate =
       MockMDCFlexibleHeaderViewAnimationDelegate(didChangeAnimatedExpectation: didChangeAnimatedExpectation,
                                                  didChangeNotAnimatedExpectation: nil,

--- a/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
+++ b/components/FlexibleHeader/tests/snapshot/FlexibleHeaderViewAnimationDelegateTests.swift
@@ -16,15 +16,32 @@ import XCTest
 import MaterialComponents.MaterialFlexibleHeader
 
 private class MockMDCFlexibleHeaderViewAnimationDelegate: NSObject, MDCFlexibleHeaderViewAnimationDelegate {
-  var didCompleteExpectation: XCTestExpectation
-  init(didCompleteExpectation: XCTestExpectation) {
+  var didChangeAnimatedExpectation: XCTestExpectation?
+  var didChangeNotAnimatedExpectation: XCTestExpectation?
+  var didCompleteExpectation: XCTestExpectation?
+  init(didChangeAnimatedExpectation: XCTestExpectation?,
+       didChangeNotAnimatedExpectation: XCTestExpectation?,
+       didCompleteExpectation: XCTestExpectation?) {
+    self.didChangeAnimatedExpectation = didChangeAnimatedExpectation
+    self.didChangeNotAnimatedExpectation = didChangeNotAnimatedExpectation
     self.didCompleteExpectation = didCompleteExpectation
 
     super.init()
   }
 
+  @objc
+  func flexibleHeaderView(_ flexibleHeaderView: MDCFlexibleHeaderView,
+                          didChangeTrackingScrollViewAnimated animated: Bool) {
+    if animated {
+      didChangeAnimatedExpectation?.fulfill()
+    } else {
+      didChangeNotAnimatedExpectation?.fulfill()
+    }
+  }
+
+  @objc
   func flexibleHeaderViewChangeTrackingScrollViewAnimationDidComplete(_ flexibleHeaderView: MDCFlexibleHeaderView) {
-    didCompleteExpectation.fulfill()
+    didCompleteExpectation?.fulfill()
   }
 }
 
@@ -48,8 +65,11 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
     window.layer.speed = 100000
     CATransaction.flush()
 
-    let mockDelegate = MockMDCFlexibleHeaderViewAnimationDelegate(didCompleteExpectation:
-        expectation(description: "didComplete"))
+    let didCompleteExpectation = expectation(description: "didComplete")
+    let mockDelegate =
+      MockMDCFlexibleHeaderViewAnimationDelegate(didChangeAnimatedExpectation: nil,
+                                                 didChangeNotAnimatedExpectation: nil,
+                                                 didCompleteExpectation: didCompleteExpectation)
     fhv.animationDelegate = mockDelegate
 
     // When
@@ -57,7 +77,7 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
 
     // Then
     let waiter = XCTWaiter()
-    let result = waiter.wait(for: [mockDelegate.didCompleteExpectation], timeout: 0.01)
+    let result = waiter.wait(for: [didCompleteExpectation], timeout: 0.01)
     XCTAssertEqual(result, .timedOut)
   }
 
@@ -83,8 +103,11 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
     window.layer.speed = 100000
     CATransaction.flush()
 
-    let mockDelegate = MockMDCFlexibleHeaderViewAnimationDelegate(didCompleteExpectation:
-        expectation(description: "didComplete"))
+    let didCompleteExpectation = expectation(description: "didComplete")
+    let mockDelegate =
+      MockMDCFlexibleHeaderViewAnimationDelegate(didChangeAnimatedExpectation: nil,
+                                                 didChangeNotAnimatedExpectation: nil,
+                                                 didCompleteExpectation: didCompleteExpectation)
     fhv.animationDelegate = mockDelegate
 
     // When
@@ -92,6 +115,44 @@ class FlexibleHeaderViewAnimationDelegateTests: XCTestCase {
     fhv.trackingScrollView = scrollView2
 
     // Then
-    wait(for: [mockDelegate.didCompleteExpectation], timeout: 0.1)
+    wait(for: [didCompleteExpectation], timeout: 0.1)
+  }
+
+  func testAnimationCallbackIsInvokedNotAnimatedWhenTheTrackingScrollViewIsChanged() {
+    // Given
+    let fhv = MDCFlexibleHeaderView()
+    fhv.frame = CGRect(x: 0, y: 0, width: 100, height: 0)
+    fhv.minMaxHeightIncludesSafeArea = false
+    fhv.sharedWithManyScrollViews = true
+    fhv.maximumHeight = 200
+    let scrollView1 = UIScrollView()
+    let scrollView2 = UIScrollView()
+    let largeScrollableArea = CGSize(width: fhv.frame.width, height: 1000)
+    scrollView1.contentSize = largeScrollableArea
+    scrollView2.contentSize = largeScrollableArea
+    // Fully expanded.
+    scrollView1.contentOffset = CGPoint(x: 0, y: -200)
+    // Fully collapsed.
+    scrollView2.contentOffset = CGPoint(x: 0, y: 300)
+    fhv.trackingScrollView = scrollView1
+
+    let window = UIWindow()
+    window.addSubview(fhv)
+    window.makeKeyAndVisible()
+    window.layer.speed = 100000
+    CATransaction.flush()
+
+    let didChangeAnimatedExpectation = expectation(description: "didComplete")
+    let mockDelegate =
+      MockMDCFlexibleHeaderViewAnimationDelegate(didChangeAnimatedExpectation: didChangeAnimatedExpectation,
+                                                 didChangeNotAnimatedExpectation: nil,
+                                                 didCompleteExpectation: nil)
+    fhv.animationDelegate = mockDelegate
+
+    // When
+    fhv.trackingScrollView = scrollView2
+
+    // Then
+    wait(for: [didChangeAnimatedExpectation], timeout: 0.1)
   }
 }


### PR DESCRIPTION
This change also makes all of the methods on MDCFlexibleHeaderViewAnimationDelegate optional so that APIs can be conditionally implemented as needed.

Closes https://github.com/material-components/material-components-ios/issues/8644