### PR TITLE
[Catalog] Handle dynamic type in Dragons on iOS 10

### DIFF
--- a/catalog/MDCDragons/MDCDragonsController.swift
+++ b/catalog/MDCDragons/MDCDragonsController.swift
@@ -102,6 +102,8 @@ class MDCDragonsController: UIViewController,
     tableView.backgroundColor = Constants.bgColor
     tableView.delegate = self
     tableView.dataSource = self
+    tableView.rowHeight = UITableView.automaticDimension
+    tableView.estimatedRowHeight = 44
     view.addSubview(tableView)
     view.backgroundColor = Constants.bgColor
 


### PR DESCRIPTION
Sets `tableView.rowHeight` and `tableView.estimatedRowHeight` to fix a dynamic type layout issue on iOS 10.

Fixes #8821 

Before:
![before](https://user-images.githubusercontent.com/581764/68891138-45211300-06ee-11ea-80dd-5a9dde49c19b.png)

After:
![after](https://user-images.githubusercontent.com/581764/68891142-481c0380-06ee-11ea-9e85-0b4e59a9985c.png)

