### PR TITLE
[Banner] Add an example to show how Banner can be used as bottom bar in AppBar.

### DIFF
--- a/components/AppBar/examples/AppBarBannerExample.m
+++ b/components/AppBar/examples/AppBarBannerExample.m
@@ -1,0 +1,142 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialAppBar.h"
+#import "MaterialAppBar+Theming.h"
+#import "MaterialBanner.h"
+#import "MaterialBanner+Theming.h"
+#import "MDCFlexibleHeaderView+canAlwaysExpandToMaximumHeight.h"
+
+@interface AppBarBannerExample : UITableViewController
+
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
+@property(nonatomic, strong) MDCBannerView *banner;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+
+@end
+
+@implementation AppBarBannerExample
+
+- (void)dealloc {
+  // Required for pre-iOS 11 devices because we've enabled observesTrackingScrollViewScrollEvents.
+  self.appBarViewController.headerView.trackingScrollView = nil;
+}
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    _containerScheme = [[MDCContainerScheme alloc] init];
+    _appBarViewController = [[MDCAppBarViewController alloc] init];
+    [_appBarViewController applyPrimaryThemeWithScheme:_containerScheme];
+    _banner = [[MDCBannerView alloc] init];
+    [_banner applyThemeWithScheme:_containerScheme];
+
+    // Behavioral flags.
+    _appBarViewController.inferTopSafeAreaInsetFromViewController = YES;
+    _appBarViewController.headerView.minMaxHeightIncludesSafeArea = NO;
+    _appBarViewController.headerView.canAlwaysExpandToMaximumHeight = NO;
+    _appBarViewController.headerView.sharedWithManyScrollViews = YES;
+    _appBarViewController.headerView.canOverExtend = NO;
+    _appBarViewController.enableFlexibleHeader = NO;
+
+    self.title = @"Banner";
+    [self addChildViewController:_appBarViewController];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.banner.textView.text = @"This banner has been set as bottomBar of this AppBar.";
+  [self.banner.leadingButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [self.banner.leadingButton addTarget:self
+                                action:@selector(dismissBanner)
+                      forControlEvents:UIControlEventTouchUpInside];
+  self.banner.trailingButton.hidden = YES;
+  [self.banner sizeToFit];
+  self.appBarViewController.headerStackView.bottomBar = self.banner;
+
+  self.appBarViewController.headerView.trackingScrollView = self.tableView;
+  self.appBarViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
+  [self.view addSubview:self.appBarViewController.view];
+  [self.appBarViewController didMoveToParentViewController:self];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+  // Ensure that our status bar is white.
+  return UIStatusBarStyleLightContent;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+  return self.appBarViewController;
+}
+
+- (void)dismissBanner {
+  self.appBarViewController.headerStackView.bottomBar = nil;
+  self.banner = nil;
+}
+
+@end
+
+@implementation AppBarBannerExample (TypicalUse)
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+
+  [self.navigationController setNavigationBarHidden:YES animated:animated];
+}
+
+@end
+
+@implementation AppBarBannerExample (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  // clang-format off
+  return @{
+    @"breadcrumbs" : @[ @"App Bar", @"Banner" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @YES
+  };
+  // clang-format on
+}
+
+- (BOOL)catalogShouldHideNavigation {
+  return YES;
+}
+
+@end
+
+#pragma mark - Typical application code (not Material-specific)
+
+@implementation AppBarBannerExample (UITableViewDataSource)
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return 50;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"cell"];
+  if (!cell) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                  reuseIdentifier:@"cell"];
+  }
+  cell.selectionStyle = UITableViewCellSelectionStyleNone;
+  return cell;
+}
+
+@end

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -51,6 +51,7 @@ mdc_examples_objc_library(
     deps = [
         ":Banner",
         "//components/AppBar",
+        "//components/AppBar:Theming",
         "//components/Buttons",
         "//components/Buttons:Theming",
         "//components/schemes/Color",

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -50,6 +50,7 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":Banner",
+        "//components/AppBar",
         "//components/Buttons",
         "//components/Buttons:Theming",
         "//components/schemes/Color",

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -50,6 +50,7 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":Banner",
+        ":Theming",
         "//components/AppBar",
         "//components/AppBar:Theming",
         "//components/Buttons",

--- a/components/Banner/examples/AppBarBannerExample.m
+++ b/components/Banner/examples/AppBarBannerExample.m
@@ -14,11 +14,10 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialAppBar.h"
 #import "MaterialAppBar+Theming.h"
-#import "MaterialBanner.h"
+#import "MaterialAppBar.h"
 #import "MaterialBanner+Theming.h"
-#import "MDCFlexibleHeaderView+canAlwaysExpandToMaximumHeight.h"
+#import "MaterialBanner.h"
 
 @interface AppBarBannerExample : UITableViewController
 
@@ -41,16 +40,12 @@
     _containerScheme = [[MDCContainerScheme alloc] init];
     _appBarViewController = [[MDCAppBarViewController alloc] init];
     [_appBarViewController applyPrimaryThemeWithScheme:_containerScheme];
-    _banner = [[MDCBannerView alloc] init];
-    [_banner applyThemeWithScheme:_containerScheme];
 
     // Behavioral flags.
     _appBarViewController.inferTopSafeAreaInsetFromViewController = YES;
-    _appBarViewController.headerView.minMaxHeightIncludesSafeArea = NO;
-    _appBarViewController.headerView.canAlwaysExpandToMaximumHeight = NO;
     _appBarViewController.headerView.sharedWithManyScrollViews = YES;
     _appBarViewController.headerView.canOverExtend = NO;
-    _appBarViewController.enableFlexibleHeader = NO;
+    _appBarViewController.shouldAdjustHeightBasedOnHeaderStackView = YES;
 
     self.title = @"Banner";
     [self addChildViewController:_appBarViewController];
@@ -61,19 +56,16 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.banner.textView.text = @"This banner has been set as bottomBar of this AppBar.";
-  [self.banner.leadingButton setTitle:@"Dismiss" forState:UIControlStateNormal];
-  [self.banner.leadingButton addTarget:self
-                                action:@selector(dismissBanner)
-                      forControlEvents:UIControlEventTouchUpInside];
-  self.banner.trailingButton.hidden = YES;
-  [self.banner sizeToFit];
-  self.appBarViewController.headerStackView.bottomBar = self.banner;
-
   self.appBarViewController.headerView.trackingScrollView = self.tableView;
   self.appBarViewController.headerView.observesTrackingScrollViewScrollEvents = YES;
   [self.view addSubview:self.appBarViewController.view];
   [self.appBarViewController didMoveToParentViewController:self];
+
+  self.navigationItem.rightBarButtonItem =
+      [[UIBarButtonItem alloc] initWithTitle:@"Banner"
+                                       style:UIBarButtonItemStyleDone
+                                      target:self
+                                      action:@selector(showBanner)];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -88,6 +80,19 @@
 - (void)dismissBanner {
   self.appBarViewController.headerStackView.bottomBar = nil;
   self.banner = nil;
+}
+
+- (void)showBanner {
+  self.banner = [[MDCBannerView alloc] init];
+  [self.banner applyThemeWithScheme:_containerScheme];
+  self.banner.textView.text = @"This banner has been set as bottomBar of this AppBar.";
+  [self.banner.leadingButton setTitle:@"Dismiss" forState:UIControlStateNormal];
+  [self.banner.leadingButton addTarget:self
+                                action:@selector(dismissBanner)
+                      forControlEvents:UIControlEventTouchUpInside];
+  self.banner.trailingButton.hidden = YES;
+  [self.banner sizeToFit];
+  self.appBarViewController.headerStackView.bottomBar = self.banner;
 }
 
 @end
@@ -107,7 +112,7 @@
 + (NSDictionary *)catalogMetadata {
   // clang-format off
   return @{
-    @"breadcrumbs" : @[ @"App Bar", @"Banner" ],
+    @"breadcrumbs" : @[ @"Banner", @"App Bar + Banner" ],
     @"primaryDemo" : @NO,
     @"presentable" : @YES
   };
@@ -136,6 +141,7 @@
                                   reuseIdentifier:@"cell"];
   }
   cell.selectionStyle = UITableViewCellSelectionStyleNone;
+  cell.textLabel.text = [@(indexPath.row) stringValue];
   return cell;
 }
 

--- a/components/Banner/examples/AppBarBannerExample.m
+++ b/components/Banner/examples/AppBarBannerExample.m
@@ -91,7 +91,6 @@
                                 action:@selector(dismissBanner)
                       forControlEvents:UIControlEventTouchUpInside];
   self.banner.trailingButton.hidden = YES;
-  [self.banner sizeToFit];
   self.appBarViewController.headerStackView.bottomBar = self.banner;
 }
 


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8677.

This PR adds an example to show how Banner could be used as a bottomBar in AppBar.

|Screenshot|
|-----|
|![appbarbanner](https://user-images.githubusercontent.com/8836258/68698933-005f7580-0550-11ea-957f-d8121e3f468d.gif)|
