### PR TITLE
[Ripple] Add usesSuperviewShadowLayerAsMask flag.

### DIFF
--- a/components/Ripple/README.md
+++ b/components/Ripple/README.md
@@ -386,6 +386,7 @@ Example usage:
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
+
 ```swift
 // During initialization:
 rippleView.usesSuperviewShadowLayerAsMask = false
@@ -397,6 +398,7 @@ rippleView.layer.mask = rippleViewMask
 ```
 
 #### Objective-C
+
 ```objc
 // During initialization:
 rippleView.usesSuperviewShadowLayerAsMask = NO;

--- a/components/Ripple/README.md
+++ b/components/Ripple/README.md
@@ -45,6 +45,8 @@ Ripple is a visual form of feedback for touch events providing users a clear sig
   - [MDCRippleTouchController](#mdcrippletouchcontroller)
   - [MDCRippleView](#mdcrippleview)
   - [MDCStatefulRippleView](#mdcstatefulrippleview)
+- [Migrations](#migrations)
+  - [usesSuperviewShadowLayerAsMask migration](#usessuperviewshadowlayerasmask-migration)
 
 - - -
 
@@ -359,4 +361,53 @@ MDCStatefulRippleView *statefulRippleView = [[MDCStatefulRippleView alloc] init]
 }
 ```
 <!--</div>-->
+
+
+## Migrations
+
+<!-- Extracted from docs/migration-usesSuperviewShadowLayerAsMask.md -->
+
+### usesSuperviewShadowLayerAsMask migration
+
+tl;dr: If you are adding ripples to views with custom `layer.shadowPath` values, please disable
+`usesSuperviewShadowLayerAsMask` and assign an explicit layer mask to the ripple view if needed
+instead. usesSuperviewShadowLayerAsMask will eventually be disabled by default and then deleted.
+
+MDCRippleView currently implements a convenience behavior that will inherit its parent view's
+`layer.shadowPath` as the mask of the ripple view itself. This works for the general case where the
+ripple view's frame equals the bounds of its super view, but behaves unexpectedly for any other
+frame of the ripple view.
+
+Due to the brittleness of this behavior, a new migration property, `usesSuperviewShadowLayerAsMask`,
+has been added that will allow you to disable this behavior in favor of a more explicit
+determination of the ripple's layer mask.
+
+Example usage:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// During initialization:
+rippleView.usesSuperviewShadowLayerAsMask = false
+
+// Simple example of applying a mask to the ripple view using the ripple view's bounds:
+let rippleViewMask = CAShapeLayer()
+rippleViewMask.path = UIBezierPath(rect: rippleView.bounds).cgPath
+rippleView.layer.mask = rippleViewMask
+```
+
+#### Objective-C
+```objc
+// During initialization:
+rippleView.usesSuperviewShadowLayerAsMask = NO;
+
+// Simple example of applying a mask to the ripple view using the ripple view's bounds:
+CAShapeLayer *rippleViewMask = [[CAShapeLayer alloc] init];
+rippleViewMask.path = [UIBezierPath bezierPathWithRect:rippleView.bounds].CGPath;
+rippleView.layer.mask = rippleViewMask;
+```
+<!--</div>-->
+
+Please consider disabling `usesSuperviewShadowLayerAsMask` if you are creating MDCRippleView
+instances. The property will be disabled by default in the future and then deprecated.
 

--- a/components/Ripple/docs/README.md
+++ b/components/Ripple/docs/README.md
@@ -25,3 +25,7 @@ Ripple is a material design implementation of touch feedback and is a successor 
 ## Usage
 
 - [Typical use](typical-use.md)
+
+## Migrations
+
+- [usesSuperviewShadowLayerAsMask]](migration-usesSuperviewShadowLayerAsMask.md)

--- a/components/Ripple/docs/migration-usesSuperviewShadowLayerAsMask.md
+++ b/components/Ripple/docs/migration-usesSuperviewShadowLayerAsMask.md
@@ -1,0 +1,43 @@
+### usesSuperviewShadowLayerAsMask migration
+
+tl;dr: If you are adding ripples to views with custom `layer.shadowPath` values, please disable
+`usesSuperviewShadowLayerAsMask` and assign an explicit layer mask to the ripple view if needed
+instead. usesSuperviewShadowLayerAsMask will eventually be disabled by default and then deleted.
+
+MDCRippleView currently implements a convenience behavior that will inherit its parent view's
+`layer.shadowPath` as the mask of the ripple view itself. This works for the general case where the
+ripple view's frame equals the bounds of its super view, but behaves unexpectedly for any other
+frame of the ripple view.
+
+Due to the brittleness of this behavior, a new migration property, `usesSuperviewShadowLayerAsMask`,
+has been added that will allow you to disable this behavior in favor of a more explicit
+determination of the ripple's layer mask.
+
+Example usage:
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+// During initialization:
+rippleView.usesSuperviewShadowLayerAsMask = false
+
+// Simple example of applying a mask to the ripple view using the ripple view's bounds:
+let rippleViewMask = CAShapeLayer()
+rippleViewMask.path = UIBezierPath(rect: rippleView.bounds).cgPath
+rippleView.layer.mask = rippleViewMask
+```
+
+#### Objective-C
+```objc
+// During initialization:
+rippleView.usesSuperviewShadowLayerAsMask = NO;
+
+// Simple example of applying a mask to the ripple view using the ripple view's bounds:
+CAShapeLayer *rippleViewMask = [[CAShapeLayer alloc] init];
+rippleViewMask.path = [UIBezierPath bezierPathWithRect:rippleView.bounds].CGPath;
+rippleView.layer.mask = rippleViewMask;
+```
+<!--</div>-->
+
+Please consider disabling `usesSuperviewShadowLayerAsMask` if you are creating MDCRippleView
+instances. The property will be disabled by default in the future and then deprecated.

