### PR TITLE
[TextFields] Added header comment: placeholder APIs are for `label text`

### DIFF
--- a/components/TextFields/src/MDCMultilineTextField.h
+++ b/components/TextFields/src/MDCMultilineTextField.h
@@ -61,8 +61,7 @@
  Note: Inherited from MDCTextInput protocol. Added here to declare Interface Builder support
  (IBInspectable).
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most closely align with the "label text" as described in the guidance..
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
 

--- a/components/TextFields/src/MDCMultilineTextField.h
+++ b/components/TextFields/src/MDCMultilineTextField.h
@@ -55,11 +55,12 @@
 
 /**
  The text string of the placeholder label.
- Bringing convenience api found in UITextField to all MDCTextInputs. Maps to the .text of the
+ Bringing convenience API found in UITextField to all MDCTextInputs. Maps to the .text of the
  placeholder label.
 
  Note: Inherited from MDCTextInput protocol. Added here to declare Interface Builder support
  (IBInspectable).
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
 

--- a/components/TextFields/src/MDCMultilineTextField.h
+++ b/components/TextFields/src/MDCMultilineTextField.h
@@ -61,7 +61,8 @@
  Note: Inherited from MDCTextInput protocol. Added here to declare Interface Builder support
  (IBInspectable).
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. The placeholder-related properties of this class most closely align with the "label text" as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance..
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
 

--- a/components/TextFields/src/MDCMultilineTextField.h
+++ b/components/TextFields/src/MDCMultilineTextField.h
@@ -60,7 +60,9 @@
 
  Note: Inherited from MDCTextInput protocol. Added here to declare Interface Builder support
  (IBInspectable).
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
 

--- a/components/TextFields/src/MDCMultilineTextField.h
+++ b/components/TextFields/src/MDCMultilineTextField.h
@@ -62,7 +62,7 @@
  (IBInspectable).
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
  placeholder as distinct from `label text`. The placeholder-related properties of this class most
- closely align with the "label text" as described in the guidance..
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, nullable, copy) IBInspectable NSString *placeholder;
 

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -48,8 +48,10 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  The attributed text string of the placeholder label.
  Bringing convenience API found in UITextField to all MDCTextInputs. Maps to the .attributedText of
  the placeholder label.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedPlaceholder;
 
@@ -111,8 +113,10 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
 
 /**
  Should it have the standard behavior of disappearing when you type? Defaults to YES.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(nonatomic, assign) BOOL hidesPlaceholderOnInput;
 
@@ -140,16 +144,20 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  The text string of the placeholder label.
  Bringing convenience api found in UITextField to all MDCTextInputs. Maps to the .text of the
  placeholder label.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(nonatomic, nullable, copy) NSString *placeholder;
 
 /**
  The label displaying text when no input text has been entered.
- 
 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(nonatomic, nonnull, strong, readonly) UILabel *placeholderLabel;
 

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -46,9 +46,10 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
 
 /**
  The attributed text string of the placeholder label.
- Bringing convenience api found in UITextField to all MDCTextInputs. Maps to the .attributedText of
- the
- placeholder label.
+ Bringing convenience API found in UITextField to all MDCTextInputs. Maps to the .attributedText of
+ the placeholder label.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
  */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedPlaceholder;
 
@@ -108,7 +109,11 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
 /** The font of the text in the input. */
 @property(nonatomic, nullable, strong) UIFont *font;
 
-/** Should it have the standard behavior of disappearing when you type? Defaults to YES. */
+/**
+ Should it have the standard behavior of disappearing when you type? Defaults to YES.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+ */
 @property(nonatomic, assign) BOOL hidesPlaceholderOnInput;
 
 /**
@@ -135,12 +140,16 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  The text string of the placeholder label.
  Bringing convenience api found in UITextField to all MDCTextInputs. Maps to the .text of the
  placeholder label.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
  */
 @property(nonatomic, nullable, copy) NSString *placeholder;
 
 /**
- The label displaying text when no input text has been entered. The Material Design guidelines call
- this 'Hint text.'
+ The label displaying text when no input text has been entered.
+ 
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
  */
 @property(nonatomic, nonnull, strong, readonly) UILabel *placeholderLabel;
 

--- a/components/TextFields/src/MDCTextInput.h
+++ b/components/TextFields/src/MDCTextInput.h
@@ -50,8 +50,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  the placeholder label.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedPlaceholder;
 
@@ -115,8 +115,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  Should it have the standard behavior of disappearing when you type? Defaults to YES.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, assign) BOOL hidesPlaceholderOnInput;
 
@@ -146,8 +146,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
  placeholder label.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, nullable, copy) NSString *placeholder;
 
@@ -156,8 +156,8 @@ typedef NS_ENUM(NSUInteger, MDCTextInputTextInsetsMode) {
 
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, nonnull, strong, readonly) UILabel *placeholderLabel;
 

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -106,8 +106,8 @@
  Default is inlinePlaceholderColorDefault.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColor;
 
