### PR TITLE
[Dragons] Simplify the MDCDragonsTableViewCell accessory types.

### DIFF
--- a/catalog/MDCDragons/MDCDragonsController.swift
+++ b/catalog/MDCDragons/MDCDragonsController.swift
@@ -196,10 +196,10 @@ class MDCDragonsController: UIViewController,
     let node = nodeData.node
     if !node.isExample() && !isSearchActive {
       if nodeData.expanded {
-        cell.accessoryView = cell.expandedButton
+        cell.accessoryView = cell.expandedAccessoryView
         cell.textLabel?.textColor = Constants.headerColor
       } else {
-        cell.accessoryView = cell.defaultButton
+        cell.accessoryView = cell.collapsedAccessoryView
         cell.textLabel?.textColor = Constants.titleColor
       }
     } else {
@@ -228,11 +228,11 @@ class MDCDragonsController: UIViewController,
       self.tableView.beginUpdates()
       if nodeData.expanded {
         collapseCells(at: indexPath)
-        cell.accessoryView = cell.defaultButton
+        cell.accessoryView = cell.collapsedAccessoryView
         cell.textLabel?.textColor = Constants.titleColor
       } else {
         expandCells(at: indexPath)
-        cell.accessoryView = cell.expandedButton
+        cell.accessoryView = cell.expandedAccessoryView
         cell.textLabel?.textColor = Constants.headerColor
       }
       self.tableView.endUpdates()

--- a/catalog/MDCDragons/MDCDragonsTableViewCell.swift
+++ b/catalog/MDCDragons/MDCDragonsTableViewCell.swift
@@ -18,25 +18,25 @@ import MaterialComponents.MaterialIcons_ic_arrow_back
 
 class MDCDragonsTableViewCell: UITableViewCell {
 
-  lazy var defaultButton: UIButton = {
+  lazy var collapsedAccessoryView: UIView = {
     let image = MDCIcons.imageFor_ic_chevron_right()
-    let button = UIButton(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
-    button.setImage(image, for: .normal)
-    return button
+    let view = UIImageView(image: image)
+    view.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+    return view
   }()
 
-  lazy var expandedButton: UIButton = {
+  lazy var expandedAccessoryView: UIView = {
     let image = MDCIcons.imageFor_ic_chevron_right()
-    let button = UIButton(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
-    button.setImage(image, for: .normal)
-    button.transform = CGAffineTransform(rotationAngle: CGFloat.pi / 2)
-    return button
+    let view = UIImageView(image: image)
+    view.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
+    view.transform = CGAffineTransform(rotationAngle: CGFloat.pi / 2)
+    return view
   }()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-    self.accessoryView = self.defaultButton
+    self.accessoryView = self.collapsedAccessoryView
 
     // Treat the entire cell as an accessibility button for VoiceOver purposes.
     self.isAccessibilityElement = true


### PR DESCRIPTION
The accessory views do not need to be buttons. They are now image views and the names of the properties have been updated to reflect their functional purpose. From a public point of view, the properties only need to be UIViews, so the property types have been updated accordingly as well.

Polish as part of https://github.com/material-components/material-components-ios/pull/8856