### PR TITLE
[Banner] update constraint when frame is changed.

### DIFF
--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -174,7 +174,6 @@ static NSString *const exampleSuperLongText =
   }
   self.bannerView.frame =
       CGRectMake(0.0f, topAreaInset, bannerViewSize.width, bannerViewSize.height);
-  [self.bannerView setNeedsUpdateConstraints];
 }
 
 #pragma mark - Internal helpers

--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -339,6 +339,12 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 
 #pragma mark - UIView overrides
 
+- (void)setFrame:(CGRect)frame {
+  [super setFrame:frame];
+
+  [self setNeedsUpdateConstraints];
+}
+
 - (CGSize)sizeThatFits:(CGSize)size {
   MDCBannerViewLayoutStyle layoutStyle = [self layoutStyleForSizeToFit:size];
   CGFloat frameHeight = 0.0f;


### PR DESCRIPTION
Because Banner needs to update constraints when there is a bound change, and when some view controller in the view hierarchy changes Banner's frame, it might forget to update constraint. Setting it in the frame setter would help making sure it is not missed.

Manually verified with examples. Snapshot doesn't change too.