### PR TITLE
[Buttons] Update accessibility label for FABs

### DIFF
--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -84,13 +84,13 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
     let floatingPlusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     floatingButton.layer.addSublayer(floatingPlusShapeLayer)
     floatingButton.applySecondaryTheme(withScheme: containerScheme)
-    floatingButton.accessibilityLabel = "Programmatic FAB"
+    floatingButton.accessibilityLabel = "Programmatic floating action button"
     innerContainerView.addSubview(floatingButton)
 
     let storyboardPlusShapeLayer =
       ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     storyboardFloating.applySecondaryTheme(withScheme: containerScheme)
-    storyboardFloating.accessibilityLabel = "Storyboard FAB"
+    storyboardFloating.accessibilityLabel = "Storyboard floating action button"
     storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
 
     storyboardContained.applyContainedTheme(withScheme: containerScheme)

--- a/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
+++ b/components/Buttons/examples/ButtonsStoryboardAndProgrammatic.swift
@@ -83,10 +83,14 @@ class ButtonsSwiftAndStoryboardController: UIViewController {
 
     let floatingPlusShapeLayer = ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
     floatingButton.layer.addSublayer(floatingPlusShapeLayer)
+    floatingButton.applySecondaryTheme(withScheme: containerScheme)
+    floatingButton.accessibilityLabel = "Programmatic FAB"
     innerContainerView.addSubview(floatingButton)
 
     let storyboardPlusShapeLayer =
       ButtonsTypicalUseSupplemental.createPlusShapeLayer(floatingButton)
+    storyboardFloating.applySecondaryTheme(withScheme: containerScheme)
+    storyboardFloating.accessibilityLabel = "Storyboard FAB"
     storyboardFloating.layer.addSublayer(storyboardPlusShapeLayer)
 
     storyboardContained.applyContainedTheme(withScheme: containerScheme)


### PR DESCRIPTION
This change updates the accessibility label for both FABs within the `Buttons (Swift and Storyboard)` example.

Closes #8854 