### PR TITLE
[AppBar] Add API to auto adjust height based on HeaderStackView for app bar.

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -36,6 +36,13 @@
  */
 @property(nonatomic, strong, nonnull) MDCHeaderStackView *headerStackView;
 
+/**
+ When this flag is set to NO, the flexible header behavior will be turned off. Which means the height of the app bar will be fixed to the sum of the top bar height and the bottom bar height.
+
+ Defaults to YES.
+*/
+@property(nonatomic) BOOL enableFlexibleHeader;
+
 @end
 
 #pragma mark - To be deprecated

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -40,6 +40,8 @@
  When this flag is set to YES, the height of the app bar will be automatically adjusted to the sum
  of the top bar height and the bottom bar height.
 
+ Enabling this property will disable `minMaxHeightIncludesSafeArea` on the flexible header view.
+
  Defaults to NO.
 */
 @property(nonatomic) BOOL shouldAdjustHeightBasedOnHeaderStackView;

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -37,7 +37,8 @@
 @property(nonatomic, strong, nonnull) MDCHeaderStackView *headerStackView;
 
 /**
- When this flag is set to NO, the flexible header behavior will be turned off. Which means the height of the app bar will be fixed to the sum of the top bar height and the bottom bar height.
+ When this flag is set to NO, the flexible header behavior will be turned off. Which means the
+ height of the app bar will be fixed to the sum of the top bar height and the bottom bar height.
 
  Defaults to YES.
 */

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -37,12 +37,12 @@
 @property(nonatomic, strong, nonnull) MDCHeaderStackView *headerStackView;
 
 /**
- When this flag is set to NO, the flexible header behavior will be turned off. Which means the
- height of the app bar will be fixed to the sum of the top bar height and the bottom bar height.
+ When this flag is set to YES, the height of the app bar will be automatically adjusted to the sum
+ of the top bar height and the bottom bar height.
 
- Defaults to YES.
+ Defaults to NO.
 */
-@property(nonatomic) BOOL enableFlexibleHeader;
+@property(nonatomic) BOOL shouldAdjustHeightBasedOnHeaderStackView;
 
 @end
 

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -293,8 +293,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 - (void)enforceHeaderViewMinMaxHeightToHeaderViewHeight {
   CGFloat heightSum = 0;
-  heightSum += [self.headerStackView.topBar sizeThatFits: self.view.frame.size].height;
-  heightSum += [self.headerStackView.bottomBar sizeThatFits: self.view.frame.size].height;
+  heightSum += [self.headerStackView.topBar sizeThatFits:self.view.frame.size].height;
+  heightSum += [self.headerStackView.bottomBar sizeThatFits:self.view.frame.size].height;
   self.headerView.minimumHeight = self.headerView.maximumHeight = heightSum;
 }
 

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -292,9 +292,10 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 - (void)adjustHeightBasedOnHeaderStackView {
   CGFloat heightSum = 0;
-  heightSum += [self.headerStackView.topBar sizeThatFits:self.view.frame.size].height;
-  heightSum += [self.headerStackView.bottomBar sizeThatFits:self.view.frame.size].height;
-  self.headerView.minimumHeight = self.headerView.maximumHeight = heightSum;
+  heightSum += [self.headerStackView.topBar sizeThatFits:self.view.bounds.size].height;
+  heightSum += [self.headerStackView.bottomBar sizeThatFits:self.view.bounds.size].height;
+  self.headerView.minimumHeight = heightSum;
+  self.headerView.maximumHeight = heightSum;
 }
 
 @end

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -70,6 +70,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
   self.headerStackView.translatesAutoresizingMaskIntoConstraints = NO;
   self.headerStackView.topBar = self.navigationBar;
+  self.enableFlexibleHeader = YES;
 }
 
 #pragma mark - Properties
@@ -147,6 +148,14 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   backBarButtonItem.accessibilityLabel = NSLocalizedStringFromTableInBundle(
       key, kMaterialAppBarStringsTableName, [[self class] bundle], @"Back");
   return backBarButtonItem;
+}
+
+- (void)setEnableFlexibleHeader:(BOOL)enableFlexibleHeader {
+  _enableFlexibleHeader = enableFlexibleHeader;
+  if (!enableFlexibleHeader) {
+    self.headerView.minMaxHeightIncludesSafeArea = NO;
+    [self enforceHeaderViewMinMaxHeightToHeaderViewHeight];
+  }
 }
 
 - (void)setInferTopSafeAreaInsetFromViewController:(BOOL)inferTopSafeAreaInsetFromViewController {
@@ -242,6 +251,10 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
     // height to make it smaller when the status bar is hidden.
     _verticalConstraint.constant = MDCDeviceTopSafeAreaInset();
   }
+
+  if (!self.enableFlexibleHeader) {
+    [self enforceHeaderViewMinMaxHeightToHeaderViewHeight];
+  }
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {
@@ -274,6 +287,15 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   } else {
     [pvc dismissViewControllerAnimated:YES completion:nil];
   }
+}
+
+#pragma mark - Private
+
+- (void)enforceHeaderViewMinMaxHeightToHeaderViewHeight {
+  CGFloat heightSum = 0;
+  heightSum += [self.headerStackView.topBar sizeThatFits: self.view.frame.size].height;
+  heightSum += [self.headerStackView.bottomBar sizeThatFits: self.view.frame.size].height;
+  self.headerView.minimumHeight = self.headerView.maximumHeight = heightSum;
 }
 
 @end

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -70,7 +70,6 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
   self.headerStackView.translatesAutoresizingMaskIntoConstraints = NO;
   self.headerStackView.topBar = self.navigationBar;
