### PR TITLE
[FeatureHighlight] Make "Color" example accessible.

### DIFF
--- a/components/FeatureHighlight/examples/FeatureHighlightColorExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightColorExample.m
@@ -27,6 +27,8 @@
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:cell.accessoryView
                                                               completion:nil];
   highlightController.titleText = @"So pretty!";
+  // Remove "double-tap to dismiss"
+  highlightController.accessibilityHint = nil;
   highlightController.bodyText = @"What a nice color you've chosen.";
   highlightController.outerHighlightColor = cell.accessoryView.backgroundColor;
   [MDCFeatureHighlightAccessibilityMutator mutate:highlightController];

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.h
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.h
@@ -31,7 +31,7 @@
 @end
 
 @interface FeatureHighlightColorExample : MDCCollectionViewController
-@property(nonatomic) NSArray *colors;
+@property(nonatomic) NSDictionary<NSString *, UIColor *> *colorNameToColorMap;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 

--- a/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
+++ b/components/FeatureHighlight/examples/supplemental/FeatureHighlightExampleSupplemental.m
@@ -114,18 +114,27 @@ static NSString *const reuseIdentifier = @"Cell";
   [self.collectionView registerClass:[MDCCollectionViewTextCell class]
           forCellWithReuseIdentifier:reuseIdentifier];
 
-  self.colors = @[
-    MDCPalette.redPalette.tint500,        MDCPalette.pinkPalette.tint500,
-    MDCPalette.purplePalette.tint500,     MDCPalette.deepPurplePalette.tint500,
-    MDCPalette.indigoPalette.tint500,     MDCPalette.bluePalette.tint500,
-    MDCPalette.lightBluePalette.tint500,  MDCPalette.cyanPalette.tint500,
-    MDCPalette.tealPalette.tint500,       MDCPalette.greenPalette.tint500,
-    MDCPalette.lightGreenPalette.tint500, MDCPalette.limePalette.tint500,
-    MDCPalette.yellowPalette.tint500,     MDCPalette.amberPalette.tint500,
-    MDCPalette.orangePalette.tint500,     MDCPalette.deepOrangePalette.tint500,
-    MDCPalette.brownPalette.tint500,      MDCPalette.greyPalette.tint500,
-    MDCPalette.blueGreyPalette.tint500,
-  ];
+  self.colorNameToColorMap = @{
+    @"Red" : MDCPalette.redPalette.tint500,
+    @"Pink" : MDCPalette.pinkPalette.tint500,
+    @"Purple" : MDCPalette.purplePalette.tint500,
+    @"Deep Purple" : MDCPalette.deepPurplePalette.tint500,
+    @"Indigo" : MDCPalette.indigoPalette.tint500,
+    @"Blue" : MDCPalette.bluePalette.tint500,
+    @"Light Blue" : MDCPalette.lightBluePalette.tint500,
+    @"Cyan" : MDCPalette.cyanPalette.tint500,
+    @"Teal" : MDCPalette.tealPalette.tint500,
+    @"Green" : MDCPalette.greenPalette.tint500,
+    @"Light Green" : MDCPalette.lightGreenPalette.tint500,
+    @"Lime" : MDCPalette.limePalette.tint500,
+    @"Yellow" : MDCPalette.yellowPalette.tint500,
+    @"Amber" : MDCPalette.amberPalette.tint500,
+    @"Orange" : MDCPalette.orangePalette.tint500,
+    @"Deep Orange" : MDCPalette.deepOrangePalette.tint500,
+    @"Brown" : MDCPalette.brownPalette.tint500,
+    @"Grey" : MDCPalette.greyPalette.tint500,
+    @"Blue Grey" : MDCPalette.blueGreyPalette.tint500,
+  };
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
@@ -134,7 +143,7 @@ static NSString *const reuseIdentifier = @"Cell";
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView
      numberOfItemsInSection:(NSInteger)section {
-  return self.colors.count;
+  return self.colorNameToColorMap.count;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
@@ -144,7 +153,11 @@ static NSString *const reuseIdentifier = @"Cell";
                                                 forIndexPath:indexPath];
 
   UIView *accessory = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
-  accessory.backgroundColor = self.colors[indexPath.row];
+  NSString *colorName = self.colorNameToColorMap.allKeys[indexPath.row];
+  accessory.backgroundColor = self.colorNameToColorMap[colorName];
+  cell.accessibilityLabel = colorName;
+  cell.isAccessibilityElement = YES;
+  cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
   cell.accessoryView = accessory;
 
   return cell;


### PR DESCRIPTION
Includes the following changes:
1.  Each cell is an accessibility element with the color name as the label.
2.  Shown Feature Highlights no longer include the "double-tap to dismiss"
    hint.

|Before|After|
|---|---|
|![IMG_0099](https://user-images.githubusercontent.com/1753199/68967680-c344ee80-07ae-11ea-8b97-43a0045ffc53.PNG)|![IMG_0098](https://user-images.githubusercontent.com/1753199/68967657-b4f6d280-07ae-11ea-828f-4976f05ce862.PNG)|


Closes #8889