### PR TITLE
[TextControls] Add dynamic type functionality to text controls example

### DIFF
--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -24,7 +24,7 @@ static CGFloat const kDefaultPadding = 15.0;
 /**
  Typical use example showing how to place an @c MDCBaseTextField in a UIViewController.
  */
-@interface MDCTextControlTextFieldTypicalUseExample : UIViewController
+@interface MDCTextControlTextFieldTypicalUseExampleContentViewController : UIViewController
 
 /** The MDCBaseTextField for this example. */
 @property(nonatomic, strong) MDCBaseTextField *baseTextField;
@@ -43,21 +43,10 @@ static CGFloat const kDefaultPadding = 15.0;
 
 @end
 
-@implementation MDCTextControlTextFieldTypicalUseExample
+@implementation MDCTextControlTextFieldTypicalUseExampleContentViewController
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-  self.title = kExampleTitle;
-
-  if (!self.containerScheme) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
-    self.containerScheme = containerScheme;
-  }
-
-  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 
   self.resignFirstResponderButton = [self createFirstResponderButton];
   [self.view addSubview:self.resignFirstResponderButton];
@@ -68,6 +57,12 @@ static CGFloat const kDefaultPadding = 15.0;
   self.baseTextField.placeholder = @"This is placeholder text";
   self.baseTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   self.baseTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
+  self.baseTextField.adjustsFontForContentSizeCategory = YES;
+  self.baseTextField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+  self.baseTextField.leadingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
+  self.baseTextField.trailingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
   [self.view addSubview:self.baseTextField];
 
   self.filledTextField = [[MDCFilledTextField alloc] initWithFrame:self.placeholderTextFieldFrame];
@@ -75,6 +70,12 @@ static CGFloat const kDefaultPadding = 15.0;
   self.filledTextField.placeholder = @"This is placeholder text";
   self.filledTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   self.filledTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
+  self.filledTextField.adjustsFontForContentSizeCategory = YES;
+  self.filledTextField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+  self.filledTextField.leadingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
+  self.filledTextField.trailingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
   [self.view addSubview:self.filledTextField];
 
   self.outlinedTextField =
@@ -83,6 +84,12 @@ static CGFloat const kDefaultPadding = 15.0;
   self.outlinedTextField.placeholder = @"This is placeholder text";
   self.outlinedTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
   self.outlinedTextField.leadingAssistiveLabel.text = @"This is leading assistive text";
+  self.outlinedTextField.adjustsFontForContentSizeCategory = YES;
+  self.outlinedTextField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+  self.outlinedTextField.leadingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
+  self.outlinedTextField.trailingAssistiveLabel.font =
+      [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
   [self.view addSubview:self.outlinedTextField];
 }
 
@@ -142,6 +149,204 @@ static CGFloat const kDefaultPadding = 15.0;
   self.baseTextField.frame = CGRectMake(
       kDefaultPadding, CGRectGetMaxY(self.outlinedTextField.frame) + kDefaultPadding,
       CGRectGetWidth(self.baseTextField.frame), CGRectGetHeight(self.baseTextField.frame));
