### PR TITLE
[TextControls] Add accessibilityLabel override to MDCBaseTextField

### DIFF
--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
+               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
+               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
+               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
                BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -84,7 +84,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BlueprintIdentifier = "2C63165AF80D4A62273720ED3CA4CFB9"
                BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -98,7 +98,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BlueprintIdentifier = "0354651EAEF4B2CABBA094A419C1DBAD"
                BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -112,7 +112,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA36F5CABC29BF4F91DA44204B9C3260"
+               BlueprintIdentifier = "89B723BC451D1DF9CA7DE0D9874C0D1D"
                BuildableName = "MaterialComponents-Unit-private-Icons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Icons-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -147,7 +147,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5AEABD73C978E231D0994587B4ACF0E1"
+               BlueprintIdentifier = "B4007B964B906502259A30F7E31A8AEF"
                BuildableName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -157,7 +157,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
+               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
                BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -167,7 +167,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B0A8024F093ADA9CC587BC090A4419AC"
+               BlueprintIdentifier = "F9A1C2C676D59A467CE625CC201AECD7"
                BuildableName = "MaterialComponents-Unit-ActivityIndicator-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActivityIndicator-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -177,7 +177,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "027EC1DCE82E80AD5CB428F3AD39E984"
+               BlueprintIdentifier = "8C46E47EB837574D5E196A3C581844C0"
                BuildableName = "MaterialComponents-Unit-AnimationTiming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AnimationTiming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -187,7 +187,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "01685AAF95CBA5141F9D3EA6BBE3F6BC"
+               BlueprintIdentifier = "D37ABB65F9E6B518263D31AFB3D087C2"
                BuildableName = "MaterialComponents-Unit-AppBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -197,7 +197,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3CF8C2598DC6D0BCB9945A3AD65F04B6"
+               BlueprintIdentifier = "94B3E58C44A700988ADE2A82BF33C9A9"
                BuildableName = "MaterialComponents-Unit-AppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -207,7 +207,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "03FA600006B7E2633E888EEF668E440C"
+               BlueprintIdentifier = "0D21D281D2C2BAB92899837B215F5450"
                BuildableName = "MaterialComponents-Unit-BottomAppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomAppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -217,7 +217,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "27A570C3560F017DFBA0E30DFB39517E"
+               BlueprintIdentifier = "BA2DD0920A9B3BB5FE27034EBFA62ABA"
                BuildableName = "MaterialComponents-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -227,7 +227,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F308FA69D1B592D4B533AE4C17612901"
+               BlueprintIdentifier = "80173564EC18CF366248DFC25163ED6B"
                BuildableName = "MaterialComponents-Unit-BottomSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -237,7 +237,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E83366297A43215B3B11A00FF810EFAF"
+               BlueprintIdentifier = "745B0D3392123254C65B9F418977041A"
                BuildableName = "MaterialComponents-Unit-ButtonBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ButtonBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -247,7 +247,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77C34355FC0CD1527B69ED2B007A7DD4"
+               BlueprintIdentifier = "43DCFEF96304B034C3664F305572ABD5"
                BuildableName = "MaterialComponents-Unit-Buttons+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -257,7 +257,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A71EAA04FB08E01EE3FAC73A2E95767F"
+               BlueprintIdentifier = "45D58D0961BC20F6D59C95F2C4F1FDA5"
                BuildableName = "MaterialComponents-Unit-Buttons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -267,7 +267,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5A4FC0F41A2DEB369D630388A554614F"
+               BlueprintIdentifier = "DD528C02CBDEFDE0F458DD2D6B1B4676"
                BuildableName = "MaterialComponents-Unit-Cards+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -277,7 +277,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "81C4EE9F6E002798282F33F8910D6ACB"
+               BlueprintIdentifier = "05810B57A981A5B06B768C24EEB8E7DB"
                BuildableName = "MaterialComponents-Unit-Cards-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -287,7 +287,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E5CF4CA83D5E81EF70FE005E6A8C8FEA"
+               BlueprintIdentifier = "0B7115667542383E0A99478310BA194D"
                BuildableName = "MaterialComponents-Unit-Chips+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -297,7 +297,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "19A6FEC8B2FB764ED6B5C90B84F56EBB"
+               BlueprintIdentifier = "EA9FAB6D74825D78CBF90D53164BB7FC"
                BuildableName = "MaterialComponents-Unit-Chips-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -307,7 +307,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "45FDA756DF5E703C196D4AB94261BD5B"
+               BlueprintIdentifier = "1D1B2FAA23E11B1893BDCD191E2F2FBA"
                BuildableName = "MaterialComponents-Unit-CollectionCells-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionCells-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -317,7 +317,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77CED09DA4CB77C956A8F549CBDA11A8"
+               BlueprintIdentifier = "41F2D6961E1E281C845A16F1C4FC18C8"
                BuildableName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -327,7 +327,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F4B8E12E2380F086C99D6CE2939B11E5"
+               BlueprintIdentifier = "FD92690A61F9B8339B2E406D4836688E"
                BuildableName = "MaterialComponents-Unit-Collections-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Collections-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -337,7 +337,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8B6D50BC877CBCEB53C3910BD4E8EF26"
+               BlueprintIdentifier = "6B7855B0186993EAABB1825E38EA7A6B"
                BuildableName = "MaterialComponents-Unit-Dialogs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -347,7 +347,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BD3536BF760F8AEEF8E9E04AEEB496E6"
