### PR TITLE
[Dragons] Treat MDCDragonsTableViewCell as an a11y button.

### DIFF
--- a/catalog/MDCDragons/MDCDragonsTableViewCell.swift
+++ b/catalog/MDCDragons/MDCDragonsTableViewCell.swift
@@ -35,7 +35,12 @@ class MDCDragonsTableViewCell: UITableViewCell {
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+
     self.accessoryView = self.defaultButton
+
+    // Treat the entire cell as an accessibility button for VoiceOver purposes.
+    self.isAccessibilityElement = true
+    self.accessibilityTraits = .button
   }
 
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
The "expanded button" accessory item doesn't need to be treated as an independent button for VoiceOver because tapping the cell causes it to expand/collapse.

Fixes https://github.com/material-components/material-components-ios/issues/8852