### PR TITLE
[TextControls] Snapshot test MDCTextControl TextFields with AXXXL content size

### DIFF
--- a/components/TextControls/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
+++ b/components/TextControls/tests/snapshot/MDCBaseTextFieldSnapshotTests.m
@@ -33,6 +33,7 @@
 
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
+  [MDCTextControlSnapshotTestHelpers setUpViewControllerHierarchy];
   self.textField = [MDCBaseTextFieldTestsSnapshotTestHelpers createBaseTextField];
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
@@ -43,8 +44,9 @@
 - (void)tearDown {
   [super tearDown];
   [MDCTextControlSnapshotTestHelpers
-      removeTextControlFromKeyWindow:(UIView<MDCTextControl> *)self.textField];
+      removeTextControlFromViewHierarchy:(UIView<MDCTextControl> *)self.textField];
   self.textField = nil;
+  [MDCTextControlSnapshotTestHelpers tearDownViewControllerHierarchy];
   [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
@@ -191,6 +193,18 @@
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
       configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithScaledFontsAndXXXLargeContentSize {
+  // Given
+  MDCBaseTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithScaledFontsAndAXXXLargeContentSize:textField];
 
   // Then
   [self validateTextField:textField];

--- a/components/TextControls/tests/snapshot/MDCFilledTextFieldSnapshotTests.m
+++ b/components/TextControls/tests/snapshot/MDCFilledTextFieldSnapshotTests.m
@@ -33,6 +33,7 @@
 
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
+  [MDCTextControlSnapshotTestHelpers setUpViewControllerHierarchy];
   self.textField = [MDCBaseTextFieldTestsSnapshotTestHelpers createFilledTextField];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
@@ -43,8 +44,9 @@
 - (void)tearDown {
   [super tearDown];
   [MDCTextControlSnapshotTestHelpers
-      removeTextControlFromKeyWindow:(UIView<MDCTextControl> *)self.textField];
+      removeTextControlFromViewHierarchy:(UIView<MDCTextControl> *)self.textField];
   self.textField = nil;
+  [MDCTextControlSnapshotTestHelpers tearDownViewControllerHierarchy];
   [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
@@ -191,6 +193,18 @@
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
       configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithScaledFontsAndXXXLargeContentSize {
+  // Given
+  MDCFilledTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithScaledFontsAndAXXXLargeContentSize:textField];
 
   // Then
   [self validateTextField:textField];

--- a/components/TextControls/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
+++ b/components/TextControls/tests/snapshot/MDCOutlinedTextFieldSnapshotTests.m
@@ -33,6 +33,7 @@
 
   self.areAnimationsEnabled = UIView.areAnimationsEnabled;
   [UIView setAnimationsEnabled:NO];
+  [MDCTextControlSnapshotTestHelpers setUpViewControllerHierarchy];
   self.textField = [MDCBaseTextFieldTestsSnapshotTestHelpers createOutlinedTextField];
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
@@ -43,8 +44,9 @@
 - (void)tearDown {
   [super tearDown];
   [MDCTextControlSnapshotTestHelpers
-      removeTextControlFromKeyWindow:(UIView<MDCTextControl> *)self.textField];
+      removeTextControlFromViewHierarchy:(UIView<MDCTextControl> *)self.textField];
   self.textField = nil;
+  [MDCTextControlSnapshotTestHelpers tearDownViewControllerHierarchy];
   [UIView setAnimationsEnabled:self.areAnimationsEnabled];
 }
 
@@ -191,6 +193,18 @@
   // When
   [MDCBaseTextFieldTestsSnapshotTestHelpers
       configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:textField];
+
+  // Then
+  [self validateTextField:textField];
+}
+
+- (void)testTextFieldWithScaledFontsAndXXXLargeContentSize {
+  // Given
+  MDCOutlinedTextField *textField = self.textField;
+
+  // When
+  [MDCBaseTextFieldTestsSnapshotTestHelpers
+      configureTextFieldWithScaledFontsAndAXXXLargeContentSize:textField];
 
   // Then
   [self validateTextField:textField];

--- a/components/TextControls/tests/snapshot/supplemental/MDCBaseTextFieldTestsSnapshotTestHelpers.h
+++ b/components/TextControls/tests/snapshot/supplemental/MDCBaseTextFieldTestsSnapshotTestHelpers.h
@@ -36,4 +36,6 @@
 + (void)configureEditingTextFieldWithVisiblePlaceholderAndLabelText:(MDCBaseTextField *)textField;
 + (void)configureTextFieldWithColoredAssistiveLabelTextWhileEditing:(MDCBaseTextField *)textField;
 + (void)configureTextFieldWithColoredAssistiveLabelTextWhileDisabled:(MDCBaseTextField *)textField;
++ (void)configureTextFieldWithScaledFontsAndAXXXLargeContentSize:(MDCBaseTextField *)textField;
+
 @end

--- a/components/TextControls/tests/snapshot/supplemental/MDCTextControlSnapshotTestHelpers.h
+++ b/components/TextControls/tests/snapshot/supplemental/MDCTextControlSnapshotTestHelpers.h
@@ -20,9 +20,11 @@
 
 @interface MDCTextControlSnapshotTestHelpers : NSObject
 
-+ (void)removeTextControlFromKeyWindow:(UIView<MDCTextControl> *)textControl;
-+ (void)addTextControlToKeyWindow:(UIView<MDCTextControl> *)textControl;
-
++ (void)setUpViewControllerHierarchy;
++ (void)tearDownViewControllerHierarchy;
++ (void)applyContentSizeCategory:(UIContentSizeCategory)contentSizeCategory;
++ (void)removeTextControlFromViewHierarchy:(UIView<MDCTextControl> *)textControl;
++ (void)addTextControlToViewHierarchy:(UIView<MDCTextControl> *)textControl;
 + (void)validateTextControl:(UIView<MDCTextControl> *)textControl
                withTestCase:(MDCSnapshotTestCase *)testCase;
 @end

--- a/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBaseTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32d3a6e722ba967d2c4404423cdd575152e10c498411c213cc3e1bdb0b877241
+size 37986

--- a/snapshot_test_goldens/goldens_64/MDCFilledTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCFilledTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:734622677916a5cc42fe0b4a202147b72c81dc19f803b0b0d53a194abcd7c635
+size 37945

--- a/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCOutlinedTextFieldTestsSnapshotTests/testTextFieldWithScaledFontsAndXXXLargeContentSize_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c0d9bc53d74a6e9a18f33aa395db772c4be28151cfbd08286394f652d58ac98
+size 38540


### PR DESCRIPTION
Note: This PR no longer relates to the automatic adjusting behavior on MDCBaseTextField. Instead, it is solely about adding snapshot test coverage for accessibility XXXL content sizes.

Closes #8800.