+               BlueprintIdentifier = "16B54118DCADAB12E1C7971638192E70"
                BuildableName = "MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FeatureHighlight-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -357,7 +357,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "54DA72D929DF5C601614DEA46BF8BCBD"
+               BlueprintIdentifier = "919EA9C4B1DA0DCE8A22DA6AD6D22004"
                BuildableName = "MaterialComponents-Unit-FlexibleHeader-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FlexibleHeader-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -367,7 +367,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40538FB8F5280A29E587B2AC7FA19996"
+               BlueprintIdentifier = "DD96F0D40893D6684084982F979474AE"
                BuildableName = "MaterialComponents-Unit-HeaderStackView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-HeaderStackView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -377,7 +377,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "39534A756102CCEB20BCB47FA182E668"
+               BlueprintIdentifier = "EFD44542DBC0185BC0D566684BA50A6E"
                BuildableName = "MaterialComponents-Unit-Ink-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ink-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -387,7 +387,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F02FF61FFD3A802B2E6990E6B9EE5055"
+               BlueprintIdentifier = "9F58F86853D3E0FDDBA5631E1A35CA43"
                BuildableName = "MaterialComponents-Unit-LibraryInfo-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-LibraryInfo-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -397,7 +397,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "03427D937E6D8A8191170B67AE7889C9"
+               BlueprintIdentifier = "3E6CBB25095E0170DF57B0DD05CBC412"
                BuildableName = "MaterialComponents-Unit-List-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -407,17 +407,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "54E4A1F93A01EFD44DF2FE9F161F5432"
-               BuildableName = "MaterialComponents-Unit-MaskedTransition-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-MaskedTransition-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B4629C7878F9AFE418078795704416C5"
+               BlueprintIdentifier = "23FFE4D5F6492A6DC712F0AB717741D2"
                BuildableName = "MaterialComponents-Unit-NavigationBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -427,7 +417,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E3CBD9C1497A4E2DAAC98B2EAAA0479E"
+               BlueprintIdentifier = "14A620A56D2AD82F9273153203BD5EAF"
                BuildableName = "MaterialComponents-Unit-NavigationDrawer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationDrawer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -437,7 +427,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D170AD26DF679291AB1D74BB27AC7C8B"
+               BlueprintIdentifier = "CD081D1A63ACC6AC7A71F3F5556FD8AD"
                BuildableName = "MaterialComponents-Unit-OverlayWindow-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-OverlayWindow-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -447,7 +437,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EE6CF86481A77C792D90EFD206C1CECB"
+               BlueprintIdentifier = "E29E55A4639CE37E8FB3DDAC9B20194E"
                BuildableName = "MaterialComponents-Unit-PageControl-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-PageControl-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -457,7 +447,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D874218BA137CC6352E8E6E9332504FD"
+               BlueprintIdentifier = "D6EAEAC9D49B3CFED17B43BF62B01346"
                BuildableName = "MaterialComponents-Unit-Palettes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Palettes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -467,7 +457,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "11781C83418AE7B8585083ED3C25C17F"
+               BlueprintIdentifier = "53F0D8C581B4758659FD35C94EB31E13"
                BuildableName = "MaterialComponents-Unit-ProgressView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -477,7 +467,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E55985B3B36899547E3DAD57139D837"
+               BlueprintIdentifier = "02F2617D094EB7169C123E283AA13B67"
                BuildableName = "MaterialComponents-Unit-Ripple-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ripple-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -487,7 +477,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40DF556CD433DD58174A388CB98720BA"
+               BlueprintIdentifier = "BE98BC65FA9999766C2E69A304C35FF2"
                BuildableName = "MaterialComponents-Unit-ShadowElevations-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowElevations-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -497,7 +487,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63BECCA23B5C7169DC15BE5A873A72DE"
+               BlueprintIdentifier = "F1E296B410A2D87309640290B20388D2"
                BuildableName = "MaterialComponents-Unit-ShadowLayer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowLayer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -507,7 +497,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "39710615DB72A2B845D5C1FAE318B3FD"
+               BlueprintIdentifier = "E0C04DEA8AC278158FBE4D9257F931E3"
                BuildableName = "MaterialComponents-Unit-ShapeLibrary-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShapeLibrary-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -517,7 +507,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A3B3E8A72DCB2CA75D4911B5D2451F50"
+               BlueprintIdentifier = "1D03AA9B31017661DD29289E59523231"
                BuildableName = "MaterialComponents-Unit-Shapes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Shapes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -527,7 +517,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A458D45BCEE7FA0DDDA98F1CDE6DF9CC"
+               BlueprintIdentifier = "01E9D9C6A91BEF14E7D80A62F4FAA5FA"
                BuildableName = "MaterialComponents-Unit-Slider-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Slider-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -537,7 +527,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD00D81B63E0194EE3564DE3ACE5C85E"
+               BlueprintIdentifier = "AB33E94F75E49ED1F52E2D0DBCC4D2CB"
                BuildableName = "MaterialComponents-Unit-Snackbar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Snackbar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -547,7 +537,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2E7D3177D716EEC8BDDA94E73594540"
+               BlueprintIdentifier = "677E70310D5DAC22ECBB5BA8BB191675"
                BuildableName = "MaterialComponents-Unit-Tabs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -557,7 +547,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ECB402E3778D6604B67D9334F798E2F0"
+               BlueprintIdentifier = "65C7EC9341922173CB5AEC619C857BFE"
                BuildableName = "MaterialComponents-Unit-Tabs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -567,7 +557,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B50EEF945A805597D167E9A4A2BF40E1"
