### PR TITLE
[Catalog] Fix Banner positioning in example for iOS 10

### DIFF
--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -58,7 +58,6 @@ mdc_examples_objc_library(
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",
-        "//components/private/Application",
     ],
 )
 

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -58,6 +58,7 @@ mdc_examples_objc_library(
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",
+        "//components/private/Application",
     ],
 )
 

--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialAppBar.h"
-#import "MaterialApplication.h"
 #import "MaterialBanner.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
@@ -174,13 +172,7 @@ static NSString *const exampleSuperLongText =
   if (@available(iOS 11.0, *)) {
     yOrigin = self.view.safeAreaInsets.top;
   } else {
-    if ([self.parentViewController isKindOfClass:[MDCAppBarContainerViewController class]]) {
-      MDCAppBarContainerViewController *containerViewController =
-          (MDCAppBarContainerViewController *)self.parentViewController;
-      UIApplication *safeApplication = [UIApplication mdc_safeSharedApplication];
-      yOrigin = CGRectGetMaxY(containerViewController.appBarViewController.navigationBar.frame) +
-                CGRectGetHeight(safeApplication.statusBarFrame);
-    }
+    yOrigin = self.topLayoutGuide.length;
   }
 
   self.bannerView.frame = CGRectMake(0.0f, yOrigin, bannerViewSize.width, bannerViewSize.height);

--- a/components/Banner/examples/BannerTypicalUseExampleViewController.m
+++ b/components/Banner/examples/BannerTypicalUseExampleViewController.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "MaterialAppBar.h"
+#import "MaterialApplication.h"
 #import "MaterialBanner.h"
 #import "MaterialButtons+Theming.h"
 #import "MaterialButtons.h"
@@ -168,12 +170,20 @@ static NSString *const exampleSuperLongText =
 
   CGSize bannerViewSize = [self.bannerView sizeThatFits:self.view.bounds.size];
   // Adjust bannerViewContainer's frame
-  CGFloat topAreaInset = 0.0f;
+  CGFloat yOrigin = 0.0f;
   if (@available(iOS 11.0, *)) {
-    topAreaInset = self.view.safeAreaInsets.top;
+    yOrigin = self.view.safeAreaInsets.top;
+  } else {
+    if ([self.parentViewController isKindOfClass:[MDCAppBarContainerViewController class]]) {
+      MDCAppBarContainerViewController *containerViewController =
+          (MDCAppBarContainerViewController *)self.parentViewController;
+      UIApplication *safeApplication = [UIApplication mdc_safeSharedApplication];
+      yOrigin = CGRectGetMaxY(containerViewController.appBarViewController.navigationBar.frame) +
+                CGRectGetHeight(safeApplication.statusBarFrame);
+    }
   }
-  self.bannerView.frame =
-      CGRectMake(0.0f, topAreaInset, bannerViewSize.width, bannerViewSize.height);
+
+  self.bannerView.frame = CGRectMake(0.0f, yOrigin, bannerViewSize.width, bannerViewSize.height);
 }
 
 #pragma mark - Internal helpers


### PR DESCRIPTION
The typical use banner example now accounts for the app and status bars on iOS 10.

Fixes #8825 

Before:
![before](https://user-images.githubusercontent.com/581764/68899617-0a27db00-0700-11ea-89b9-16797fee254f.png)

After:
![after](https://user-images.githubusercontent.com/581764/68899624-0d22cb80-0700-11ea-813a-77b758f63d07.png)
