### PR TITLE
[Dialogs] Remove usage of `buttonFont` in example

### DIFF
--- a/components/Dialogs/examples/DialogsTallTextAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsTallTextAlertExampleViewController.m
@@ -14,6 +14,7 @@
 
 #import <MaterialComponents/MaterialContainerScheme.h>
 #import <MaterialComponents/MaterialDialogs+Theming.h>
+#import "MDCAlertController+ButtonForAction.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
@@ -93,7 +94,10 @@
     dialogButtonFont = [UIFont fontWithName:urduFontName size:20.0];
   }
   alert.messageFont = dialogBodyFont;
-  alert.buttonFont = dialogButtonFont;
+  MDCButton *buttonForRetryAction = [alert buttonForAction:retryAction];
+  buttonForRetryAction.titleLabel.font = dialogButtonFont;
+  MDCButton *buttonForCancelAction = [alert buttonForAction:cancelAction];
+  buttonForCancelAction.titleLabel.font = dialogButtonFont;
 
   [self presentViewController:alert animated:YES completion:nil];
 }


### PR DESCRIPTION
The `buttonFont` API is deprecated within MDCAlertController. This change removes it's usage from the catalog example. This removal brings us closer to being able to delete the API.

## Screenshots

| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPhone 7 - 2019-11-11 at 10 31 29](https://user-images.githubusercontent.com/7131294/68611204-6ecc0700-046e-11ea-9b8b-fe6ca39f18ee.png)|![Simulator Screen Shot - iPhone 7 - 2019-11-11 at 10 22 36](https://user-images.githubusercontent.com/7131294/68611214-72f82480-046e-11ea-8b26-50c693d791c1.png)|



Related to #6637 