+}
+
+@end
+
+/** This view controller manages a child view controller that contains the actual example content.
+ * It overrides the child view controller's trait collection based off the user's behavior. */
+@interface MDCTextControlTextFieldTypicalUseExample : UIViewController
+
+/** The container scheme injected into this example. */
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
+
+@end
+
+@interface MDCTextControlTextFieldTypicalUseExample ()
+@property(nonatomic, strong) MDCButton *decreaseContentSizeButton;
+@property(nonatomic, strong) MDCButton *increaseContentSizeButton;
+@property(nonatomic, strong) NSArray *contentSizeCategories;
+@property(nonatomic, strong) UIContentSizeCategory contentSizeCategory;
+@end
+
+@implementation MDCTextControlTextFieldTypicalUseExample
+
+#pragma mark Object Lifecycle
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+  }
+  return self;
+}
+
+#pragma mark View Controller Lifecycle
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.title = kExampleTitle;
+  [self setUpChildViewController];
+  [self setUpContentSizeCategories];
+  [self setUpContainerScheme];
+  [self setUpContentSizeButtons];
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self.decreaseContentSizeButton sizeToFit];
+  [self.increaseContentSizeButton sizeToFit];
+  CGFloat viewWidth = CGRectGetWidth(self.view.frame);
+  CGFloat viewHeight = CGRectGetHeight(self.view.frame);
+  CGFloat padding = (CGFloat)15.0;
+  self.decreaseContentSizeButton.frame = CGRectMake(
+      padding, self.preferredButtonMinY, CGRectGetWidth(self.decreaseContentSizeButton.frame),
+      CGRectGetHeight(self.decreaseContentSizeButton.frame));
+  self.increaseContentSizeButton.frame =
+      CGRectMake(CGRectGetMaxX(self.decreaseContentSizeButton.frame) + padding,
+                 self.preferredButtonMinY, CGRectGetWidth(self.increaseContentSizeButton.frame),
+                 CGRectGetHeight(self.increaseContentSizeButton.frame));
+  CGFloat buttonMaxY = CGRectGetMaxY(self.increaseContentSizeButton.frame);
+  CGFloat childMinY = buttonMaxY + padding;
+  self.contentViewController.view.frame =
+      CGRectMake(0, childMinY, viewWidth, viewHeight - childMinY);
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  [self.contentViewController.view setNeedsLayout];
+}
+
+#pragma mark Setup
+
+- (void)setUpChildViewController {
+  MDCTextControlTextFieldTypicalUseExampleContentViewController *viewController =
+      [[MDCTextControlTextFieldTypicalUseExampleContentViewController alloc] init];
+  [self addChildViewController:viewController];
+  [self.view addSubview:viewController.view];
+}
+
+- (void)setUpContainerScheme {
+  if (!self.containerScheme) {
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+    self.containerScheme = containerScheme;
+  }
+}
+
+- (void)setUpContentSizeCategories {
+  self.contentSizeCategories = @[
+    UIContentSizeCategoryExtraSmall, UIContentSizeCategorySmall, UIContentSizeCategoryMedium,
+    UIContentSizeCategoryLarge, UIContentSizeCategoryExtraLarge,
+    UIContentSizeCategoryExtraExtraLarge, UIContentSizeCategoryExtraExtraExtraLarge,
+    UIContentSizeCategoryAccessibilityMedium, UIContentSizeCategoryAccessibilityLarge,
+    UIContentSizeCategoryAccessibilityExtraLarge, UIContentSizeCategoryAccessibilityExtraExtraLarge,
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge
+  ];
+}
+
+- (void)setUpContentSizeButtons {
+  self.increaseContentSizeButton = [self createIncreaseContentSizeButton];
+  [self.view addSubview:self.increaseContentSizeButton];
+  self.decreaseContentSizeButton = [self createDecreaseContentSizeButton];
+  [self.view addSubview:self.decreaseContentSizeButton];
+}
+
+- (MDCButton *)createDecreaseContentSizeButton {
+  return [self createContentSizeButtonWithTitle:@"Decrease size"
+                                       selector:@selector(decreaseContentSize:)];
+}
+
+- (MDCButton *)createIncreaseContentSizeButton {
+  return [self createContentSizeButtonWithTitle:@"Increase size"
+                                       selector:@selector(increaseContentSize:)];
+}
+
+- (void)increaseContentSize:(MDCButton *)button {
+  if (self.contentSizeCategory) {
+    NSInteger idx = [self.contentSizeCategories indexOfObject:self.contentSizeCategory];
+    if (idx < (NSInteger)self.contentSizeCategories.count - 1) {
+      idx += 1;
+      UIContentSizeCategory newContentSizeCategory = self.contentSizeCategories[idx];
+      self.contentSizeCategory = newContentSizeCategory;
+      self.increaseContentSizeButton.enabled =
+          idx != (NSInteger)self.contentSizeCategories.count - 1;
+      self.decreaseContentSizeButton.enabled = idx > 0;
+    }
+  }
+}
+
+- (void)decreaseContentSize:(MDCButton *)button {
+  if (self.contentSizeCategory) {
+    NSInteger idx = [self.contentSizeCategories indexOfObject:self.contentSizeCategory];
+    if (idx > (NSInteger)0) {
+      idx -= 1;
+      UIContentSizeCategory newContentSizeCategory = self.contentSizeCategories[idx];
+      self.contentSizeCategory = newContentSizeCategory;
+      self.increaseContentSizeButton.enabled =
+          idx != (NSInteger)self.contentSizeCategories.count - 1;
+      self.decreaseContentSizeButton.enabled = idx > 0;
+    }
+  }
+}
+
+- (MDCButton *)createContentSizeButtonWithTitle:(NSString *)title selector:(SEL)selector {
+  MDCButton *button = [[MDCButton alloc] init];
+  [button setTitle:title forState:UIControlStateNormal];
+  [button addTarget:self action:selector forControlEvents:UIControlEventTouchUpInside];
+  [button sizeToFit];
+  button.enabled = NO;
+  if (@available(iOS 10.0, *)) {
+    button.enabled = YES;
+  }
+  return button;
+}
+
+#pragma mark Accessors
+
+- (void)setContentSizeCategory:(UIContentSizeCategory)contentSizeCategory {
+  if (@available(iOS 10.0, *)) {
+    UITraitCollection *contentSizeCategoryTraitCollection =
+        [UITraitCollection traitCollectionWithPreferredContentSizeCategory:contentSizeCategory];
+    UITraitCollection *currentTraitCollection = self.contentViewController.traitCollection;
+    NSArray *traitCollections = @[ currentTraitCollection, contentSizeCategoryTraitCollection ];
+    UITraitCollection *traitCollection =
+        [UITraitCollection traitCollectionWithTraitsFromCollections:traitCollections];
+    [self setOverrideTraitCollection:traitCollection
+              forChildViewController:self.contentViewController];
+    [self.view setNeedsLayout];
+  }
+}
+
+- (UIContentSizeCategory)contentSizeCategory {
+  if (@available(iOS 10.0, *)) {
+    return self.contentViewController.traitCollection.preferredContentSizeCategory;
+  }
+  return nil;
+}
+
+- (void)setContainerScheme:(id<MDCContainerScheming>)containerScheme {
+  self.contentViewController.containerScheme = containerScheme;
+}
+
+- (id<MDCContainerScheming>)containerScheme {
+  return self.contentViewController.containerScheme;
+}
+
+- (MDCTextControlTextFieldTypicalUseExampleContentViewController *)contentViewController {
+  return (
+      MDCTextControlTextFieldTypicalUseExampleContentViewController *)[[self childViewControllers]
+      firstObject];
+}
+
+- (CGFloat)preferredButtonMinY {
+  if (@available(iOS 11.0, *)) {
+    return (CGFloat)(self.view.safeAreaInsets.top + kDefaultPadding);
+  } else {
+    return (CGFloat)120;
+  }
 }
 
 @end

