### PR TITLE
[Cards] Make the shaped collection cell an accessibility button.

### DIFF
--- a/components/Cards/examples/CardsShapedEditReorderExample.swift
+++ b/components/Cards/examples/CardsShapedEditReorderExample.swift
@@ -33,6 +33,10 @@ class ShapedCardCollectionCell: MDCCardCollectionCell {
     let shapeGenerator = MDCRectangleShapeGenerator()
     shapeGenerator.topLeftCorner = MDCCutCornerTreatment(cut: 20)
     self.shapeGenerator = shapeGenerator
+
+    self.isAccessibilityElement = true
+    self.accessibilityTraits = .button
+    self.accessibilityLabel = "Shaped collection cell"
   }
 }
 


### PR DESCRIPTION
Stacked on top of https://github.com/material-components/material-components-ios/pull/8899

Note that this PR does not implement VoiceOver reordering.

Part of https://github.com/material-components/material-components-ios/issues/8866