### PR TITLE
[TextFields] Give MDCTextField clear button proper hit area insets

### DIFF
--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCTextInput.h"
 #import "MDCButton.h"
+#import "MDCTextInput.h"
 
 extern const CGFloat MDCTextInputBorderRadius;
 extern const CGFloat MDCTextInputFullPadding;

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -13,12 +13,16 @@
 // limitations under the License.
 
 #import "MDCTextInput.h"
+#import "MDCButton.h"
 
 extern const CGFloat MDCTextInputBorderRadius;
 extern const CGFloat MDCTextInputFullPadding;
 extern const CGFloat MDCTextInputHalfPadding;
 
 UIKIT_EXTERN UIColor *_Nonnull MDCTextInputCursorColor(void);
+
+@interface MDCTextInputClearButton : MDCButton
+@end
 
 /** A controller for common traits shared by text inputs. */
 @interface MDCTextInputCommonFundament : NSObject <MDCTextInput, NSCopying>

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.h
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.h
@@ -22,6 +22,7 @@ extern const CGFloat MDCTextInputHalfPadding;
 UIKIT_EXTERN UIColor *_Nonnull MDCTextInputCursorColor(void);
 
 @interface MDCTextInputClearButton : MDCButton
+@property(nonatomic, assign) UIEdgeInsets minimumTouchTargetInsets;
 @end
 
 /** A controller for common traits shared by text inputs. */

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -65,14 +65,15 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   CGFloat height = CGRectGetHeight(self.bounds);
   CGFloat verticalInset = MIN(0, -(MDCTextInputClearButtonTouchTargetSize - height) / 2);
   CGFloat horizontalInset = MIN(0, -(MDCTextInputClearButtonTouchTargetSize - width) / 2);
-  self.hitAreaInsets =
+  self.minimumTouchTargetInsets =
       UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  if (!UIEdgeInsetsEqualToEdgeInsets(self.hitAreaInsets, UIEdgeInsetsZero)) {
+  if (!UIEdgeInsetsEqualToEdgeInsets(self.minimumTouchTargetInsets, UIEdgeInsetsZero)) {
     return CGRectContainsPoint(
-        UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), self.hitAreaInsets), point);
+        UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), self.minimumTouchTargetInsets),
+        point);
   }
   return [super pointInside:point withEvent:event];
 }

--- a/components/TextFields/src/private/MDCTextInputCommonFundament.m
+++ b/components/TextFields/src/private/MDCTextInputCommonFundament.m
@@ -39,6 +39,7 @@ static const CGFloat MDCTextInputHintTextOpacity = (CGFloat)0.54;
 static const CGFloat MDCTextInputOverlayViewToEditingRectPadding = 2;
 const CGFloat MDCTextInputFullPadding = 16;
 const CGFloat MDCTextInputHalfPadding = 8;
+const CGFloat MDCTextInputClearButtonTouchTargetSize = 48;
 
 UIColor *_Nonnull MDCTextInputCursorColor() {
   return [MDCPalette bluePalette].accent700;
@@ -55,6 +56,27 @@ static inline UIColor *MDCTextInputTextColor() {
 static inline UIColor *MDCTextInputUnderlineColor() {
   return [UIColor lightGrayColor];
 }
+
+@implementation MDCTextInputClearButton
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  CGFloat width = CGRectGetWidth(self.bounds);
+  CGFloat height = CGRectGetHeight(self.bounds);
+  CGFloat verticalInset = MIN(0, -(MDCTextInputClearButtonTouchTargetSize - height) / 2);
+  CGFloat horizontalInset = MIN(0, -(MDCTextInputClearButtonTouchTargetSize - width) / 2);
+  self.hitAreaInsets =
+      UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+  if (!UIEdgeInsetsEqualToEdgeInsets(self.hitAreaInsets, UIEdgeInsetsZero)) {
+    return CGRectContainsPoint(
+        UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), self.hitAreaInsets), point);
+  }
+  return [super pointInside:point withEvent:event];
+}
+@end
 
 @interface MDCTextInputCommonFundament () {
   BOOL _mdc_adjustsFontForContentSizeCategory;
@@ -197,7 +219,7 @@ static inline UIColor *MDCTextInputUnderlineColor() {
   if (!_clearButton) {
     // The following MDCButton configuration creates an MDCButton that mimics a UIButton with a
     // "clear" icon and adds a ripple effect.
-    MDCButton *clearButton = [[MDCButton alloc] init];
+    MDCTextInputClearButton *clearButton = [[MDCTextInputClearButton alloc] init];
     clearButton.backgroundColor = UIColor.clearColor;
     // This ink color was taken from the MDCButton+MaterialTheming behavior, with UIColor.blackColor
     // taken from the onSurfaceColor value of the MDCColorSchemeDefaultsMaterial201907 color scheme.

--- a/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
+++ b/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
@@ -86,9 +86,10 @@
 
   // Then
   CGFloat negativeFifteen = (CGFloat)(-1 * 15);
-  UIEdgeInsets hitAreaInsets =
+  UIEdgeInsets minimumTouchTargetInsets =
       UIEdgeInsetsMake(negativeFifteen, negativeFifteen, negativeFifteen, negativeFifteen);
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(clearButton.hitAreaInsets, hitAreaInsets));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(clearButton.minimumTouchTargetInsets,
+                                              minimumTouchTargetInsets));
 }
 
 @end

--- a/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
+++ b/components/TextFields/tests/unit/MDCTextInputCommonFundamentTests.m
@@ -77,4 +77,18 @@
   XCTAssertNotEqual(self.textInput.placeholderLabel.font, self.textInput.font);
 }
 
+- (void)testClearButtonTouchTarget {
+  // Given
+  MDCTextInputClearButton *clearButton =
+      [[MDCTextInputClearButton alloc] initWithFrame:CGRectMake(50, 50, 18, 18)];
+  [clearButton setNeedsLayout];
+  [clearButton layoutIfNeeded];
+
+  // Then
+  CGFloat negativeFifteen = (CGFloat)(-1 * 15);
+  UIEdgeInsets hitAreaInsets =
+      UIEdgeInsetsMake(negativeFifteen, negativeFifteen, negativeFifteen, negativeFifteen);
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(clearButton.hitAreaInsets, hitAreaInsets));
+}
+
 @end


### PR DESCRIPTION
This PR makes the MDCTextField clear button always meet the minimum touch target.

Closes #5373.