### PR TITLE
[Dialogs] Provide accessibility traits for Input Field example

### DIFF
--- a/components/Dialogs/examples/supplemental/DialogsKeyboardExampleViewControllerSupplemental.m
+++ b/components/Dialogs/examples/supplemental/DialogsKeyboardExampleViewControllerSupplemental.m
@@ -41,6 +41,10 @@ static NSString *const kReusableIdentifierItem = @"cell";
       [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
                                                 forIndexPath:indexPath];
   cell.textLabel.text = @"Show Dialog";
+  cell.textLabel.isAccessibilityElement = NO;
+  cell.accessibilityLabel = cell.textLabel.text;
+  cell.isAccessibilityElement = YES;
+  cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
   return cell;
 }
 


### PR DESCRIPTION
Set the correct accessibility traits for the collection cell that presents a
Dialog.

|Before|After|
|---|---|
|![IMG_0065](https://user-images.githubusercontent.com/1753199/68968199-02c00a80-07b0-11ea-9cc4-59b98e31e4ba.PNG)|![IMG_0102](https://user-images.githubusercontent.com/1753199/68968219-0b184580-07b0-11ea-8c70-4273603e88e7.PNG)|



Closes #8879
