### PR TITLE
[AppBar] Make example titles more accurate.

### DIFF
--- a/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
+++ b/components/AppBar/examples/AppBarAnimatedGlitchExample.swift
@@ -45,7 +45,7 @@ class AppBarAnimatedJumpExample: UIViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-    self.title = "Tab Bar Example"
+    self.title = "Manual Tabs Jump (Animated)"
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarGlitchExample.swift
+++ b/components/AppBar/examples/AppBarGlitchExample.swift
@@ -45,7 +45,7 @@ class AppBarJumpExample: UIViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-    self.title = "Tab Bar Example"
+    self.title = "Manual Tabs Jump"
     self.firstTab.title = "First"
     self.secondTab.title = "Second"
   }

--- a/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
+++ b/components/AppBar/examples/AppBarInheritedAnimatedJumpExample.swift
@@ -45,7 +45,7 @@ class AppBarInheritedAnimatedJumpExample: UIViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-    self.title = "Tab Bar Example"
+    self.title = "Manual Tabs Jump (Animated, UITableViewController)"
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/components/AppBar/examples/AppBarManualTabsExample.swift
+++ b/components/AppBar/examples/AppBarManualTabsExample.swift
@@ -49,7 +49,7 @@ class AppBarManualTabsExample: UIViewController {
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-    self.title = "Tab Bar Example"
+    self.title = "Manual Tabs"
     self.firstTab.title = "First"
     self.secondTab.title = "Second"
   }


### PR DESCRIPTION
Have the titles reflect their catalog breadcrumb names.

Found while auditing dragons.
