### PR TITLE
[BottomSheet] Ignore background tap location if VoiceOver on

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -213,7 +213,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
   CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  if ([contentView pointInside:pointInContentView withEvent:nil]) {
+  if (!UIAccessibilityIsVoiceOverRunning() && [contentView pointInside:pointInContentView
+                                                             withEvent:nil]) {
     return;
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -210,13 +210,18 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   if (!_dismissOnBackgroundTap) {
     return;
   }
-  // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
-  CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  BOOL isVoiceOverFocusedOnScrim =
-      UIAccessibilityIsVoiceOverRunning() && [_dimmingView accessibilityElementIsFocused];
-  if (!isVoiceOverFocusedOnScrim && [contentView pointInside:pointInContentView withEvent:nil]) {
-    return;
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    // If VoiceOver is running, only dismiss if the background view is focused.
+    if (![_dimmingView accessibilityElementIsFocused]) {
+      return;
+    }
+  } else {
+    // If VoiceOver is not running, only dismiss if the tap is outside of the presented view.
+    CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
+    if ([contentView pointInside:pointInContentView withEvent:nil]) {
+      return;
+    }
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -213,8 +213,9 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
   CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  if (!UIAccessibilityIsVoiceOverRunning() && [contentView pointInside:pointInContentView
-                                                             withEvent:nil]) {
+  BOOL isVoiceOverFocusedOnScrim =
+      UIAccessibilityIsVoiceOverRunning() && [_dimmingView accessibilityElementIsFocused];
+  if (!isVoiceOverFocusedOnScrim && [contentView pointInside:pointInContentView withEvent:nil]) {
     return;
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
Adds VoiceOver dismissal logic to `MDCBottomSheetPresentationController`.

Fixes #8835 