### PR TITLE
[ActionSheet] Allow Swift example to support dynamic type

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -105,6 +105,7 @@ mdc_examples_swift_library(
     deps = [
         ":ActionSheet",
         ":Theming",
+        "//components/AppBar",
         "//components/schemes/Color",
         "//components/schemes/Container",
         "//components/schemes/Typography",

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 
+import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTypographyScheme

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -45,6 +45,10 @@ class ActionSheetSwiftExampleViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
+    if let appBarContainer = parent as? MDCAppBarContainerViewController {
+      appBarContainer.appBarViewController.headerView.trackingScrollView = tableView
+    }
     tableView.delegate = self
     tableView.dataSource = self
     tableView.frame = view.bounds
@@ -53,14 +57,6 @@ class ActionSheetSwiftExampleViewController: UIViewController {
     tableView.estimatedRowHeight = 56
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
     view.addSubview(tableView)
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    view.backgroundColor = containerScheme.colorScheme.backgroundColor
-    let firstRowHeight = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).size.height
-    tableView.contentInset = UIEdgeInsets(top: firstRowHeight / 2, left: 0, bottom: 0, right: 0)
   }
 
   func showActionSheet(_ type: ActionSheetExampleType) {

--- a/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
+++ b/components/ActionSheet/examples/ActionSheetSwiftExampleViewController.swift
@@ -47,16 +47,20 @@ class ActionSheetSwiftExampleViewController: UIViewController {
 
     tableView.delegate = self
     tableView.dataSource = self
+    tableView.frame = view.bounds
+    tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    tableView.rowHeight = UITableView.automaticDimension
+    tableView.estimatedRowHeight = 56
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+    view.addSubview(tableView)
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    
+
     view.backgroundColor = containerScheme.colorScheme.backgroundColor
-    tableView.frame = view.frame
-    tableView.frame.origin.y = 0.0
-    view.addSubview(tableView)
+    let firstRowHeight = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).size.height
+    tableView.contentInset = UIEdgeInsets(top: firstRowHeight / 2, left: 0, bottom: 0, right: 0)
   }
 
   func showActionSheet(_ type: ActionSheetExampleType) {


### PR DESCRIPTION
Perviously the ActionSheet swift example did not support dynamic type. This updates the example table to support dynamic type.

## Screenshots

| Before | After |
|---|---|
|![Simulator Screen Shot - iPhone 5 - 2019-11-15 at 10 11 58](https://user-images.githubusercontent.com/7131294/68965314-5f133200-0790-11ea-988f-63871d8f5183.png)|![Simulator Screen Shot - iPhone 5 - 2019-11-15 at 10 11 20](https://user-images.githubusercontent.com/7131294/68965322-63d7e600-0790-11ea-826c-a7724b8935c5.png)|



Closes #8820 