### PR TITLE
[Tabs] Mark TabBarView as accessibility tab bar.

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -440,6 +440,19 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   return UIEdgeInsetsZero;
 }
 
+#pragma mark - UIAccessibility
+
+- (BOOL)isAccessibilityElement {
+  return NO;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits {
+  if (@available(iOS 10.0, *)) {
+    return [super accessibilityTraits] | UIAccessibilityTraitTabBar;
+  }
+  return [super accessibilityTraits];
+}
+
 #pragma mark - Custom APIs
 
 - (id)accessibilityElementForItem:(UITabBarItem *)item {

--- a/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
+++ b/components/Tabs/tests/unit/TabBarView/MDCTabBarViewTests.m
@@ -1138,6 +1138,24 @@ static UIImage *fakeImage(CGSize size) {
   XCTAssertNoThrow([self.tabBarView layoutIfNeeded]);
 }
 
+#pragma mark - UIAccessibility
+
+- (void)testTabBarViewNotAccessibilityElement {
+  // Then
+  XCTAssertFalse(self.tabBarView.isAccessibilityElement);
+}
+
+- (void)testTabBarViewAlwaysBehavesAsTabBarOniOS10 {
+  // When
+  self.tabBarView.accessibilityTraits = UIAccessibilityTraitLink;
+
+  if (@available(iOS 10.0, *)) {
+    // Then
+    XCTAssertEqual(self.tabBarView.accessibilityTraits,
+                   UIAccessibilityTraitTabBar | UIAccessibilityTraitLink);
+  }
+}
+
 #pragma mark - Custom APIs
 
 - (void)testAccessibilityElementForItemNotInItemsArrayReturnsNil {


### PR DESCRIPTION
Marks the `MDCTabBarView` class a tab bar for UIAccessibility. This
supplements the accessibility information provided to users by including the
element's index and total number of items. In VoiceOver, this is vocalized as
something similar to "{title}, tab, 1 of 3".

Closes #8495