### PR TITLE
[BottomNavigation] Clean up badge value test example

### DIFF
--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -156,11 +156,13 @@ mdc_examples_swift_library(
         ":BottomNavigation",
         ":BottomNavigationBeta",
         ":ColorThemer",
+        ":Theming",
         ":ObjcExamples",
         ":TypographyThemer",
         "//components/AppBar",
         "//components/Buttons",
         "//components/Palettes",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
+++ b/components/BottomNavigation/examples/BottomNavigationNilBadges.swift
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
+import MaterialComponents.MaterialBottomNavigation
+import MaterialComponents.MaterialBottomNavigation_Theming
+import MaterialComponents.MaterialContainerScheme
 
 class BottomNavigationNilBadges : UIViewController {
 
-  @objc var colorScheme = MDCSemanticColorScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   // Create a bottom navigation bar to add to a view.
   let bottomNavBar = MDCBottomNavigationBar()
@@ -35,7 +37,7 @@ class BottomNavigationNilBadges : UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
     // Always show bottom navigation bar item titles.
@@ -51,16 +53,14 @@ class BottomNavigationNilBadges : UIViewController {
     bottomNavBar.items = [ tabBarItem1, tabBarItem2 ]
 
     // Select a bottom navigation bar item.
-    bottomNavBar.selectedItem = tabBarItem2;
+    bottomNavBar.selectedItem = tabBarItem2
 
     // Test that
-    tabBarItem1.badgeValue = "";
-    tabBarItem2.badgeValue = nil;
+    tabBarItem1.badgeValue = ""
+    tabBarItem2.badgeValue = nil
 
     // Theme the bottom navigation bar.
-    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
-                                                               toBottomNavigation: bottomNavBar);
-
+    bottomNavBar.applyPrimaryTheme(withScheme: containerScheme)
   }
   
   func layoutBottomNavBar() {


### PR DESCRIPTION
This cleans up the bottom navigation `Badge Value Test` example to have the correct imports, use our modern theming, and removes semicolons.

## Screenshots

| Before | After |
| --- | --- | 
|![Simulator Screen Shot - iPhone 11 Pro Max - 2019-11-15 at 08 29 50](https://user-images.githubusercontent.com/7131294/68959206-7a774080-0782-11ea-9edf-6bab766b3c4c.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2019-11-15 at 08 31 40](https://user-images.githubusercontent.com/7131294/68959214-7fd48b00-0782-11ea-84ec-0b6087e40bfd.png)|



NO_BUG=This is cleanup I found while working on #8837 