### PR TITLE
[Banner] Support use case where no button appears on Banner.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -438,8 +438,12 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
     self.imageViewConstraintCenterY.active = YES;
     self.textViewConstraintCenterY.active = YES;
     self.buttonContainerConstraintWidthWithLeadingButton.active = YES;
-    self.buttonContainerConstraintLeadingWithTextView.active = YES;
     self.buttonContainerConstraintTopWithMargin.active = YES;
+    if (self.leadingButton.hidden) {
+      self.textViewConstraintTrailing.active = YES;
+    } else {
+      self.buttonContainerConstraintLeadingWithTextView.active = YES;
+    }
   } else {
     self.imageViewConstraintTopLarge.active = YES;
     if (!self.imageView.hidden) {

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testShortTextWithNoAction_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testShortTextWithNoAction_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:baf9850ed1f3fb0c29d6f494c122c73c72fe44cf16337d4d5347b43c660a4988
-size 6513
+oid sha256:988a344bc6392ccbd980f291c8c324a4645038c7d31acb2482c55cdea84a903c
+size 6487


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8954.

When all buttons are hidden on the banner, we don't want to let the hidden button to occupy an invisible area which affects textView's layout.