### PR TITLE
[Snackbar] Add invisible hit target for legacy snackbar

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -759,7 +759,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   } else {  // This is a horizontal layout, and there are buttons present.
     if (MDCSnackbarMessage.usesLegacySnackbar) {
       // Align the content and buttons horizontally.
-      formatString = @"H:[content]-(==kTitleButtonPadding)-[buttons][buttonGutter(==kRightMargin)]|";
+      formatString =
+          @"H:[content]-(==kTitleButtonPadding)-[buttons][buttonGutter(==kRightMargin)]|";
       [constraints addObjectsFromArray:[NSLayoutConstraint
                                            constraintsWithVisualFormat:formatString
                                                                options:NSLayoutFormatAlignAllCenterY


### PR DESCRIPTION
When the snackbar is in legacy mode, add an invisible hit area between the action button and the edge of the screen. This ensures that tapping the area between the button and the edge of the screen registers as a button tap and doesn't just dismiss the snackbar. 

Fixes #8806 