### PR TITLE
[TextControls] Add adjusts content size category behavior

### DIFF
--- a/components/TextControls/src/MDCBaseTextField.m
+++ b/components/TextControls/src/MDCBaseTextField.m
@@ -76,6 +76,11 @@
   [self setUpColorViewModels];
   [self setUpLabel];
   [self setUpAssistiveLabels];
+  [self observeContentSizeCategoryNotifications];
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark View Setup
@@ -502,6 +507,29 @@
     font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
   });
   return font;
+}
+
+#pragma mark Dynamic Type
+
+- (void)setAdjustsFontForContentSizeCategory:(BOOL)adjustsFontForContentSizeCategory {
+  if (@available(iOS 10.0, *)) {
+    [super setAdjustsFontForContentSizeCategory:adjustsFontForContentSizeCategory];
+    self.leadingAssistiveLabel.adjustsFontForContentSizeCategory =
+        adjustsFontForContentSizeCategory;
+    self.trailingAssistiveLabel.adjustsFontForContentSizeCategory =
+        adjustsFontForContentSizeCategory;
+  }
+}
+
+- (void)observeContentSizeCategoryNotifications {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(contentSizeCategoryDidChange:)
+                                               name:UIContentSizeCategoryDidChangeNotification
+                                             object:nil];
+}
+
+- (void)contentSizeCategoryDidChange:(NSNotification *)notification {
+  [self setNeedsLayout];
 }
 
 #pragma mark MDCTextControlState

--- a/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
@@ -443,17 +443,19 @@
 }
 
 - (void)testAdjustsFontForContentSizeCategory {
-  // Given
-  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
-  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+  if (@available(iOS 10.0, *)) {
+    // Given
+    CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+    MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
 
-  // When
-  textField.adjustsFontForContentSizeCategory = YES;
+    // When
+    textField.adjustsFontForContentSizeCategory = YES;
 
-  // Then
-  XCTAssertTrue(textField.adjustsFontForContentSizeCategory);
-  XCTAssertTrue(textField.leadingAssistiveLabel.adjustsFontForContentSizeCategory);
-  XCTAssertTrue(textField.trailingAssistiveLabel.adjustsFontForContentSizeCategory);
+    // Then
+    XCTAssertTrue(textField.adjustsFontForContentSizeCategory);
+    XCTAssertTrue(textField.leadingAssistiveLabel.adjustsFontForContentSizeCategory);
+    XCTAssertTrue(textField.trailingAssistiveLabel.adjustsFontForContentSizeCategory);
+  }
 }
 
 @end

--- a/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/MDCBaseTextFieldTests.m
@@ -442,4 +442,18 @@
   XCTAssertTrue([userSpecifiedAccessibilityLabel isEqualToString:textField.accessibilityLabel]);
 }
 
+- (void)testAdjustsFontForContentSizeCategory {
+  // Given
+  CGRect textFieldFrame = CGRectMake(0, 0, 130, 100);
+  MDCBaseTextField *textField = [[MDCBaseTextField alloc] initWithFrame:textFieldFrame];
+
+  // When
+  textField.adjustsFontForContentSizeCategory = YES;
+
+  // Then
+  XCTAssertTrue(textField.adjustsFontForContentSizeCategory);
+  XCTAssertTrue(textField.leadingAssistiveLabel.adjustsFontForContentSizeCategory);
+  XCTAssertTrue(textField.trailingAssistiveLabel.adjustsFontForContentSizeCategory);
+}
+
 @end


### PR DESCRIPTION
This PR adds `UIContentSizeCategoryDidChangeNotification` observing and an implementation of `UIContentSizeCategoryAdjusting`.

Snapshot tests validating behavior in larger content sizes were added in #8781.

Closes #8770.