### PR TITLE
[Slider] Update documentation to match behavior.

### DIFF
--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -27,6 +27,8 @@ or discrete set of values.
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/go/design-sliders">Material Design guidelines: Slider</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/sliders/api-docs/Classes/MDCSlider.html">MDCSlider</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/sliders/api-docs/Protocols/MDCSliderDelegate.html">MDCSliderDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/sliders/api-docs/Enums.html">Enumerations</a></li>
+  <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/sliders/api-docs/Enums/MDCSliderTrackTickVisibility.html">MDCSliderTrackTickVisibility</a></li>
 </ul>
 
 ## Table of contents
@@ -159,26 +161,49 @@ func didChangeSliderValue(senderSlider:MDCSlider) {
 
 ### Differences from UISlider
 
-Does not have api to:
+#### UISlider APIs not present in MDCSlider
 
-- set right and left icons
-- set the thumb image
-- set the right and left track images (for a custom track)
-- set the right (background track) color
+`MDCSlider` does not support the following `UISlider` APIs:
 
-Same features:
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item">  Setting the left/right icons via `minimumValueImage` and `maximumValueImage`.</li>
+  <li class="icon-list-item icon-list-item">  Setting the thumb image via `setThumbImage:forState:`.</li>
+  <li class="icon-list-item icon-list-item">  Setting the right/left track images (for a custom track) via `setMinimumTrackImage:forState:` and `setMaximumTrackImage:forState:`.</li>
+</ul>
 
-- set color for thumb via @c thumbColor
-- set color of track via @c trackColor
+#### UISlider APIs with different names in MDCSlider
 
-New features:
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item">  The UISlider API `minimumTrackTintColor` has an equivalent API `setTrackFillColor:forState:` in </li>
+    MDCSlider.  This API must first be enabled by setting `statefulAPIEnabled = YES`. 
+  <li class="icon-list-item icon-list-item">  The UISlider API `maximumTrackTintColor` has an equivalent API `setTrackBackgroundColor:forState:`</li>
+    in MDCSlider.  This API must first be enabled by setting `statefulAPIEnabled = YES`.
+  <li class="icon-list-item icon-list-item">  The UISlider API `thumbTintColor` has an equivalent API `setThumbColor:forState:` in MDCSlider.  This</li>
+    API must first be enabled by setting `statefulAPIEnabled = YES`.     
 
-- making the slider a snap to discrete values via property numberOfDiscreteValues
+#### MDCSlider enhancements not in MDCSlider
+
+<ul class="icon-list">
+  <li class="icon-list-item icon-list-item--link">  MDCSlider can behave as a <a href="https://material.io/components/sliders/#discrete-slider">Material Discrete Slider</a></li> by
+    setting `discrete = YES` and `numberOfDiscreteValues` to a value greater than or equal to 2. Discrete 
+    Sliders only allow their calculated discrete values to be selected as the Slider's value.  If 
+    `numberOfDiscreteValues` is less than 2, then the Slider will behave as a 
+    [Material Continuous Slider](https://material.io/components/sliders/#continuous-slider).
+  <li class="icon-list-item icon-list-item">  For Discrete Sliders, the track tick color is configured with the `setFilledTrackTickColor:forState:` and</li>
+    `setBackgroundTrackTickColor:forState:` APIs.  The filled track ticks are those overlapping the 
+    filled/active part of the Slider.  The background track ticks are found in any other portions of the track.  These 
+    APIs must first be enabled by setting `statefulAPIEnabled = YES`.
+  <li class="icon-list-item icon-list-item">  Track tick marks can be made shown always, never, or only when dragging via the `trackTickVisibility` </li>
+    API.  If `numberOfDiscreteValues` is less than 2, then tick marks will never be shown.
+  <li class="icon-list-item icon-list-item">  An anchor point can be set via `filledTrackAnchorValue` to control the starting position of the filled track.</li>
+  <li class="icon-list-item icon-list-item">  The track can be made taller (or shorter) by setting the value of `trackHeight`. </li>
+</ul>
 
 #### `-accessibilityActivate`
 
-Our implementation closely resembles what UISlider does but it's not an exact match. On an
-`accessibilityActivate` we move one sixth of the amount between the current value and the midpoint value.
+MDCSlider closely resembles what UISlider does but it's not an exact match. On an
+`accessibilityActivate` event, the value moves one sixth of the amount between the current value and the 
+midpoint value.
 
 
 ## Extensions

--- a/components/Slider/README.md
+++ b/components/Slider/README.md
@@ -201,7 +201,7 @@ func didChangeSliderValue(senderSlider:MDCSlider) {
 
 #### `-accessibilityActivate`
 
-MDCSlider closely resembles what UISlider does but it's not an exact match. On an
+MDCSlider's behavior is very similar to that of UISlider, but it's not exactly the same. On an
 `accessibilityActivate` event, the value moves one sixth of the amount between the current value and the 
 midpoint value.
 

--- a/components/Slider/docs/differences-from-uislider.md
+++ b/components/Slider/docs/differences-from-uislider.md
@@ -1,22 +1,40 @@
 ### Differences from UISlider
 
-Does not have api to:
+#### UISlider APIs not present in MDCSlider
 
-- set right and left icons
-- set the thumb image
-- set the right and left track images (for a custom track)
-- set the right (background track) color
+`MDCSlider` does not support the following `UISlider` APIs:
 
-Same features:
+*   Setting the left/right icons via `minimumValueImage` and `maximumValueImage`.
+*   Setting the thumb image via `setThumbImage:forState:`.
+*   Setting the right/left track images (for a custom track) via `setMinimumTrackImage:forState:` and `setMaximumTrackImage:forState:`.
 
-- set color for thumb via @c thumbColor
-- set color of track via @c trackColor
+#### UISlider APIs with different names in MDCSlider
 
-New features:
+*   The UISlider API `minimumTrackTintColor` has an equivalent API `setTrackFillColor:forState:` in 
+    MDCSlider.  This API must first be enabled by setting `statefulAPIEnabled = YES`. 
+*   The UISlider API `maximumTrackTintColor` has an equivalent API `setTrackBackgroundColor:forState:`
+    in MDCSlider.  This API must first be enabled by setting `statefulAPIEnabled = YES`.
+*   The UISlider API `thumbTintColor` has an equivalent API `setThumbColor:forState:` in MDCSlider.  This
+    API must first be enabled by setting `statefulAPIEnabled = YES`.     
 
-- making the slider a snap to discrete values via property numberOfDiscreteValues
+#### MDCSlider enhancements not in MDCSlider
+
+*   MDCSlider can behave as a [Material Discrete Slider](https://material.io/components/sliders/#discrete-slider) by
+    setting `discrete = YES` and `numberOfDiscreteValues` to a value greater than or equal to 2. Discrete 
+    Sliders only allow their calculated discrete values to be selected as the Slider's value.  If 
+    `numberOfDiscreteValues` is less than 2, then the Slider will behave as a 
+    [Material Continuous Slider](https://material.io/components/sliders/#continuous-slider).
+*   For Discrete Sliders, the track tick color is configured with the `setFilledTrackTickColor:forState:` and
+    `setBackgroundTrackTickColor:forState:` APIs.  The filled track ticks are those overlapping the 
+    filled/active part of the Slider.  The background track ticks are found in any other portions of the track.  These 
+    APIs must first be enabled by setting `statefulAPIEnabled = YES`.
+*   Track tick marks can be made shown always, never, or only when dragging via the `trackTickVisibility` 
+    API.  If `numberOfDiscreteValues` is less than 2, then tick marks will never be shown.
+*   An anchor point can be set via `filledTrackAnchorValue` to control the starting position of the filled track.
+*   The track can be made taller (or shorter) by setting the value of `trackHeight`. 
 
 #### `-accessibilityActivate`
 
-Our implementation closely resembles what UISlider does but it's not an exact match. On an
-`accessibilityActivate` we move one sixth of the amount between the current value and the midpoint value.
+MDCSlider closely resembles what UISlider does but it's not an exact match. On an
+`accessibilityActivate` event, the value moves one sixth of the amount between the current value and the 
+midpoint value.

--- a/components/Slider/docs/differences-from-uislider.md
+++ b/components/Slider/docs/differences-from-uislider.md
@@ -35,6 +35,6 @@
 
 #### `-accessibilityActivate`
 
-MDCSlider closely resembles what UISlider does but it's not an exact match. On an
+MDCSlider's behavior is very similar to that of UISlider, but it's not exactly the same. On an
 `accessibilityActivate` event, the value moves one sixth of the amount between the current value and the 
 midpoint value.

--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -234,10 +234,7 @@ IB_DESIGNABLE
 /**
  Configures the visibility of the track tick marks.
 
- @note Unless this property is set explicitly, its value will change based on the value of
-       @c continuous. When @c continuous is @c true, @c trackTickVisibility is
-       @c MDCSliderTrackTickVisibilityNever. When @c continuous is false, @c trackTickVisibility
-       is @c MDCSliderTrackTickVisibilityWhenDragging.
+ The default value is @c MDCSliderTrackTickVisibilityWhenDragging.
  */
 @property(nonatomic, assign) MDCSliderTrackTickVisibility trackTickVisibility;
 


### PR DESCRIPTION
The MDCSlider documentation needs to be updated to match its current behavior.
This commit corrects an outdated behavioral description for the
`trackTickVisibility` API. It also updates the README to include more recent
changes to the APIs.

Follow-up from #8758