+               BlueprintIdentifier = "C6A23C8B5908FD78FE34A67729C2963A"
                BuildableName = "MaterialComponents-Unit-TextFields+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -577,7 +567,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9DA1A0A583AD4899700804119FFD82FD"
+               BlueprintIdentifier = "9F61A38CA52D206DF08D9E5D94647280"
                BuildableName = "MaterialComponents-Unit-TextFields-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -587,7 +577,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "284C1435D749967DBB39C2C7BEEC913D"
+               BlueprintIdentifier = "0CB893291E1B4FC20AC7FDDAD0A68D43"
                BuildableName = "MaterialComponents-Unit-Themes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Themes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -597,7 +587,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6D6C1C5C03CAFD5D168FAB91261516D7"
+               BlueprintIdentifier = "37E1456A86A5A28FD3D831E9AB71F5BC"
                BuildableName = "MaterialComponents-Unit-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -607,7 +597,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8F3FD7328015DC98B8037E7FFF518448"
+               BlueprintIdentifier = "B07C48452F3391E69111165EB171C4C9"
                BuildableName = "MaterialComponents-Unit-private-Application-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Application-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -617,7 +607,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B806406D612E43DCE5A95FEEA92EC974"
+               BlueprintIdentifier = "C7628DA70B1BCEC947183B38BE5ECD17"
                BuildableName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -627,7 +617,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B0715BE751696065197E7B132CF798F"
+               BlueprintIdentifier = "F01DD0A685E0FD0FC0C7D8D74F0F0D15"
                BuildableName = "MaterialComponents-Unit-private-Math-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Math-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -637,7 +627,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CB469A2460E3EB8813D9C7F41CEE2CBE"
+               BlueprintIdentifier = "2CCB248F91C25755FA45D758D56FC4D2"
                BuildableName = "MaterialComponents-Unit-private-Overlay-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Overlay-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -647,7 +637,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1696A1FD72898E5DC7DA0796EB5316E1"
+               BlueprintIdentifier = "9D52CDF22F9BD517B5E19353CF9F7F19"
                BuildableName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -657,7 +647,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9AFC701DBAF2EF24708C16FEEBD31375"
+               BlueprintIdentifier = "EDA533AD1F1B185ED1F39DCB9D1E1853"
                BuildableName = "MaterialComponents-Unit-private-UIMetrics-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-UIMetrics-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -667,7 +657,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4ACBFD51FB960AC748AEB19DF9674935"
+               BlueprintIdentifier = "67D836C778895EBC6E55636E4F918DD1"
                BuildableName = "MaterialComponents-Unit-schemes-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -677,7 +667,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B44ED38F9D474CF38FADA04FDF5D2690"
+               BlueprintIdentifier = "3CA10DECBC9881C3CF8CECC909A2C10B"
                BuildableName = "MaterialComponents-Unit-schemes-Container-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Container-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -687,7 +677,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C748C221DF64CED78C87F098E988341D"
+               BlueprintIdentifier = "9D30DFB4194781852526722245FD987E"
                BuildableName = "MaterialComponents-Unit-schemes-Shape-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Shape-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -697,7 +687,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7155239C0BF2B487269FB421906F7B92"
+               BlueprintIdentifier = "058FCCE5EAAE9D3A4AF5D2C3C8F3462A"
                BuildableName = "MaterialComponents-Unit-schemes-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -707,7 +697,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
+               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -717,7 +707,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
+               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -727,7 +717,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "88EDC6F080DD13A85C457E8DF3D5680A"
+               BlueprintIdentifier = "ACE8F8377BC344DD26C128FBE324B08E"
                BuildableName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -737,7 +727,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1407E65B882514BA19258E4E7E2CD8E7"
+               BlueprintIdentifier = "3EF1C285419E755C019EC7F5334722D6"
                BuildableName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -747,7 +737,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653B6FE35A1B4CDC5CA7D92E67DF97A6"
+               BlueprintIdentifier = "94C1D3154090898637E0243EBB10377B"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -757,7 +747,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BEFB959C8B8734803945286E9C2346C5"
+               BlueprintIdentifier = "7F8F825884AA0C4686D14359DF4344AB"
                BuildableName = "MaterialComponents-Unit-List+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -767,7 +757,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CCD06113384824F0016FA0CF5D813CF6"
+               BlueprintIdentifier = "8C8DCDF159BDAF73E764F62FE202514D"
                BuildableName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -777,7 +767,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BD5BBE89295C3C6B3C801FCC69091C85"
+               BlueprintIdentifier = "F42EF0E7EEE873B8FD4CEB200A146CD5"
                BuildableName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -787,7 +777,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4DA89912E26C1D30834DA796EADFD68E"
+               BlueprintIdentifier = "80FDCBA97111C2F0E5D54C41D9C997FC"
                BuildableName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -797,7 +787,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8E9B17CEB9CECE59A5FEEB2347DF98BE"
+               BlueprintIdentifier = "A207417F15F963263F5D6F3BAB63C75A"
                BuildableName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -807,17 +797,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6D639A36C9D1FE04FD788429B31BD983"
-               BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "46A0CD17FDDAF1CACABA145E5854C52A"
+               BlueprintIdentifier = "0184BB648CA66A248247C2228748118B"
                BuildableName = "MaterialComponents-Unit-Elevation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Elevation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -827,7 +807,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E59EBFC9F0205AB50A9355945690F57C"
