### PR TITLE
[Cards] Fix bug in the "Typical use" example where the image would not appear.

### DIFF
--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialCards_Theming
 import MaterialComponents.MaterialButtons_Theming
 
 class CardExampleViewController: UIViewController {
-  @IBOutlet weak var imageView: CardImageView!
+  @IBOutlet weak var imageView: UIImageView!
   @IBOutlet weak var card: MDCCard!
   @IBOutlet weak var button: MDCButton!
 
@@ -49,6 +49,10 @@ class CardExampleViewController: UIViewController {
 
     imageView.isAccessibilityElement = true
     imageView.accessibilityLabel = "Missing Dish"
+    imageView.layer.cornerRadius = card.layer.cornerRadius
+    if #available(iOSApplicationExtension 11.0, *) {
+      imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    }
   }
 
   override public var traitCollection: UITraitCollection {
@@ -70,21 +74,4 @@ extension CardExampleViewController {
       "presentable": true,
     ]
   }
-}
-
-class CardImageView: UIImageView {
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    self.curveImageToCorners()
-  }
-
-  func curveImageToCorners() {
-    // The main image from the xib is taken from: https://unsplash.com/photos/wMzx2nBdeng
-    // License details: https://unsplash.com/license
-    if let card = self.superview as? MDCCard,
-      let shapedShadowLayer = card.layer as? MDCShapedShadowLayer {
-      self.layer.mask = shapedShadowLayer.shapeLayer
-    }
-  }
-
 }

--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -50,7 +50,7 @@ class CardExampleViewController: UIViewController {
     imageView.isAccessibilityElement = true
     imageView.accessibilityLabel = "Missing Dish"
     imageView.layer.cornerRadius = card.layer.cornerRadius
-    if #available(iOSApplicationExtension 11.0, *) {
+    if #available(iOS 11.0, *) {
       imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     }
   }

--- a/components/Cards/examples/resources/CardExampleViewController.xib
+++ b/components/Cards/examples/resources/CardExampleViewController.xib
@@ -23,7 +23,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BAQ-GJ-1pn" customClass="MDCCard">
                     <rect key="frame" x="26" y="150.33333333333334" width="323" height="511.66666666666663"/>
                     <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk" customClass="CardImageView" customModule="MaterialComponentsExamples" customModuleProvider="target">
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sample-image" translatesAutoresizingMaskIntoConstraints="NO" id="ldt-3r-Agk">
                             <rect key="frame" x="0.0" y="0.0" width="323" height="323"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="ldt-3r-Agk" secondAttribute="height" multiplier="15:15" id="OUj-9G-eou"/>


### PR DESCRIPTION
The image was not appearing because the card using a custom image view that was trying to inherit the mask of the card's shape layer.

This change removes the custom image view and instead applies custom corner radii to the image view directly. This is not ideal, but is an improvement. Ideally, the card would provide a content view that is clipped to the card's shape. It's not possible to enable clipping on the card itself because this causes the shadow to go away.

| Before | After |
|:--|:--|
| ![Simulator Screen Shot - iPhone Xʀ - 2019-11-15 at 12 57 37](https://user-images.githubusercontent.com/45670/68964703-08b1ed80-07a8-11ea-978c-2c71145ca8c3.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-11-15 at 12 56 52](https://user-images.githubusercontent.com/45670/68964693-02bc0c80-07a8-11ea-9d3d-644b81aebee6.png) |

Part of https://github.com/material-components/material-components-ios/issues/8861