### PR TITLE
[Dialogs] Set dialog message accessibilityFrame based on visible message text

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -673,6 +673,12 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
         CGRectGetHeight(self.bounds) - actionsScrollViewRect.size.height;
     self.contentScrollView.frame = contentScrollViewRect;
   }
+
+  CGRect messageFrameInWindow = [self convertRect:self.messageLabel.frame toView:self.window];
+  CGRect contentScrollFrameInWindow = [self convertRect:self.contentScrollView.frame
+                                                 toView:self.window];
+  CGRect visibleMessageRect = CGRectIntersection(messageFrameInWindow, contentScrollFrameInWindow);
+  self.messageLabel.accessibilityFrame = visibleMessageRect;
 }
 
 #pragma mark - Dynamic Type


### PR DESCRIPTION
Update the accessibility frame for dialog message labels to only include what is visible on screen. 

Fixes #7637

To test locally:

1. Open the MDC Dragons app
2. Navigate to the Dialogs Alert Comparison example (Dialogs -> Alert Comparison)
3. Tap on the "Material Alert" button
4. Enable VoiceOver
5. Move focus to the dialog's message text. 

![dialog-accessibility-frame](https://user-images.githubusercontent.com/581764/68699067-46b4d480-0550-11ea-9244-41e85f8dfb2a.png)