+               BlueprintIdentifier = "41A5C3CA19A72E9A7972D4A10AAB39E9"
                BuildableName = "MaterialComponents-Unit-private-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -837,7 +817,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BlueprintIdentifier = "2C63165AF80D4A62273720ED3CA4CFB9"
                BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -847,7 +827,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BlueprintIdentifier = "0354651EAEF4B2CABBA094A419C1DBAD"
                BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -857,9 +837,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA36F5CABC29BF4F91DA44204B9C3260"
+               BlueprintIdentifier = "89B723BC451D1DF9CA7DE0D9874C0D1D"
                BuildableName = "MaterialComponents-Unit-private-Icons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Icons-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F6A00750AE102113B1F787ADEAE3026F"
+               BuildableName = "MaterialComponents-Unit-TextControls-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
+               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
+               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BlueprintIdentifier = "2C63165AF80D4A62273720ED3CA4CFB9"
                BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -70,7 +70,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BlueprintIdentifier = "0354651EAEF4B2CABBA094A419C1DBAD"
                BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -84,7 +84,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA36F5CABC29BF4F91DA44204B9C3260"
+               BlueprintIdentifier = "89B723BC451D1DF9CA7DE0D9874C0D1D"
                BuildableName = "MaterialComponents-Unit-private-Icons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Icons-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -118,7 +118,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5AEABD73C978E231D0994587B4ACF0E1"
+               BlueprintIdentifier = "B4007B964B906502259A30F7E31A8AEF"
                BuildableName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -128,7 +128,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DC25A5F5327A7ED56ADE6B4CD0B2EB5"
+               BlueprintIdentifier = "0F32E70FA07BF0B93ADEC8AC71B958CF"
                BuildableName = "MaterialComponents-Unit-ActionSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActionSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -138,7 +138,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B0A8024F093ADA9CC587BC090A4419AC"
+               BlueprintIdentifier = "F9A1C2C676D59A467CE625CC201AECD7"
                BuildableName = "MaterialComponents-Unit-ActivityIndicator-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ActivityIndicator-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -148,7 +148,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "027EC1DCE82E80AD5CB428F3AD39E984"
+               BlueprintIdentifier = "8C46E47EB837574D5E196A3C581844C0"
                BuildableName = "MaterialComponents-Unit-AnimationTiming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AnimationTiming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -158,7 +158,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "01685AAF95CBA5141F9D3EA6BBE3F6BC"
+               BlueprintIdentifier = "D37ABB65F9E6B518263D31AFB3D087C2"
                BuildableName = "MaterialComponents-Unit-AppBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -168,7 +168,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3CF8C2598DC6D0BCB9945A3AD65F04B6"
+               BlueprintIdentifier = "94B3E58C44A700988ADE2A82BF33C9A9"
                BuildableName = "MaterialComponents-Unit-AppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-AppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -178,7 +178,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "03FA600006B7E2633E888EEF668E440C"
+               BlueprintIdentifier = "0D21D281D2C2BAB92899837B215F5450"
                BuildableName = "MaterialComponents-Unit-BottomAppBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomAppBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -188,7 +188,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "27A570C3560F017DFBA0E30DFB39517E"
+               BlueprintIdentifier = "BA2DD0920A9B3BB5FE27034EBFA62ABA"
                BuildableName = "MaterialComponents-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -198,7 +198,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F308FA69D1B592D4B533AE4C17612901"
+               BlueprintIdentifier = "80173564EC18CF366248DFC25163ED6B"
                BuildableName = "MaterialComponents-Unit-BottomSheet-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomSheet-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -208,7 +208,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E83366297A43215B3B11A00FF810EFAF"
+               BlueprintIdentifier = "745B0D3392123254C65B9F418977041A"
                BuildableName = "MaterialComponents-Unit-ButtonBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ButtonBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -218,7 +218,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77C34355FC0CD1527B69ED2B007A7DD4"
+               BlueprintIdentifier = "43DCFEF96304B034C3664F305572ABD5"
                BuildableName = "MaterialComponents-Unit-Buttons+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -228,7 +228,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A71EAA04FB08E01EE3FAC73A2E95767F"
+               BlueprintIdentifier = "45D58D0961BC20F6D59C95F2C4F1FDA5"
                BuildableName = "MaterialComponents-Unit-Buttons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Buttons-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -238,7 +238,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5A4FC0F41A2DEB369D630388A554614F"
+               BlueprintIdentifier = "DD528C02CBDEFDE0F458DD2D6B1B4676"
                BuildableName = "MaterialComponents-Unit-Cards+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -248,7 +248,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "81C4EE9F6E002798282F33F8910D6ACB"
+               BlueprintIdentifier = "05810B57A981A5B06B768C24EEB8E7DB"
                BuildableName = "MaterialComponents-Unit-Cards-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Cards-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -258,7 +258,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E5CF4CA83D5E81EF70FE005E6A8C8FEA"
+               BlueprintIdentifier = "0B7115667542383E0A99478310BA194D"
                BuildableName = "MaterialComponents-Unit-Chips+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -268,7 +268,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "19A6FEC8B2FB764ED6B5C90B84F56EBB"
+               BlueprintIdentifier = "EA9FAB6D74825D78CBF90D53164BB7FC"
                BuildableName = "MaterialComponents-Unit-Chips-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Chips-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -278,7 +278,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "45FDA756DF5E703C196D4AB94261BD5B"
+               BlueprintIdentifier = "1D1B2FAA23E11B1893BDCD191E2F2FBA"
                BuildableName = "MaterialComponents-Unit-CollectionCells-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionCells-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -288,7 +288,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77CED09DA4CB77C956A8F549CBDA11A8"
