### PR TITLE
[Dialogs] Make the "Dialogs with accessory view" example's cells accessibility buttons.

### DIFF
--- a/components/Dialogs/examples/DialogsAccessoryExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAccessoryExampleViewController.swift
@@ -112,7 +112,12 @@ extension DialogsAccessoryExampleViewController {
                                                   for: indexPath)
     guard let customCell = cell as? MDCCollectionViewTextCell else { return cell }
 
-    customCell.textLabel?.text = menu[indexPath.row]
+    customCell.isAccessibilityElement = true
+    customCell.accessibilityTraits = .button
+
+    let cellTitle = menu[indexPath.row]
+    customCell.accessibilityLabel = cellTitle
+    customCell.textLabel?.text = cellTitle
 
     return customCell
   }


### PR DESCRIPTION
Fixes https://github.com/material-components/material-components-ios/issues/8880

Prior to this PR, the cells were being read as labels and not as buttons by VoiceOver.

After this PR, the cells are read as buttons by VoiceOver.