@@ -115,8 +115,8 @@
  Default value for inlinePlaceholderColor.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance..
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
@@ -137,8 +137,8 @@
  Default is inlinePlaceholderFontDefault;
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFont;
 
@@ -146,8 +146,8 @@
  Default value for inlinePlaceholderFont.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(class, nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFontDefault;
 
@@ -200,8 +200,8 @@
  The text displayed in the placeholder label.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @property(nonatomic, nullable, copy) NSString *placeholderText;
 

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -104,10 +104,16 @@
  The color applied to the placeholder when inline (not floating).
 
  Default is inlinePlaceholderColorDefault.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
  */
 @property(nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColor;
 
-/** Default value for inlinePlaceholderColor. */
+/**
+ Default value for inlinePlaceholderColor.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+ */
 @property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
 /**
@@ -125,10 +131,16 @@
  The font applied to the placeholder when inline (not floating).
 
  Default is inlinePlaceholderFontDefault;
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @property(nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFont;
 
-/** Default value for inlinePlaceholderFont. */
+/**
+ Default value for inlinePlaceholderFont.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ */
 @property(class, nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFontDefault;
 
 /**
@@ -176,7 +188,11 @@
 /** Default value for normalColor. */
 @property(class, nonatomic, null_resettable, strong) UIColor *normalColorDefault;
 
-/** The text displayed in the placeholder label.*/
+/**
+ The text displayed in the placeholder label.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ */
 @property(nonatomic, nullable, copy) NSString *placeholderText;
 
 /**

--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -104,15 +104,19 @@
  The color applied to the placeholder when inline (not floating).
 
  Default is inlinePlaceholderColorDefault.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColor;
 
 /**
  Default value for inlinePlaceholderColor.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance..
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance..
  */
 @property(class, nonatomic, null_resettable, strong) UIColor *inlinePlaceholderColorDefault;
 
@@ -132,14 +136,18 @@
 
  Default is inlinePlaceholderFontDefault;
 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @property(nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFont;
 
 /**
  Default value for inlinePlaceholderFont.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @property(class, nonatomic, null_resettable, strong) UIFont *inlinePlaceholderFontDefault;
 
@@ -190,8 +198,10 @@
 
 /**
  The text displayed in the placeholder label.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @property(nonatomic, nullable, copy) NSString *placeholderText;
 

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -54,6 +54,8 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
  Underline Height Normal - 0p
 
  Underline View Mode - While editing
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
 */
 @interface MDCTextInputControllerBase : NSObject <MDCTextInputControllerFloatingPlaceholder>
 

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -54,8 +54,10 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
  Underline Height Normal - 0p
 
  Underline View Mode - While editing
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
 */
 @interface MDCTextInputControllerBase : NSObject <MDCTextInputControllerFloatingPlaceholder>
 

--- a/components/TextFields/src/MDCTextInputControllerBase.h
+++ b/components/TextFields/src/MDCTextInputControllerBase.h
@@ -56,8 +56,8 @@ extern const CGFloat MDCTextInputControllerBaseDefaultBorderRadius;
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
 */
 @interface MDCTextInputControllerBase : NSObject <MDCTextInputControllerFloatingPlaceholder>
 

--- a/components/TextFields/src/MDCTextInputControllerFilled.h
+++ b/components/TextFields/src/MDCTextInputControllerFilled.h
@@ -50,8 +50,10 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @interface MDCTextInputControllerFilled : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerFilled.h
+++ b/components/TextFields/src/MDCTextInputControllerFilled.h
@@ -50,6 +50,8 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @interface MDCTextInputControllerFilled : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerFilled.h
+++ b/components/TextFields/src/MDCTextInputControllerFilled.h
@@ -52,8 +52,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @interface MDCTextInputControllerFilled : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
+++ b/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
@@ -14,7 +14,11 @@
 
 #import "MDCTextInputController.h"
 
-/** Controllers that have the ability to move the placeholder to a title position. */
+/**
+ Controllers that have the ability to move the placeholder to a title position.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ */
 @protocol MDCTextInputControllerFloatingPlaceholder <MDCTextInputController>
 
 /**

--- a/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
+++ b/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
@@ -18,8 +18,8 @@
  Controllers that have the ability to move the placeholder to a title position.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @protocol MDCTextInputControllerFloatingPlaceholder <MDCTextInputController>
 

--- a/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
+++ b/components/TextFields/src/MDCTextInputControllerFloatingPlaceholder.h
@@ -17,7 +17,9 @@
 /**
  Controllers that have the ability to move the placeholder to a title position.
 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @protocol MDCTextInputControllerFloatingPlaceholder <MDCTextInputController>
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
@@ -56,8 +56,10 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
 */
 @interface MDCTextInputControllerLegacyDefault : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
@@ -58,8 +58,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
 */
 @interface MDCTextInputControllerLegacyDefault : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyDefault.h
@@ -56,6 +56,8 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
 */
 @interface MDCTextInputControllerLegacyDefault : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
@@ -49,6 +49,8 @@
  Underline Height Normal - 0p
 
  Underline View Mode - While editing
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @interface MDCTextInputControllerLegacyFullWidth : MDCTextInputControllerFullWidth
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
@@ -49,8 +49,10 @@
  Underline Height Normal - 0p
 
  Underline View Mode - While editing
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @interface MDCTextInputControllerLegacyFullWidth : MDCTextInputControllerFullWidth
 

--- a/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
+++ b/components/TextFields/src/MDCTextInputControllerLegacyFullWidth.h
@@ -51,8 +51,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @interface MDCTextInputControllerLegacyFullWidth : MDCTextInputControllerFullWidth
 

--- a/components/TextFields/src/MDCTextInputControllerOutlined.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.h
@@ -54,6 +54,8 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @interface MDCTextInputControllerOutlined : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerOutlined.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.h
@@ -55,7 +55,9 @@
 
  Underline View Mode - While editing
 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @interface MDCTextInputControllerOutlined : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerOutlined.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlined.h
@@ -56,8 +56,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @interface MDCTextInputControllerOutlined : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
@@ -63,8 +63,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 
 @interface MDCTextInputControllerOutlinedTextArea : MDCTextInputControllerBase

--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
@@ -62,7 +62,9 @@
 
  Underline View Mode - While editing
 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 
 @interface MDCTextInputControllerOutlinedTextArea : MDCTextInputControllerBase

--- a/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
+++ b/components/TextFields/src/MDCTextInputControllerOutlinedTextArea.h
@@ -61,6 +61,8 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 
 @interface MDCTextInputControllerOutlinedTextArea : MDCTextInputControllerBase

--- a/components/TextFields/src/MDCTextInputControllerUnderline.h
+++ b/components/TextFields/src/MDCTextInputControllerUnderline.h
@@ -49,8 +49,10 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 @interface MDCTextInputControllerUnderline : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerUnderline.h
+++ b/components/TextFields/src/MDCTextInputControllerUnderline.h
@@ -49,6 +49,8 @@
  Underline Height Normal - 1p
 
  Underline View Mode - While editing
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
  */
 @interface MDCTextInputControllerUnderline : MDCTextInputControllerBase
 

--- a/components/TextFields/src/MDCTextInputControllerUnderline.h
+++ b/components/TextFields/src/MDCTextInputControllerUnderline.h
@@ -51,8 +51,8 @@
  Underline View Mode - While editing
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 @interface MDCTextInputControllerUnderline : MDCTextInputControllerBase
 

--- a/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
+++ b/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
@@ -28,15 +28,19 @@
 
 /**
  Refreshes the layout and style of the placeholder label. Called within updateLayout.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 - (void)updatePlaceholder;
 
 /**
  Refreshes the layout and style of the border view. Called within updateLayout.
- 
- Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
+ placeholder as distinct from `label text`. This property most similarly aligns with the `label
+ text` as described in the guidance.
  */
 - (BOOL)isPlaceholderUp;
 

--- a/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
+++ b/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
@@ -26,10 +26,18 @@
 /** Refreshes the geometry and style of the component. */
 - (void)updateLayout;
 
-/** Refreshes the layout and style of the placeholder label. Called within updateLayout. */
+/**
+ Refreshes the layout and style of the placeholder label. Called within updateLayout.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ */
 - (void)updatePlaceholder;
 
-/** Refreshes the layout and style of the border view. Called within updateLayout. */
+/**
+ Refreshes the layout and style of the border view. Called within updateLayout.
+ 
+ Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats placeholder as distinct from `label text`. This property most similarly aligns with the `label text` as described in the guidance.
+ */
 - (BOOL)isPlaceholderUp;
 
 /** Calculates the actual number of lines for the label provded. */

--- a/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
+++ b/components/TextFields/src/private/MDCTextInputControllerBase+Subclassing.h
@@ -30,8 +30,8 @@
  Refreshes the layout and style of the placeholder label. Called within updateLayout.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 - (void)updatePlaceholder;
 
@@ -39,8 +39,8 @@
  Refreshes the layout and style of the border view. Called within updateLayout.
 
  Note: The [Design guidance](https://material.io/components/text-fields/#anatomy) changed and treats
- placeholder as distinct from `label text`. This property most similarly aligns with the `label
- text` as described in the guidance.
+ placeholder as distinct from `label text`. The placeholder-related properties of this class most
+ closely align with the "label text" as described in the guidance.
  */
 - (BOOL)isPlaceholderUp;
 


### PR DESCRIPTION
Added header comment clarifying that the placeholder APIs are really for `label text` and not placeholder.

more info at https://github.com/material-components/material-components-ios/issues/7513