+               BlueprintIdentifier = "41F2D6961E1E281C845A16F1C4FC18C8"
                BuildableName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-CollectionLayoutAttributes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -298,7 +298,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F4B8E12E2380F086C99D6CE2939B11E5"
+               BlueprintIdentifier = "FD92690A61F9B8339B2E406D4836688E"
                BuildableName = "MaterialComponents-Unit-Collections-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Collections-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -308,7 +308,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8B6D50BC877CBCEB53C3910BD4E8EF26"
+               BlueprintIdentifier = "6B7855B0186993EAABB1825E38EA7A6B"
                BuildableName = "MaterialComponents-Unit-Dialogs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -318,7 +318,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BD3536BF760F8AEEF8E9E04AEEB496E6"
+               BlueprintIdentifier = "16B54118DCADAB12E1C7971638192E70"
                BuildableName = "MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FeatureHighlight-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -328,7 +328,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "54DA72D929DF5C601614DEA46BF8BCBD"
+               BlueprintIdentifier = "919EA9C4B1DA0DCE8A22DA6AD6D22004"
                BuildableName = "MaterialComponents-Unit-FlexibleHeader-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-FlexibleHeader-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -338,7 +338,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40538FB8F5280A29E587B2AC7FA19996"
+               BlueprintIdentifier = "DD96F0D40893D6684084982F979474AE"
                BuildableName = "MaterialComponents-Unit-HeaderStackView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-HeaderStackView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -348,7 +348,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "39534A756102CCEB20BCB47FA182E668"
+               BlueprintIdentifier = "EFD44542DBC0185BC0D566684BA50A6E"
                BuildableName = "MaterialComponents-Unit-Ink-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ink-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -358,7 +358,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F02FF61FFD3A802B2E6990E6B9EE5055"
+               BlueprintIdentifier = "9F58F86853D3E0FDDBA5631E1A35CA43"
                BuildableName = "MaterialComponents-Unit-LibraryInfo-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-LibraryInfo-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -368,7 +368,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "03427D937E6D8A8191170B67AE7889C9"
+               BlueprintIdentifier = "3E6CBB25095E0170DF57B0DD05CBC412"
                BuildableName = "MaterialComponents-Unit-List-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -378,17 +378,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "54E4A1F93A01EFD44DF2FE9F161F5432"
-               BuildableName = "MaterialComponents-Unit-MaskedTransition-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-MaskedTransition-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B4629C7878F9AFE418078795704416C5"
+               BlueprintIdentifier = "23FFE4D5F6492A6DC712F0AB717741D2"
                BuildableName = "MaterialComponents-Unit-NavigationBar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationBar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -398,7 +388,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E3CBD9C1497A4E2DAAC98B2EAAA0479E"
+               BlueprintIdentifier = "14A620A56D2AD82F9273153203BD5EAF"
                BuildableName = "MaterialComponents-Unit-NavigationDrawer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-NavigationDrawer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -408,7 +398,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D170AD26DF679291AB1D74BB27AC7C8B"
+               BlueprintIdentifier = "CD081D1A63ACC6AC7A71F3F5556FD8AD"
                BuildableName = "MaterialComponents-Unit-OverlayWindow-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-OverlayWindow-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -418,7 +408,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EE6CF86481A77C792D90EFD206C1CECB"
+               BlueprintIdentifier = "E29E55A4639CE37E8FB3DDAC9B20194E"
                BuildableName = "MaterialComponents-Unit-PageControl-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-PageControl-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -428,7 +418,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D874218BA137CC6352E8E6E9332504FD"
+               BlueprintIdentifier = "D6EAEAC9D49B3CFED17B43BF62B01346"
                BuildableName = "MaterialComponents-Unit-Palettes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Palettes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -438,7 +428,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "11781C83418AE7B8585083ED3C25C17F"
+               BlueprintIdentifier = "53F0D8C581B4758659FD35C94EB31E13"
                BuildableName = "MaterialComponents-Unit-ProgressView-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -448,7 +438,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E55985B3B36899547E3DAD57139D837"
+               BlueprintIdentifier = "02F2617D094EB7169C123E283AA13B67"
                BuildableName = "MaterialComponents-Unit-Ripple-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Ripple-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -458,7 +448,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40DF556CD433DD58174A388CB98720BA"
+               BlueprintIdentifier = "BE98BC65FA9999766C2E69A304C35FF2"
                BuildableName = "MaterialComponents-Unit-ShadowElevations-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowElevations-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -468,7 +458,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63BECCA23B5C7169DC15BE5A873A72DE"
+               BlueprintIdentifier = "F1E296B410A2D87309640290B20388D2"
                BuildableName = "MaterialComponents-Unit-ShadowLayer-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShadowLayer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -478,7 +468,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "39710615DB72A2B845D5C1FAE318B3FD"
+               BlueprintIdentifier = "E0C04DEA8AC278158FBE4D9257F931E3"
                BuildableName = "MaterialComponents-Unit-ShapeLibrary-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ShapeLibrary-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -488,7 +478,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A3B3E8A72DCB2CA75D4911B5D2451F50"
+               BlueprintIdentifier = "1D03AA9B31017661DD29289E59523231"
                BuildableName = "MaterialComponents-Unit-Shapes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Shapes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -498,7 +488,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A458D45BCEE7FA0DDDA98F1CDE6DF9CC"
