### PR TITLE
[TextControls] Use system dynamic colors for sensible defaults in iOS 13

### DIFF
--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -48,26 +48,31 @@ static CGFloat const kDefaultPadding = 15.0;
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.title = kExampleTitle;
-
   if (!self.containerScheme) {
     self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  if (@available(iOS 13.0, *)) {
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
   }
 
   self.resignFirstResponderButton = [self createFirstResponderButton];
   [self.view addSubview:self.resignFirstResponderButton];
 
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   self.baseTextField = [[MDCBaseTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
   self.baseTextField.borderStyle = UITextBorderStyleRoundedRect;
   self.baseTextField.label.text = @"This is a label";
   self.baseTextField.placeholder = @"This is placeholder text";
   self.baseTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+  self.baseTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
   [self.view addSubview:self.baseTextField];
 
   self.filledTextField = [[MDCFilledTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
   self.filledTextField.label.text = @"This is a label";
   self.filledTextField.placeholder = @"This is placeholder text";
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+  self.filledTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
   [self.view addSubview:self.filledTextField];
 
   self.outlinedTextField =
@@ -75,6 +80,7 @@ static CGFloat const kDefaultPadding = 15.0;
   self.outlinedTextField.label.text = @"This is a label";
   self.outlinedTextField.placeholder = @"This is placeholder text";
   self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+  self.outlinedTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
   [self.view addSubview:self.outlinedTextField];
 }
 

--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -47,17 +47,17 @@ static CGFloat const kDefaultPadding = 15.0;
 
 - (void)viewDidLoad {
   [super viewDidLoad];
+
   self.title = kExampleTitle;
+
   if (!self.containerScheme) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+    self.containerScheme = containerScheme;
   }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
-#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
-  if (@available(iOS 13.0, *)) {
-    self.view.backgroundColor = [UIColor systemBackgroundColor];
-  }
-#endif
 
   self.resignFirstResponderButton = [self createFirstResponderButton];
   [self.view addSubview:self.resignFirstResponderButton];

--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -53,9 +53,11 @@ static CGFloat const kDefaultPadding = 15.0;
   }
 
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     self.view.backgroundColor = [UIColor systemBackgroundColor];
   }
+#endif
 
   self.resignFirstResponderButton = [self createFirstResponderButton];
   [self.view addSubview:self.resignFirstResponderButton];

--- a/components/TextControls/src/private/MDCTextControlColorViewModel.m
+++ b/components/TextControls/src/private/MDCTextControlColorViewModel.m
@@ -39,6 +39,13 @@
   UIColor *normalLabelColor = [UIColor darkGrayColor];
   UIColor *leadingAssistiveLabelColor = [UIColor darkGrayColor];
   UIColor *trailingAssistiveLabelColor = [UIColor darkGrayColor];
+  if (@available(iOS 13.0, *)) {
+    textColor = [UIColor labelColor];
+    floatingLabelColor = [UIColor secondaryLabelColor];
+    normalLabelColor = [UIColor secondaryLabelColor];
+    leadingAssistiveLabelColor = [UIColor secondaryLabelColor];
+    trailingAssistiveLabelColor = [UIColor secondaryLabelColor];
+  }
   CGFloat disabledAlpha = (CGFloat)0.60;
   switch (state) {
     case MDCTextControlStateNormal:

--- a/components/TextControls/src/private/MDCTextControlColorViewModel.m
+++ b/components/TextControls/src/private/MDCTextControlColorViewModel.m
@@ -41,10 +41,10 @@
   UIColor *trailingAssistiveLabelColor = [UIColor darkGrayColor];
   if (@available(iOS 13.0, *)) {
     textColor = [UIColor labelColor];
-    floatingLabelColor = [UIColor secondaryLabelColor];
-    normalLabelColor = [UIColor secondaryLabelColor];
-    leadingAssistiveLabelColor = [UIColor secondaryLabelColor];
-    trailingAssistiveLabelColor = [UIColor secondaryLabelColor];
+    floatingLabelColor = [UIColor labelColor];
+    normalLabelColor = [UIColor labelColor];
+    leadingAssistiveLabelColor = [UIColor labelColor];
+    trailingAssistiveLabelColor = [UIColor labelColor];
   }
   CGFloat disabledAlpha = (CGFloat)0.60;
   switch (state) {

--- a/components/TextControls/src/private/MDCTextControlColorViewModel.m
+++ b/components/TextControls/src/private/MDCTextControlColorViewModel.m
@@ -39,6 +39,8 @@
   UIColor *normalLabelColor = [UIColor darkGrayColor];
   UIColor *leadingAssistiveLabelColor = [UIColor darkGrayColor];
   UIColor *trailingAssistiveLabelColor = [UIColor darkGrayColor];
+
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     textColor = [UIColor labelColor];
     floatingLabelColor = [UIColor labelColor];
@@ -46,6 +48,8 @@
     leadingAssistiveLabelColor = [UIColor labelColor];
     trailingAssistiveLabelColor = [UIColor labelColor];
   }
+#endif
+
   CGFloat disabledAlpha = (CGFloat)0.60;
   switch (state) {
     case MDCTextControlStateNormal:

--- a/components/TextControls/src/private/MDCTextControlStyleFilled.m
+++ b/components/TextControls/src/private/MDCTextControlStyleFilled.m
@@ -68,6 +68,9 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 - (void)setUpUnderlineColors {
   self.underlineColors = [NSMutableDictionary new];
   UIColor *underlineColor = [UIColor blackColor];
+  if (@available(iOS 13.0, *)) {
+    underlineColor = [UIColor labelColor];
+  }
   self.underlineColors[@(MDCTextControlStateNormal)] = underlineColor;
   self.underlineColors[@(MDCTextControlStateEditing)] = underlineColor;
   self.underlineColors[@(MDCTextControlStateDisabled)] = underlineColor;
@@ -75,7 +78,12 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 - (void)setUpFilledBackgroundColors {
   self.filledBackgroundColors = [NSMutableDictionary new];
-  UIColor *filledBackgroundColor = [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.05];
+  UIColor *filledBackgroundColor = [UIColor blackColor];
+  filledBackgroundColor = [filledBackgroundColor colorWithAlphaComponent:(CGFloat)0.05];
+  if (@available(iOS 13.0, *)) {
+    filledBackgroundColor = [UIColor secondarySystemBackgroundColor];
+  }
+
   self.filledBackgroundColors[@(MDCTextControlStateNormal)] = filledBackgroundColor;
   self.filledBackgroundColors[@(MDCTextControlStateEditing)] = filledBackgroundColor;
   self.filledBackgroundColors[@(MDCTextControlStateDisabled)] = filledBackgroundColor;

--- a/components/TextControls/src/private/MDCTextControlStyleFilled.m
+++ b/components/TextControls/src/private/MDCTextControlStyleFilled.m
@@ -68,9 +68,11 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 - (void)setUpUnderlineColors {
   self.underlineColors = [NSMutableDictionary new];
   UIColor *underlineColor = [UIColor blackColor];
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     underlineColor = [UIColor labelColor];
   }
+#endif
   self.underlineColors[@(MDCTextControlStateNormal)] = underlineColor;
   self.underlineColors[@(MDCTextControlStateEditing)] = underlineColor;
   self.underlineColors[@(MDCTextControlStateDisabled)] = underlineColor;
@@ -80,9 +82,11 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
   self.filledBackgroundColors = [NSMutableDictionary new];
   UIColor *filledBackgroundColor = [UIColor blackColor];
   filledBackgroundColor = [filledBackgroundColor colorWithAlphaComponent:(CGFloat)0.05];
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     filledBackgroundColor = [UIColor secondarySystemBackgroundColor];
   }
+#endif
 
   self.filledBackgroundColors[@(MDCTextControlStateNormal)] = filledBackgroundColor;
   self.filledBackgroundColors[@(MDCTextControlStateEditing)] = filledBackgroundColor;

--- a/components/TextControls/src/private/MDCTextControlStyleOutlined.m
+++ b/components/TextControls/src/private/MDCTextControlStyleOutlined.m
@@ -52,10 +52,14 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 
 - (void)setUpOutlineColors {
   self.outlineColors = [NSMutableDictionary new];
-  self.outlineColors[@(MDCTextControlStateNormal)] = [UIColor blackColor];
-  self.outlineColors[@(MDCTextControlStateEditing)] = [UIColor blackColor];
+  UIColor *outlineColor = [UIColor blackColor];
+  if (@available(iOS 13.0, *)) {
+    outlineColor = [UIColor labelColor];
+  }
+  self.outlineColors[@(MDCTextControlStateNormal)] = outlineColor;
+  self.outlineColors[@(MDCTextControlStateEditing)] = outlineColor;
   self.outlineColors[@(MDCTextControlStateDisabled)] =
-      [[UIColor blackColor] colorWithAlphaComponent:(CGFloat)0.60];
+      [outlineColor colorWithAlphaComponent:(CGFloat)0.60];
 }
 
 - (void)setUpOutlineLineWidths {

--- a/components/TextControls/src/private/MDCTextControlStyleOutlined.m
+++ b/components/TextControls/src/private/MDCTextControlStyleOutlined.m
@@ -53,9 +53,11 @@ static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
 - (void)setUpOutlineColors {
   self.outlineColors = [NSMutableDictionary new];
   UIColor *outlineColor = [UIColor blackColor];
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     outlineColor = [UIColor labelColor];
   }
+#endif
   self.outlineColors[@(MDCTextControlStateNormal)] = outlineColor;
   self.outlineColors[@(MDCTextControlStateEditing)] = outlineColor;
   self.outlineColors[@(MDCTextControlStateDisabled)] =


### PR DESCRIPTION
MDCFilledTextField and MDCOutlinedTextField are completely unreadable (inaccessible) in iOS 13 dark mode when shown over the system background color. When using `borderStyle`, MDCBaseTextField is completely unreadable in iOS 13 dark mode when shown over _any_ color, because UITextField adds a system background color to the textfield's background. This PR addresses these issues. This PR doesn't affect pre-iOS 13 behavior.

Note that the system placeholder and clear button never pass contrast in dark mode. I know the system clear button doesn't even pass contrast in light mode.

Note that the below gifs are outdated. Here's what it looks like now in dark mode:

<img width="371" alt="Screen Shot 2019-11-14 at 11 40 07 AM" src="https://user-images.githubusercontent.com/8020010/68877158-9a036000-06d3-11ea-8cd2-902a1d2b0eb1.png">

Here's a before gif in iOS 13 dark mode:
![iOS13darkbefore](https://user-images.githubusercontent.com/8020010/68875587-15afdd80-06d1-11ea-8bee-b583a56e4537.gif)

Here's an after gif in iOS 13 light mode:
![iOS13light](https://user-images.githubusercontent.com/8020010/68875641-2c563480-06d1-11ea-8172-5743390bf839.gif)

Here's an after gif in iOS 13 dark mode:

![iOS13Dark](https://user-images.githubusercontent.com/8020010/68875625-282a1700-06d1-11ea-9f3d-2d56d068f3ed.gif)

Closes #8817.