### PR TITLE
[PageControl] Fixes contrast ratio and button interactivity for example

### DIFF
--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -177,6 +177,7 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   transition.duration = kActivityIndicatorExampleAnimationDuration;
   transition.completion = ^{
     self->_button.enabled = YES;
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self->_button);
   };
 
   [_activityIndicator stopAnimatingWithTransition:transition];

--- a/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
+++ b/components/ActivityIndicator/examples/ActivityIndicatorTransitionExampleViewController.m
@@ -177,7 +177,6 @@ static const NSTimeInterval kActivityIndicatorExampleAnimationDuration = 2.0 / 3
   transition.duration = kActivityIndicatorExampleAnimationDuration;
   transition.completion = ^{
     self->_button.enabled = YES;
-    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self->_button);
   };
 
   [_activityIndicator stopAnimatingWithTransition:transition];

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -200,16 +200,16 @@
   CGPoint offset = _scrollView.contentOffset;
   offset.x = nextPage * CGRectGetWidth(_scrollView.frame);
   [UIView animateWithDuration:0.2
-                        delay:0
-                      options:UIViewAnimationOptionCurveEaseOut
-                   animations:^{
-                     self->_scrollView.contentOffset = offset;
-                   }
-                   completion:^(BOOL completed) {
-    if (completed) {
-      [self updateButtonStates];
-    }
-  }];
+      delay:0
+      options:UIViewAnimationOptionCurveEaseOut
+      animations:^{
+        self->_scrollView.contentOffset = offset;
+      }
+      completion:^(BOOL completed) {
+        if (completed) {
+          [self updateButtonStates];
+        }
+      }];
 }
 
 #pragma mark - CatalogByConvention

--- a/components/PageControl/examples/PageControlAnimationBlockExample.m
+++ b/components/PageControl/examples/PageControlAnimationBlockExample.m
@@ -71,6 +71,8 @@
   // Page control configuration.
   _pageControl = [[MDCPageControl alloc] init];
   _pageControl.numberOfPages = pageColors.count;
+  _pageControl.currentPageIndicatorTintColor = UIColor.whiteColor;
+  _pageControl.pageIndicatorTintColor = UIColor.lightGrayColor;
 
   // We want the page control to span the bottom of the screen.
   CGSize pageControlSize = [_pageControl sizeThatFits:self.view.bounds.size];
@@ -92,6 +94,7 @@
   [_incrementButton addTarget:self
                        action:@selector(didTapButton:)
              forControlEvents:UIControlEventTouchUpInside];
+  [_incrementButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateDisabled];
   [self.view addSubview:_incrementButton];
 
   _decrementButton = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -101,6 +104,7 @@
   [_decrementButton addTarget:self
                        action:@selector(didTapButton:)
              forControlEvents:UIControlEventTouchUpInside];
+  [_decrementButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateDisabled];
   [self.view addSubview:_decrementButton];
 }
 
@@ -144,6 +148,21 @@
   [_decrementButton sizeToFit];
   buttonCenterX = CGRectGetWidth(_decrementButton.frame) / 2 + 16 + edgeInsets.left;
   _decrementButton.center = CGPointMake(buttonCenterX, _pageControl.center.y);
+
+  [self updateButtonStates];
+}
+
+- (void)updateButtonStates {
+  if (_pageControl.currentPage == _pageControl.numberOfPages - 1) {
+    _incrementButton.enabled = NO;
+    _decrementButton.enabled = YES;
+  } else if (_pageControl.currentPage == 0) {
+    _decrementButton.enabled = NO;
+    _incrementButton.enabled = YES;
+  } else {
+    _incrementButton.enabled = YES;
+    _decrementButton.enabled = YES;
+  }
 }
 
 #pragma mark - UIScrollViewDelegate
@@ -154,6 +173,7 @@
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
   [_pageControl scrollViewDidEndDecelerating:scrollView];
+  [self updateButtonStates];
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
@@ -185,7 +205,11 @@
                    animations:^{
                      self->_scrollView.contentOffset = offset;
                    }
-                   completion:nil];
+                   completion:^(BOOL completed) {
+    if (completed) {
+      [self updateButtonStates];
+    }
+  }];
 }
 
 #pragma mark - CatalogByConvention


### PR DESCRIPTION
PageControlAnimationBlockExample has too-low contrast in the controls. It also does not disable the +2/-2 buttons even when they have no effect.

Updated colors to have an accessible contrast ratio, and updated the states of the buttons to show correct interactivity (enabled/disabled)

![Simulator Screen Shot - iPhone 7 - 2019-11-15 at 10 54 32](https://user-images.githubusercontent.com/4066863/68956562-532a6e80-0796-11ea-9378-463988188a47.png)

Closes #8919 
