### PR TITLE
[Banner] Deactivate custom constraints when there is a need to update constraints.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -347,6 +347,7 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
 - (void)setFrame:(CGRect)frame {
   [super setFrame:frame];
 
+  [self deactivateAllConstraints];
   [self setNeedsUpdateConstraints];
 }
 


### PR DESCRIPTION
Follow up to https://github.com/material-components/material-components-ios/pull/8765. 

Related to https://github.com/material-components/material-components-ios/pull/8785.

After setting frame, sometimes the constraints generated by the new frame (autosizingmask) might conflict with the original custom constraints before the constraints get updated. To avoid warning in console, we should deactivate those custom constraints because they will be updated anyway.