+               BlueprintIdentifier = "01E9D9C6A91BEF14E7D80A62F4FAA5FA"
                BuildableName = "MaterialComponents-Unit-Slider-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Slider-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -508,7 +498,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DD00D81B63E0194EE3564DE3ACE5C85E"
+               BlueprintIdentifier = "AB33E94F75E49ED1F52E2D0DBCC4D2CB"
                BuildableName = "MaterialComponents-Unit-Snackbar-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Snackbar-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -518,7 +508,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2E7D3177D716EEC8BDDA94E73594540"
+               BlueprintIdentifier = "677E70310D5DAC22ECBB5BA8BB191675"
                BuildableName = "MaterialComponents-Unit-Tabs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -528,7 +518,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ECB402E3778D6604B67D9334F798E2F0"
+               BlueprintIdentifier = "65C7EC9341922173CB5AEC619C857BFE"
                BuildableName = "MaterialComponents-Unit-Tabs-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Tabs-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -538,7 +528,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B50EEF945A805597D167E9A4A2BF40E1"
+               BlueprintIdentifier = "C6A23C8B5908FD78FE34A67729C2963A"
                BuildableName = "MaterialComponents-Unit-TextFields+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -548,7 +538,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9DA1A0A583AD4899700804119FFD82FD"
+               BlueprintIdentifier = "9F61A38CA52D206DF08D9E5D94647280"
                BuildableName = "MaterialComponents-Unit-TextFields-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextFields-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -558,7 +548,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "284C1435D749967DBB39C2C7BEEC913D"
+               BlueprintIdentifier = "0CB893291E1B4FC20AC7FDDAD0A68D43"
                BuildableName = "MaterialComponents-Unit-Themes-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Themes-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -568,7 +558,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6D6C1C5C03CAFD5D168FAB91261516D7"
+               BlueprintIdentifier = "37E1456A86A5A28FD3D831E9AB71F5BC"
                BuildableName = "MaterialComponents-Unit-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -578,7 +568,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8F3FD7328015DC98B8037E7FFF518448"
+               BlueprintIdentifier = "B07C48452F3391E69111165EB171C4C9"
                BuildableName = "MaterialComponents-Unit-private-Application-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Application-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -588,7 +578,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B806406D612E43DCE5A95FEEA92EC974"
+               BlueprintIdentifier = "C7628DA70B1BCEC947183B38BE5ECD17"
                BuildableName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-KeyboardWatcher-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -598,7 +588,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B0715BE751696065197E7B132CF798F"
+               BlueprintIdentifier = "F01DD0A685E0FD0FC0C7D8D74F0F0D15"
                BuildableName = "MaterialComponents-Unit-private-Math-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Math-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -608,7 +598,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CB469A2460E3EB8813D9C7F41CEE2CBE"
+               BlueprintIdentifier = "2CCB248F91C25755FA45D758D56FC4D2"
                BuildableName = "MaterialComponents-Unit-private-Overlay-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Overlay-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -618,7 +608,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1696A1FD72898E5DC7DA0796EB5316E1"
+               BlueprintIdentifier = "9D52CDF22F9BD517B5E19353CF9F7F19"
                BuildableName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-ThumbTrack-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -628,7 +618,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9AFC701DBAF2EF24708C16FEEBD31375"
+               BlueprintIdentifier = "EDA533AD1F1B185ED1F39DCB9D1E1853"
                BuildableName = "MaterialComponents-Unit-private-UIMetrics-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-UIMetrics-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -638,7 +628,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4ACBFD51FB960AC748AEB19DF9674935"
+               BlueprintIdentifier = "67D836C778895EBC6E55636E4F918DD1"
                BuildableName = "MaterialComponents-Unit-schemes-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -648,7 +638,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B44ED38F9D474CF38FADA04FDF5D2690"
+               BlueprintIdentifier = "3CA10DECBC9881C3CF8CECC909A2C10B"
                BuildableName = "MaterialComponents-Unit-schemes-Container-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Container-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -658,7 +648,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C748C221DF64CED78C87F098E988341D"
+               BlueprintIdentifier = "9D30DFB4194781852526722245FD987E"
                BuildableName = "MaterialComponents-Unit-schemes-Shape-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Shape-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -668,7 +658,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7155239C0BF2B487269FB421906F7B92"
+               BlueprintIdentifier = "058FCCE5EAAE9D3A4AF5D2C3C8F3462A"
                BuildableName = "MaterialComponents-Unit-schemes-Typography-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-schemes-Typography-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -678,7 +668,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E2E7CBF5A69F7357CB0E4A1EE2BE49F"
+               BlueprintIdentifier = "1E1A299BF41220A754196C9D68FB777D"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ActionSheetThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -688,7 +678,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A06F5C7178C1AD9F7A3741EC0D78BD34"
+               BlueprintIdentifier = "5F38DAB659843F3A8410C1286BE3F25E"
                BuildableName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ActionSheet+ColorThemer-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -698,7 +688,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "88EDC6F080DD13A85C457E8DF3D5680A"
+               BlueprintIdentifier = "ACE8F8377BC344DD26C128FBE324B08E"
                BuildableName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-BottomNavigation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -708,7 +698,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1407E65B882514BA19258E4E7E2CD8E7"
+               BlueprintIdentifier = "3EF1C285419E755C019EC7F5334722D6"
                BuildableName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-ButtonBar+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -718,7 +708,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653B6FE35A1B4CDC5CA7D92E67DF97A6"
