### PR TITLE
[ActivityIndicator] Add a voiceover layout change notification after animation in example

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -177,6 +177,7 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   transition.duration = kActivityIndicatorExampleAnimationDuration;
   transition.completion = ^{
     self->_button.enabled = YES;
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self->_button);
   };
 
   [_activityIndicator stopAnimatingWithTransition:transition];


### PR DESCRIPTION
Adds a voiceover layout change notification and re-focus button after animation in ActivityIndicator Transition example.

Closes #8841 