### PR TITLE
[ProgressView] Add accessibilityLabel

### DIFF
--- a/components/ProgressView/src/MDCProgressView.m
+++ b/components/ProgressView/src/MDCProgressView.m
@@ -265,6 +265,10 @@ static const NSTimeInterval MDCProgressViewAnimationDuration = 0.25;
   }
 }
 
+- (NSString *)accessibilityLabel {
+  return self.accessibilityProgressView.accessibilityLabel;
+}
+
 #pragma mark Private
 
 + (NSTimeInterval)animationDuration {

--- a/components/ProgressView/tests/unit/ProgressViewTests.m
+++ b/components/ProgressView/tests/unit/ProgressViewTests.m
@@ -90,4 +90,13 @@
   XCTAssertEqual(passedTraitCollection, fakeTraitCollection);
 }
 
+- (void)testAccessibilityLabelMatchesUIProgressView {
+  // Given
+  UIProgressView *uiProgressView = [[UIProgressView alloc] init];
+  MDCProgressView *mdcProgressView = [[MDCProgressView alloc] init];
+
+  // Then
+  XCTAssertEqual(uiProgressView.accessibilityLabel, mdcProgressView.accessibilityLabel);
+}
+
 @end


### PR DESCRIPTION
Uses `accessibilityProgressView`'s `accessibilityLabel` to mirror `UIProgressView` `accessibilityLabel` behavior.

Fixed #7603 