--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -113,7 +113,7 @@ static CGFloat const kDefaultPadding = 15.0;
   if (@available(iOS 11.0, *)) {
     return (CGFloat)(self.view.safeAreaInsets.top + kDefaultPadding);
   } else {
-    return (CGFloat)120;
+    return (CGFloat)self.topLayoutGuide.length;
   }
 }
 
@@ -171,15 +171,6 @@ static CGFloat const kDefaultPadding = 15.0;
 
 @implementation MDCTextControlTextFieldTypicalUseExample
 
-#pragma mark Object Lifecycle
-
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-  }
-  return self;
-}
-
 #pragma mark View Controller Lifecycle
 
 - (void)viewDidLoad {
@@ -195,6 +186,7 @@ static CGFloat const kDefaultPadding = 15.0;
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
+
   [self.decreaseContentSizeButton sizeToFit];
   [self.increaseContentSizeButton sizeToFit];
   CGFloat viewWidth = CGRectGetWidth(self.view.frame);
@@ -215,6 +207,7 @@ static CGFloat const kDefaultPadding = 15.0;
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
+
   [self.contentViewController.view setNeedsLayout];
 }
 
@@ -345,7 +338,7 @@ static CGFloat const kDefaultPadding = 15.0;
   if (@available(iOS 11.0, *)) {
     return (CGFloat)(self.view.safeAreaInsets.top + kDefaultPadding);
   } else {
-    return (CGFloat)120;
+    return (CGFloat)self.topLayoutGuide.length;
   }
 }
 


### PR DESCRIPTION
This PR adds some dynamic type functionality to the text controls example.
Note that in the largest content sizes the content goes off the screen. This will be addressed in a follow up PR.
 
Here is a gif:

![DynamicType](https://user-images.githubusercontent.com/8020010/68900027-f92b9980-0700-11ea-958e-6965638bdbc5.gif)

Closes #8845.