-  self.enableFlexibleHeader = YES;
 }
 
 #pragma mark - Properties
@@ -150,11 +149,11 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
   return backBarButtonItem;
 }
 
-- (void)setEnableFlexibleHeader:(BOOL)enableFlexibleHeader {
-  _enableFlexibleHeader = enableFlexibleHeader;
-  if (!enableFlexibleHeader) {
+- (void)setShouldAdjustHeightBasedOnHeaderStackView:(BOOL)shouldAdjustHeightBasedOnHeaderStackView {
+  _shouldAdjustHeightBasedOnHeaderStackView = shouldAdjustHeightBasedOnHeaderStackView;
+  if (shouldAdjustHeightBasedOnHeaderStackView) {
     self.headerView.minMaxHeightIncludesSafeArea = NO;
-    [self enforceHeaderViewMinMaxHeightToHeaderViewHeight];
+    [self adjustHeightBasedOnHeaderStackView];
   }
 }
 
@@ -252,8 +251,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
     _verticalConstraint.constant = MDCDeviceTopSafeAreaInset();
   }
 
-  if (!self.enableFlexibleHeader) {
-    [self enforceHeaderViewMinMaxHeightToHeaderViewHeight];
+  if (self.shouldAdjustHeightBasedOnHeaderStackView) {
+    [self adjustHeightBasedOnHeaderStackView];
   }
 }
 
@@ -291,7 +290,7 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 #pragma mark - Private
 
-- (void)enforceHeaderViewMinMaxHeightToHeaderViewHeight {
+- (void)adjustHeightBasedOnHeaderStackView {
   CGFloat heightSum = 0;
   heightSum += [self.headerStackView.topBar sizeThatFits:self.view.frame.size].height;
   heightSum += [self.headerStackView.bottomBar sizeThatFits:self.view.frame.size].height;

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -89,7 +89,7 @@
   XCTAssertTrue(blockCalled);
 }
 
-- (void)testEnableFlexibleHeaderSetToNOBehavior {
+- (void)testShouldAdjustHeightBasedOnHeaderStackViewSetToYES {
   // Given
   MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
   CGFloat navigationBarHeight =
@@ -98,7 +98,7 @@
   appBarController.headerStackView.bottomBar = bottomBar;
 
   // When
-  appBarController.enableFlexibleHeader = NO;
+  appBarController.shouldAdjustHeightBasedOnHeaderStackView = YES;
 
   // Then
   CGFloat minHeight = appBarController.headerView.minimumHeight;

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -89,4 +89,21 @@
   XCTAssertTrue(blockCalled);
 }
 
+- (void)testEnableFlexibleHeaderSetToNOBehavior {
+  // Given
+  MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
+  CGFloat navigationBarHeight = [appBarController.navigationBar intrinsicContentSize].height;
+  UIView *bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 200)];
+  appBarController.headerStackView.bottomBar = bottomBar;
+
+  // When
+  appBarController.enableFlexibleHeader = NO;
+
+  // Then
+  CGFloat minHeight = appBarController.headerView.minimumHeight;
+  CGFloat maxHeight = appBarController.headerView.maximumHeight;
+  XCTAssertEqual(minHeight, maxHeight);
+  XCTAssertEqualWithAccuracy(minHeight, 200 + navigationBarHeight, 0.01);
+}
+
 @end

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -92,7 +92,7 @@
 - (void)testEnableFlexibleHeaderSetToNOBehavior {
   // Given
   MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
-  CGFloat navigationBarHeight = [appBarController.navigationBar intrinsicContentSize].height;
+  CGFloat navigationBarHeight = [appBarController.navigationBar sizeThatFits:appBarController.headerView.frame.size].height;
   UIView *bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 200)];
   appBarController.headerStackView.bottomBar = bottomBar;
 

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -92,7 +92,8 @@
 - (void)testEnableFlexibleHeaderSetToNOBehavior {
   // Given
   MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
-  CGFloat navigationBarHeight = [appBarController.navigationBar sizeThatFits:appBarController.headerView.frame.size].height;
+  CGFloat navigationBarHeight =
+      [appBarController.navigationBar sizeThatFits:appBarController.headerView.frame.size].height;
   UIView *bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 200)];
   appBarController.headerStackView.bottomBar = bottomBar;
 

--- a/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/MDCAppBarViewControllerTests.m
@@ -94,7 +94,8 @@
   MDCAppBarViewController *appBarController = [[MDCAppBarViewController alloc] init];
   CGFloat navigationBarHeight =
       [appBarController.navigationBar sizeThatFits:appBarController.headerView.frame.size].height;
-  UIView *bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 200)];
+  CGFloat bottomBarHeight = 200;
+  UIView *bottomBar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, bottomBarHeight)];
   appBarController.headerStackView.bottomBar = bottomBar;
 
   // When
@@ -104,7 +105,7 @@
   CGFloat minHeight = appBarController.headerView.minimumHeight;
   CGFloat maxHeight = appBarController.headerView.maximumHeight;
   XCTAssertEqual(minHeight, maxHeight);
-  XCTAssertEqualWithAccuracy(minHeight, 200 + navigationBarHeight, 0.01);
+  XCTAssertEqualWithAccuracy(minHeight, bottomBarHeight + navigationBarHeight, 0.01);
 }
 
 @end


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/8677.

This API helps to reduce the complexity of calculating minimumHeight and maximumHeight on FlexibleHeader when user wants to update the app bar height based on header stack view.

This flag is required to be set during configuration stage. The reset behavior (turning back to NO) was not implemented because it would require adding API to minMaxHeight class and all configuration needs be to be set before flexible header is used. This feature can be added if needed.

