### PR TITLE
[Chips] Set UIAccessibilityTraitButton on MDCChipView's accessibilityTraits.

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -138,6 +138,7 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   _minimumSize = kMDCChipMinimumSizeDefault;
   self.rippleAllowsSelection = YES;
   self.isAccessibilityElement = YES;
+  self.accessibilityTraits = UIAccessibilityTraitButton;
   _mdc_overrideBaseElevation = -1;
   _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
 }

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -97,6 +97,7 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertFalse(chip.mdc_adjustsFontForContentSizeCategory);
   XCTAssertNotNil(chip.selectedImageView);
   XCTAssertNotNil(chip.titleLabel);
+  XCTAssertEqual(chip.accessibilityTraits, UIAccessibilityTraitButton);
   XCTAssertEqualWithAccuracy(chip.mdc_baseElevation, 0, 0.001);
   XCTAssertNil(chip.mdc_elevationDidChangeBlock);
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(chip.contentPadding, expectedContentPadding),


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-ios/issues/8788