+               BlueprintIdentifier = "94C1D3154090898637E0243EBB10377B"
                BuildableName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests.xctest"
                BlueprintName = "MaterialComponentsSnapshotTests-Unit-SnapshotTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -728,7 +718,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BEFB959C8B8734803945286E9C2346C5"
+               BlueprintIdentifier = "7F8F825884AA0C4686D14359DF4344AB"
                BuildableName = "MaterialComponents-Unit-List+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-List+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -738,7 +728,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CCD06113384824F0016FA0CF5D813CF6"
+               BlueprintIdentifier = "8C8DCDF159BDAF73E764F62FE202514D"
                BuildableName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Dialogs+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -748,7 +738,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BD5BBE89295C3C6B3C801FCC69091C85"
+               BlueprintIdentifier = "F42EF0E7EEE873B8FD4CEB200A146CD5"
                BuildableName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests.xctest"
                BlueprintName = "MaterialComponentsBeta-Unit-Tabs+TabBarView-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -758,7 +748,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4DA89912E26C1D30834DA796EADFD68E"
+               BlueprintIdentifier = "80FDCBA97111C2F0E5D54C41D9C997FC"
                BuildableName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-BottomNavigation+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -768,7 +758,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8E9B17CEB9CECE59A5FEEB2347DF98BE"
+               BlueprintIdentifier = "A207417F15F963263F5D6F3BAB63C75A"
                BuildableName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-ProgressView+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -778,17 +768,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6D639A36C9D1FE04FD788429B31BD983"
-               BuildableName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextFields+ContainedInputView-UnitTests"
-               ReferencedContainer = "container:Pods/Pods.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E59EBFC9F0205AB50A9355945690F57C"
+               BlueprintIdentifier = "41A5C3CA19A72E9A7972D4A10AAB39E9"
                BuildableName = "MaterialComponents-Unit-private-Color-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Color-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -798,7 +778,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "46A0CD17FDDAF1CACABA145E5854C52A"
+               BlueprintIdentifier = "0184BB648CA66A248247C2228748118B"
                BuildableName = "MaterialComponents-Unit-Elevation-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Elevation-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -808,7 +788,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AAA381376329BEB66C521836F8D7E598"
+               BlueprintIdentifier = "2C63165AF80D4A62273720ED3CA4CFB9"
                BuildableName = "MaterialComponents-Unit-Banner+Theming-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner+Theming-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -818,7 +798,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A432BC84C829B1F2A68FA667BE55990E"
+               BlueprintIdentifier = "0354651EAEF4B2CABBA094A419C1DBAD"
                BuildableName = "MaterialComponents-Unit-Banner-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-Banner-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -828,9 +808,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA36F5CABC29BF4F91DA44204B9C3260"
+               BlueprintIdentifier = "89B723BC451D1DF9CA7DE0D9874C0D1D"
                BuildableName = "MaterialComponents-Unit-private-Icons-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-private-Icons-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F6A00750AE102113B1F787ADEAE3026F"
+               BuildableName = "MaterialComponents-Unit-TextControls-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/components/TextControls/src/MDCBaseTextField.h
+++ b/components/TextControls/src/MDCBaseTextField.h
@@ -150,7 +150,7 @@
 @interface MDCBaseTextField (UIAccessibility)
 
 /**
- If accessibilityLabel is not set, this value will be a concatenation of any @c label text, @c
+ If @c accessibilityLabel is not set, this value will be a concatenation of any @c label text, @c
  leadingAssistiveLabel text, and @c trailingAssistiveLabel text.
  */
 @property(nullable, nonatomic, copy) NSString *accessibilityLabel;

--- a/components/TextControls/src/MDCBaseTextField.h
+++ b/components/TextControls/src/MDCBaseTextField.h
@@ -146,3 +146,13 @@
 - (nonnull UIColor *)trailingAssistiveLabelColorForState:(MDCTextControlState)state;
 
 @end
+
+@interface MDCBaseTextField (UIAccessibility)
+
+/**
+ If accessibilityLabel is not set, this value will be a concatenation of any @c label text, @c
+ leadingAssistiveLabel text, and @c trailingAssistiveLabel text.
+ */
+@property(nullable, nonatomic, copy) NSString *accessibilityLabel;
+
+@end

--- a/components/TextControls/src/MDCBaseTextField.m
+++ b/components/TextControls/src/MDCBaseTextField.m
@@ -680,7 +680,12 @@
   if (self.trailingAssistiveLabel.text.length > 0) {
     [accessibilityLabelComponents addObject:self.trailingAssistiveLabel.text];
   }
-  return [accessibilityLabelComponents componentsJoinedByString:@", "];
+
+  if (accessibilityLabelComponents.count > 0) {
+    return [accessibilityLabelComponents componentsJoinedByString:@", "];
+  }
+
+  return nil;
 }
 
 #pragma mark Color Accessors

--- a/components/TextControls/src/MDCBaseTextField.m
+++ b/components/TextControls/src/MDCBaseTextField.m
@@ -662,6 +662,27 @@
   return colorViewModel;
 }
 