--- a/components/Ripple/docs/migration-usesSuperviewShadowLayerAsMask.md
+++ b/components/Ripple/docs/migration-usesSuperviewShadowLayerAsMask.md
@@ -17,6 +17,7 @@ Example usage:
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
+
 ```swift
 // During initialization:
 rippleView.usesSuperviewShadowLayerAsMask = false
@@ -28,6 +29,7 @@ rippleView.layer.mask = rippleViewMask
 ```
 
 #### Objective-C
+
 ```objc
 // During initialization:
 rippleView.usesSuperviewShadowLayerAsMask = NO;

--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -86,6 +86,8 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
  clipped ripple effect. Consider disabling this behavior and explicitly setting a layer mask
  instead.
 
+ Changing this value to NO does not clear the mask if it was already set.
+
  Default value is YES.
  */
 @property(nonatomic, assign) BOOL usesSuperviewShadowLayerAsMask;

--- a/components/Ripple/src/MDCRippleView.h
+++ b/components/Ripple/src/MDCRippleView.h
@@ -74,6 +74,23 @@ typedef NS_ENUM(NSInteger, MDCRippleStyle) {
 @property(nonatomic, strong, nonnull) UIColor *activeRippleColor;
 
 /**
+ When rippleStyle is MDCRippleStyleBounded, this flag affects whether the layer's mask will use
+ the super view's layer.shadowPath as the mask path.
+
+ @note This behavior only takes effect if the ripple view's parent view has a non-nil shadowPath.
+
+ @note This behavioral flag will eventually become NO by default and then be deleted. The YES
+ behavior is undesired because it assumes that the frame of the ripple view always matches the
+ bounds of the superview. When this assumption is false, such as when the ripple's origin is
+ non-zero, the ripple's mask tends to be bigger than it should be resulting in an incorrectly
+ clipped ripple effect. Consider disabling this behavior and explicitly setting a layer mask
+ instead.
+
+ Default value is YES.
+ */
+@property(nonatomic, assign) BOOL usesSuperviewShadowLayerAsMask;
+
+/**
  A block that is invoked when the @c MDCRippleView receives a call to @c
  traitCollectionDidChange:. The block is called after the call to the superclass.
  */

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -57,6 +57,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 }
 
 - (void)commonMDCRippleViewInit {
+  self.usesSuperviewShadowLayerAsMask = YES;
   self.userInteractionEnabled = NO;
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 
@@ -104,7 +105,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 - (void)updateRippleStyle {
   self.layer.masksToBounds = (self.rippleStyle == MDCRippleStyleBounded);
   if (self.rippleStyle == MDCRippleStyleBounded) {
-    if (self.superview.layer.shadowPath) {
+    if (self.usesSuperviewShadowLayerAsMask && self.superview.layer.shadowPath) {
       if (!self.maskLayer) {
         // Use mask layer when the superview has a shadowPath.
         self.maskLayer = [CAShapeLayer layer];

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -57,7 +57,7 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
 }
 
 - (void)commonMDCRippleViewInit {
-  self.usesSuperviewShadowLayerAsMask = YES;
+  _usesSuperviewShadowLayerAsMask = YES;
   self.userInteractionEnabled = NO;
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 

--- a/components/Ripple/src/MDCRippleView.m
+++ b/components/Ripple/src/MDCRippleView.m
@@ -102,6 +102,14 @@ static const CGFloat kRippleFadeOutDelay = (CGFloat)0.15;
   [self updateRippleStyle];
 }
 
+- (void)setUsesSuperviewShadowLayerAsMask:(BOOL)usesSuperviewShadowLayerAsMask {
+  _usesSuperviewShadowLayerAsMask = usesSuperviewShadowLayerAsMask;
+
+  if (_usesSuperviewShadowLayerAsMask) {
+    [self setNeedsLayout];
+  }
+}
+
 - (void)updateRippleStyle {
   self.layer.masksToBounds = (self.rippleStyle == MDCRippleStyleBounded);
   if (self.rippleStyle == MDCRippleStyleBounded) {

--- a/components/Ripple/tests/unit/MDCRippleViewUsesSuperviewShadowLayerAsMaskTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewUsesSuperviewShadowLayerAsMaskTests.m
@@ -108,4 +108,21 @@
   XCTAssertTrue(CGPathEqualToPath(maskShapeLayer.path, parentView.layer.shadowPath));
 }
 
+- (void)testDoesNotInheritParentShadowPathWhenRippleStyleSetToBoundedWhenUsesSuperviewShadowLayerAsMaskDisabled {
+  // Given
+  MDCRippleView *rippleView = [[MDCRippleView alloc] init];
+  UIView *parentView = [[UIView alloc] init];
+  [parentView addSubview:rippleView];
+  parentView.frame = CGRectMake(0, 0, 100, 50);
+  rippleView.frame = CGRectMake(10, 10, 30, 30);
+
+  // When
+  rippleView.usesSuperviewShadowLayerAsMask = NO; // Disable the incorrect behavior.
+  parentView.layer.shadowPath = [UIBezierPath bezierPathWithRect:parentView.bounds].CGPath;
+  rippleView.rippleStyle = MDCRippleStyleBounded;
+
+  // Then
+  XCTAssertNil(rippleView.layer.mask);
+}
+
 @end

--- a/components/Ripple/tests/unit/MDCRippleViewUsesSuperviewShadowLayerAsMaskTests.m
+++ b/components/Ripple/tests/unit/MDCRippleViewUsesSuperviewShadowLayerAsMaskTests.m
@@ -108,7 +108,8 @@
   XCTAssertTrue(CGPathEqualToPath(maskShapeLayer.path, parentView.layer.shadowPath));
 }
 
-- (void)testDoesNotInheritParentShadowPathWhenRippleStyleSetToBoundedWhenUsesSuperviewShadowLayerAsMaskDisabled {
+- (void)
+    testDoesNotInheritParentShadowPathWhenRippleStyleSetToBoundedWhenUsesSuperviewShadowLayerAsMaskDisabled {
   // Given
   MDCRippleView *rippleView = [[MDCRippleView alloc] init];
   UIView *parentView = [[UIView alloc] init];
@@ -117,7 +118,7 @@
   rippleView.frame = CGRectMake(10, 10, 30, 30);
 
   // When
-  rippleView.usesSuperviewShadowLayerAsMask = NO; // Disable the incorrect behavior.
+  rippleView.usesSuperviewShadowLayerAsMask = NO;  // Disable the incorrect behavior.
   parentView.layer.shadowPath = [UIBezierPath bezierPathWithRect:parentView.bounds].CGPath;
   rippleView.rippleStyle = MDCRippleStyleBounded;
 


### PR DESCRIPTION
Follow-up to https://github.com/material-components/material-components-ios/pull/8808

Part of https://github.com/material-components/material-components-ios/issues/6913

From the docs:

tl;dr: If you are adding ripples to views with custom `layer.shadowPath` values, please disable
`usesSuperviewShadowLayerAsMask` and assign an explicit layer mask to the ripple view if needed
instead. usesSuperviewShadowLayerAsMask will eventually be disabled by default and then deleted.

MDCRippleView currently implements a convenience behavior that will inherit its parent view's
`layer.shadowPath` as the mask of the ripple view itself. This works for the general case where the
ripple view's frame equals the bounds of its super view, but behaves unexpectedly for any other
frame of the ripple view.

Due to the brittleness of this behavior, a new migration property, `usesSuperviewShadowLayerAsMask`,
has been added that will allow you to disable this behavior in favor of a more explicit
determination of the ripple's layer mask.

Example usage:

<!--<div class="material-code-render" markdown="1">-->
#### Swift
```swift
// During initialization:
rippleView.usesSuperviewShadowLayerAsMask = false
// Simple example of applying a mask to the ripple view using the ripple view's bounds:
let rippleViewMask = CAShapeLayer()
rippleViewMask.path = UIBezierPath(rect: rippleView.bounds).cgPath
rippleView.layer.mask = rippleViewMask
```
#### Objective-C
```objc
// During initialization:
rippleView.usesSuperviewShadowLayerAsMask = NO;
// Simple example of applying a mask to the ripple view using the ripple view's bounds:
CAShapeLayer *rippleViewMask = [[CAShapeLayer alloc] init];
rippleViewMask.path = [UIBezierPath bezierPathWithRect:rippleView.bounds].CGPath;
rippleView.layer.mask = rippleViewMask;
```
<!--</div>-->