### PR TITLE
[Buttons] Fix a11y issues in Buttons (Content Edge Insets) example 

### DIFF
--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -41,8 +41,9 @@
 
 #pragma mark - UIViewController
 
-- (id)init {
-  self = [super init];
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  self = [super initWithCoder:coder];
   if (self) {
     _containerScheme = [[MDCContainerScheme alloc] init];
   }
@@ -60,6 +61,7 @@
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
                                          forShape:MDCFloatingButtonShapeDefault
                                            inMode:MDCFloatingButtonModeNormal];
+  self.floatingActionButton.accessibilityLabel = @"Floating Button";
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -41,13 +41,23 @@
 
 #pragma mark - UIViewController
 
-- (instancetype)initWithCoder:(NSCoder *)coder
-{
+- (instancetype)initWithCoder:(NSCoder *)coder {
   self = [super initWithCoder:coder];
   if (self) {
-    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self) {
+    [self commonButtonContentEdgeInsetsExampleInitializer];
+  }
+  return self;
+}
+
+- (void)commonButtonContentEdgeInsetsExampleInitializer {
+  _containerScheme = [[MDCContainerScheme alloc] init];
 }
 
 - (void)viewDidLoad {
@@ -61,7 +71,7 @@
   [self.floatingActionButton setContentEdgeInsets:UIEdgeInsetsMake(40, 40, 0, 0)
                                          forShape:MDCFloatingButtonShapeDefault
                                            inMode:MDCFloatingButtonModeNormal];
-  self.floatingActionButton.accessibilityLabel = @"Floating Button";
+  self.floatingActionButton.accessibilityLabel = @"Floating button";
 
   [self updateInkStyle:self.inkBoundingSwitch.isOn ? MDCInkStyleBounded : MDCInkStyleUnbounded];
 }

--- a/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
+++ b/components/Buttons/examples/ButtonsContentEdgeInsetsExample.m
@@ -44,6 +44,7 @@
 - (instancetype)initWithCoder:(NSCoder *)coder {
   self = [super initWithCoder:coder];
   if (self) {
+    [self commonButtonContentEdgeInsetsExampleInitializer];
   }
   return self;
 }


### PR DESCRIPTION
In this PR we are fixing the non-accessible colors that were caused due to the container scheme being nil, as init isn't being called with a Storyboard, but rather initWithCode.

Secondly, now the FAB has a good a11y label, so it can be presented correctly when focused.

Before:
![Simulator Screen Shot - iPhone 7 - 2019-11-15 at 09 53 25](https://user-images.githubusercontent.com/4066863/68952401-c8de0c80-078d-11ea-8816-d1e667fbef6b.png)

After:
![Simulator Screen Shot - iPhone 7 - 2019-11-15 at 09 52 50](https://user-images.githubusercontent.com/4066863/68952352-b4017900-078d-11ea-8cf9-08c081a779d9.png)

Closes #8831 