### PR TITLE
[Ripple] Card with Ripple example now allows the card to be reached with voiceover.

### DIFF
--- a/components/Ripple/examples/CardWithRippleExample.swift
+++ b/components/Ripple/examples/CardWithRippleExample.swift
@@ -64,6 +64,11 @@ class CardWithRippleExample: UIViewController {
     button.addConstraint(NSLayoutConstraint(item: button, attribute: .height, relatedBy: .equal,
                                             toItem: nil, attribute: .notAnAttribute, multiplier: 1,
                                             constant: 60))
+
+    view.accessibilityElements = [card, button]
+    card.isAccessibilityElement = true
+    card.accessibilityTraits = .button
+    card.accessibilityLabel = "Card with button"
   }
 
   override public var traitCollection: UITraitCollection {


### PR DESCRIPTION
Voice Over and Switch Control users can activate the Card to show Ripple.
The card has an accessibility label and an accessibility trait to indicate that it is interactive.

Closes #8914 