### PR TITLE
[Catalog] Darken ButtonBarIconExample icon colors

### DIFF
--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -55,6 +55,7 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     deps = [
         ":ButtonBar",
+        "//components/Palettes",
         "//components/private/Icons/icons/ic_check_circle",
         "//components/private/Icons/icons/ic_info",
         "//components/schemes/Container",

--- a/components/ButtonBar/examples/ButtonBarIconExample.m
+++ b/components/ButtonBar/examples/ButtonBarIconExample.m
@@ -17,6 +17,7 @@
 #import "MaterialButtonBar.h"
 #import "MaterialIcons+ic_check_circle.h"
 #import "MaterialIcons+ic_info.h"
+#import "MaterialPalettes.h"
 
 @interface ButtonBarIconExample : UIViewController
 @end
@@ -27,7 +28,7 @@
   [super viewDidLoad];
 
   MDCButtonBar *buttonBar = [[MDCButtonBar alloc] init];
-  buttonBar.tintColor = UIColor.whiteColor;
+  buttonBar.tintColor = MDCPalette.indigoPalette.tint500;
 
   // MDCButtonBar ignores the style of UIBarButtonItem.
   UIBarButtonItemStyle ignored = UIBarButtonItemStyleDone;


### PR DESCRIPTION
Changes the icon color in ButtonBarIconExample from white to MDCPalette.indigoPalette.tint500 to achieve a contrast ratio of 5.52.

Fixes #8823 