### PR TITLE
[Catalog] Remove scrim accessibility logic from BottomSheetUIControlExample

### DIFF
--- a/components/BottomSheet/examples/BottomSheetUIControlExample.swift
+++ b/components/BottomSheet/examples/BottomSheetUIControlExample.swift
@@ -63,8 +63,6 @@ class BottomSheetUIControlExample: UIViewController {
     @objc func didTapFloatingButton(_ sender : MDCFloatingButton) {
       let menu = BottomSheetUIControl()
       let bottomSheet = MDCBottomSheetController(contentViewController: menu)
-      bottomSheet.isScrimAccessibilityElement = true
-      bottomSheet.scrimAccessibilityLabel = "Close"
       present(bottomSheet, animated: true)
     }
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -210,8 +210,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   if (!_dismissOnBackgroundTap) {
     return;
   }
-  UIView *contentView = self.presentedViewController.view;
   // Only dismiss if the tap is outside of the presented view.
+  UIView *contentView = self.presentedViewController.view;
   CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
   if ([contentView pointInside:pointInContentView withEvent:nil]) {
     return;

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -211,17 +211,10 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
     return;
   }
   UIView *contentView = self.presentedViewController.view;
-  if (UIAccessibilityIsVoiceOverRunning()) {
-    // If VoiceOver is running, only dismiss if the background view is focused.
-    if (![_dimmingView accessibilityElementIsFocused]) {
-      return;
-    }
-  } else {
-    // If VoiceOver is not running, only dismiss if the tap is outside of the presented view.
-    CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-    if ([contentView pointInside:pointInContentView withEvent:nil]) {
-      return;
-    }
+  // Only dismiss if the tap is outside of the presented view.
+  CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
+  if ([contentView pointInside:pointInContentView withEvent:nil]) {
+    return;
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -213,7 +213,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
   CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  if ([contentView pointInside:pointInContentView withEvent:nil]) {
+  if (!UIAccessibilityIsVoiceOverRunning() && [contentView pointInside:pointInContentView
+                                                             withEvent:nil]) {
     return;
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -210,13 +210,18 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   if (!_dismissOnBackgroundTap) {
     return;
   }
-  // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
-  CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  BOOL isVoiceOverFocusedOnScrim =
-      UIAccessibilityIsVoiceOverRunning() && [_dimmingView accessibilityElementIsFocused];
-  if (!isVoiceOverFocusedOnScrim && [contentView pointInside:pointInContentView withEvent:nil]) {
-    return;
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    // If VoiceOver is running, only dismiss if the background view is focused.
+    if (![_dimmingView accessibilityElementIsFocused]) {
+      return;
+    }
+  } else {
+    // If VoiceOver is not running, only dismiss if the tap is outside of the presented view.
+    CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
+    if ([contentView pointInside:pointInContentView withEvent:nil]) {
+      return;
+    }
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -213,8 +213,9 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   // Only dismiss if the tap is outside of the presented view.
   UIView *contentView = self.presentedViewController.view;
   CGPoint pointInContentView = [tapRecognizer locationInView:contentView];
-  if (!UIAccessibilityIsVoiceOverRunning() && [contentView pointInside:pointInContentView
-                                                             withEvent:nil]) {
+  BOOL isVoiceOverFocusedOnScrim =
+      UIAccessibilityIsVoiceOverRunning() && [_dimmingView accessibilityElementIsFocused];
+  if (!isVoiceOverFocusedOnScrim && [contentView pointInside:pointInContentView withEvent:nil]) {
     return;
   }
   [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
Because the BottomSheet can be dismissed in VoiceOver by using the two-fingered "Z" gesture, this logic is unnecessary. 

Fixes #8835 