+#pragma mark Accessibility Overrides
+
+- (NSString *)accessibilityLabel {
+  NSString *superAccessibilityLabel = [super accessibilityLabel];
+  if (superAccessibilityLabel.length > 0) {
+    return superAccessibilityLabel;
+  }
+
+  NSMutableArray *accessibilityLabelComponents = [NSMutableArray new];
+  if (self.label.text.length > 0) {
+    [accessibilityLabelComponents addObject:self.label.text];
+  }
+  if (self.leadingAssistiveLabel.text.length > 0) {
+    [accessibilityLabelComponents addObject:self.leadingAssistiveLabel.text];
+  }
+  if (self.trailingAssistiveLabel.text.length > 0) {
+    [accessibilityLabelComponents addObject:self.trailingAssistiveLabel.text];
+  }
+  return [accessibilityLabelComponents componentsJoinedByString:@", "];
+}
+
 #pragma mark Color Accessors
 
 - (void)setNormalLabelColor:(nonnull UIColor *)labelColor forState:(MDCTextControlState)state {

--- a/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
@@ -338,7 +338,77 @@
                                      labelState:MDCTextControlLabelStateFloating]);
 }
 
-- (void)testDefaultAccessibilityLabel {
+- (void)testDefaultAccessibilityLabelWithOnlyLabelText {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *labelText = @"label text";
+
+  // When
+  textField.label.text = labelText;
+
+  // Then
+  XCTAssertTrue([labelText isEqualToString:textField.accessibilityLabel]);
+}
+
+- (void)testDefaultAccessibilityLabelWithLeadingAssistiveLabelText {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *leadingAssistiveLabelText = @"leading assistive label text";
+
+  // When
+  textField.leadingAssistiveLabel.text = leadingAssistiveLabelText;
+
+  // Then
+  XCTAssertTrue(
+      [textField.leadingAssistiveLabel.text isEqualToString:textField.accessibilityLabel]);
+}
+
+- (void)testDefaultAccessibilityLabelWithTrailingAssistiveLabelText {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *trailingAssistiveLabelText = @"trailing assistive label text";
+
+  // When
+  textField.trailingAssistiveLabel.text = trailingAssistiveLabelText;
+
+  // Then
+  XCTAssertTrue(
+      [textField.trailingAssistiveLabel.text isEqualToString:textField.accessibilityLabel]);
+}
+
+- (void)testDefaultAccessibilityLabelWithTextSetOnEveryLabel {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *labelText = @"label text";
+  NSString *leadingAssistiveLabelText = @"leading assistive label text";
+  NSString *trailingAssistiveLabelText = @"trailing assistive label text";
+
+  // When
+  textField.label.text = labelText;
+  textField.leadingAssistiveLabel.text = leadingAssistiveLabelText;
+  textField.trailingAssistiveLabel.text = trailingAssistiveLabelText;
+
+  // Then
+  NSString *concatenatedText =
+      [NSString stringWithFormat:@"%@, %@, %@", labelText, leadingAssistiveLabelText,
+                                 trailingAssistiveLabelText];
+  XCTAssertTrue([concatenatedText isEqualToString:textField.accessibilityLabel]);
+}
+
+- (void)testDefaultAccessibilityLabelWithNoLabelText {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+
+  // Then
+  XCTAssertNil(textField.accessibilityLabel);
+}
+
+- (void)testDefaultAccessibilityLabelWithLabelTextAndLeadingAssistiveLabelText {
   // Given
   CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
   MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
@@ -361,12 +431,12 @@
   MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
   NSString *labelText = @"label text";
   NSString *leadingAssistiveLabelText = @"leading assistive label text";
-  NSString *userSpecifiedAccessibilityLabel = @"user specified accessibility label";
+  NSString *userSpecifiedAccessibilityLabel = @"user-specified accessibility label";
 
   // When
   textField.label.text = labelText;
   textField.leadingAssistiveLabel.text = leadingAssistiveLabelText;
-  textField.accessibilityLabel = userSpecifiedAccessibilityLabel÷;
+  textField.accessibilityLabel = userSpecifiedAccessibilityLabel;
 
   // Then
   XCTAssertTrue([userSpecifiedAccessibilityLabel isEqualToString:textField.accessibilityLabel]);

--- a/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
@@ -338,4 +338,38 @@
                                      labelState:MDCTextControlLabelStateFloating]);
 }
 
+- (void)testDefaultAccessibilityLabel {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *labelText = @"label text";
+  NSString *leadingAssistiveLabelText = @"leading assistive label text";
+
+  // When
+  textField.label.text = labelText;
+  textField.leadingAssistiveLabel.text = leadingAssistiveLabelText;
+
+  // Then
+  NSString *concatenatedText =
+      [NSString stringWithFormat:@"%@, %@", labelText, leadingAssistiveLabelText];
+  XCTAssertTrue([concatenatedText isEqualToString:textField.accessibilityLabel]);
+}
+
+- (void)testClientSpecifiedAccessibilityLabel {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  NSString *labelText = @"label text";
+  NSString *leadingAssistiveLabelText = @"leading assistive label text";
+  NSString *userSpecifiedAccessibilityLabel = @"user specified accessibility label";
+
+  // When
+  textField.label.text = labelText;
+  textField.leadingAssistiveLabel.text = leadingAssistiveLabelText;
+  textField.accessibilityLabel = userSpecifiedAccessibilityLabel÷;
+
+  // Then
+  XCTAssertTrue([userSpecifiedAccessibilityLabel isEqualToString:textField.accessibilityLabel]);
+}
+
 @end


### PR DESCRIPTION
UITextField has some VoiceOver support built in--the text the user enters is reflected in the accessibilityValue. The accessibilityLabel, however, seems to be nil unless a user specifies something for it. This PR doesn't change that behavior, but it does make it so that if no accessibilityLabel is set the textfield returns a concatenated string consisting of the label text and any text from the assistive labels.

Closes #8771.