### PR TITLE
[examples] Annotate all catalogShouldHideNavigation invocations with @objc.

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -186,7 +186,7 @@ extension AppBarAnimatedJumpExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarGlitchExample.swift
+++ b/components/AppBar/examples/AppBarGlitchExample.swift
@@ -151,7 +151,7 @@ extension AppBarJumpExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarImageryExample.swift
+++ b/components/AppBar/examples/AppBarImageryExample.swift
@@ -104,7 +104,7 @@ extension AppBarImagerySwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
+++ b/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
@@ -186,7 +186,7 @@ extension AppBarInheritedAnimatedJumpExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
+++ b/components/AppBar/examples/AppBarInterfaceBuilderExampleController.swift
@@ -81,7 +81,7 @@ extension AppBarInterfaceBuilderSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarManualTabsExample.swift
+++ b/components/AppBar/examples/AppBarManualTabsExample.swift
@@ -155,7 +155,7 @@ extension AppBarManualTabsExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarModalPresentationExample.swift
+++ b/components/AppBar/examples/AppBarModalPresentationExample.swift
@@ -161,7 +161,7 @@ extension AppBarModalPresentationSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarTypicalUseExample.swift
+++ b/components/AppBar/examples/AppBarTypicalUseExample.swift
@@ -94,7 +94,7 @@ extension AppBarTypicalUseSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/AppBar/examples/AppBarWithUITableViewController.swift
+++ b/components/AppBar/examples/AppBarWithUITableViewController.swift
@@ -115,7 +115,7 @@ extension AppBarWithUITableViewController {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
+++ b/components/BottomAppBar/examples/BottomAppBarTypicalUseExample.swift
@@ -146,7 +146,7 @@ extension BottomAppBarTypicalUseSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -131,7 +131,7 @@ extension BottomNavigationResetExample {
     ]
   }
 
-  class func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
+++ b/components/NavigationBar/examples/supplemental/NavigationBarTypicalUseExampleSupplemental.swift
@@ -31,7 +31,7 @@ extension NavigationBarTypicalUseSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
+++ b/components/ShadowElevations/examples/ShadowElevationsTypicalUseExample.swift
@@ -94,7 +94,7 @@ extension ShadowElevationsTypicalUseExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -258,7 +258,7 @@ extension TabBarIconSwiftExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -129,7 +129,7 @@ extension TabBarIndicatorTemplateExample {
     ]
   }
 
-  func catalogShouldHideNavigation() -> Bool {
+  @objc func catalogShouldHideNavigation() -> Bool {
     return true
   }
 }


### PR DESCRIPTION
Context:

Due to changes in the Swift runtime over the past years, methods that are considered "optional" in Objective-C need to have @objc annotations in order for Objective-C to be able to perform `respondsToSelector:` invocations.

Problem:
Many of our examples had not annotated their `catalogShouldHideNavigation` methods with the `@objc` annotation, causing the Catalog to wrap the examples in a container app bar view controller. The reason most of these examples would implement `catalogShouldHideNavigation` is because they are managing their own navigation (e.g. to demonstrate AppBar functionality), so this would often result in duplicate AppBars appearing in the example.

The fix:
All `catalogShouldHideNavigation` Swift methods have been annotated with `@objc`.

Fixes https://github.com/material-components/material-components-ios/issues/7576
Fixes https://github.com/material-components/material-components-ios/issues/7578
