### PR TITLE
[private] ZShadow example supports VoiceOver

### DIFF
--- a/components/private/Dragons/examples/ZShadow.swift
+++ b/components/private/Dragons/examples/ZShadow.swift
@@ -71,9 +71,14 @@ class ZShadowViewController: UIViewController {
     
     let tap = UITapGestureRecognizer(target: self, action: #selector(squaresTapped))
     contentView.greenTappable.addGestureRecognizer(tap)
+    contentView.greenTappable.isAccessibilityElement = true
+    contentView.greenTappable.accessibilityTraits = .button
+    contentView.greenTappable.accessibilityLabel = "Toggle Material Shadow"
     let tap2 = UITapGestureRecognizer(target: self, action: #selector(squaresTapped))
     contentView.blueTappable.addGestureRecognizer(tap2)
-    
+    contentView.blueTappable.isAccessibilityElement = true
+    contentView.blueTappable.accessibilityTraits = .button
+    contentView.blueTappable.accessibilityLabel = "Toggle UIKit Shadow"
   }
   
   @objc func squaresTapped() {


### PR DESCRIPTION
Allowing the tapable items to be correctly called out in voiceover and be interactable.

Closes #8843 