### PR TITLE
[FeatureHighlight] Add a voiceover dismissal affordance for the feature highlight.

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -57,8 +57,6 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
 
     _displayedView.accessibilityTraits = UIAccessibilityTraitButton;
 
-    _viewAccessiblityHint = [[self class] dismissAccessibilityHint];
-
     super.transitioningDelegate = self;
     super.modalPresentationStyle = UIModalPresentationCustom;
   }
@@ -350,14 +348,6 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
 
 - (NSString *)accessibilityHint {
   return _viewAccessiblityHint;
-}
-
-+ (NSString *)dismissAccessibilityHint {
-  NSString *key =
-      kMaterialFeatureHighlightStringTable[kStr_MaterialFeatureHighlightDismissAccessibilityHint];
-  NSString *localizedString = NSLocalizedStringFromTableInBundle(
-      key, kMaterialFeatureHighlightStringsTableName, [self bundle], @"Double-tap to dismiss.");
-  return localizedString;
 }
 
 #pragma mark - Private

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -109,11 +109,14 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     _displayMaskLayer = [[MDCFeatureHighlightLayer alloc] init];
     _displayMaskLayer.fillColor = [UIColor whiteColor].CGColor;
 
-    _accessibilityView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+    _accessibilityView = [[UIView alloc] initWithFrame:self.bounds];
+    _accessibilityView.autoresizingMask =
+        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     _accessibilityView.isAccessibilityElement = YES;
     _accessibilityView.accessibilityTraits = UIAccessibilityTraitButton;
     _accessibilityView.accessibilityLabel = @"Dismiss";
     [self addSubview:_accessibilityView];
+    [self sendSubviewToBack:_accessibilityView];
 
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _titleLabel.textAlignment = NSTextAlignmentNatural;
@@ -315,7 +318,13 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _displayedView = displayedView;
   [self addSubview:_displayedView];
   _displayedView.layer.mask = _displayMaskLayer;
-  self.accessibilityElements = @[ _titleLabel, _bodyLabel, _displayedView, _accessibilityView ];
+}
+
+- (NSArray *)accessibilityElements {
+  if (_displayedView) {
+    return @[ _titleLabel, _bodyLabel, _displayedView, _accessibilityView ];
+  }
+  return @[ _titleLabel, _bodyLabel, _accessibilityView ];
 }
 
 - (void)setHighlightPoint:(CGPoint)highlightPoint {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -436,8 +436,6 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _pulseLayer.fillColor = _innerHighlightColor.CGColor;
   _innerLayer.fillColor = _innerHighlightColor.CGColor;
   _outerLayer.fillColor = _outerHighlightColor.CGColor;
-
-  _accessibilityView.accessibilityFrame = self.bounds;
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -75,6 +75,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   MDCFeatureHighlightLayer *_pulseLayer;
   MDCFeatureHighlightLayer *_innerLayer;
   MDCFeatureHighlightLayer *_displayMaskLayer;
+  UIView *_accessibilityView;
 
   BOOL _mdc_adjustsFontForContentSizeCategory;
 
@@ -107,6 +108,12 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
     _displayMaskLayer = [[MDCFeatureHighlightLayer alloc] init];
     _displayMaskLayer.fillColor = [UIColor whiteColor].CGColor;
+
+    _accessibilityView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+    _accessibilityView.isAccessibilityElement = YES;
+    _accessibilityView.accessibilityTraits = UIAccessibilityTraitButton;
+    _accessibilityView.accessibilityLabel = @"Dismiss highlight button";
+    [self addSubview:_accessibilityView];
 
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _titleLabel.textAlignment = NSTextAlignmentNatural;
@@ -308,6 +315,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _displayedView = displayedView;
   [self addSubview:_displayedView];
   _displayedView.layer.mask = _displayMaskLayer;
+  self.accessibilityElements = @[_titleLabel, _bodyLabel, _displayedView, _accessibilityView];
 }
 
 - (void)setHighlightPoint:(CGPoint)highlightPoint {
@@ -419,6 +427,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _pulseLayer.fillColor = _innerHighlightColor.CGColor;
   _innerLayer.fillColor = _innerHighlightColor.CGColor;
   _outerLayer.fillColor = _outerHighlightColor.CGColor;
+
+  _accessibilityView.accessibilityFrame = self.bounds;
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
@@ -700,11 +710,11 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 #pragma mark - UIAccessibility
 
 - (void)setAccessibilityHint:(NSString *)accessibilityHint {
-  _titleLabel.accessibilityHint = accessibilityHint;
+  _accessibilityView.accessibilityHint = accessibilityHint;
 }
 
 - (NSString *)accessibilityHint {
-  return _titleLabel.accessibilityHint;
+  return _accessibilityView.accessibilityHint;
 }
 
 @end

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -315,7 +315,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _displayedView = displayedView;
   [self addSubview:_displayedView];
   _displayedView.layer.mask = _displayMaskLayer;
-  self.accessibilityElements = @[_titleLabel, _bodyLabel, _displayedView, _accessibilityView];
+  self.accessibilityElements = @[ _titleLabel, _bodyLabel, _displayedView, _accessibilityView ];
 }
 
 - (void)setHighlightPoint:(CGPoint)highlightPoint {

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -112,7 +112,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     _accessibilityView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     _accessibilityView.isAccessibilityElement = YES;
     _accessibilityView.accessibilityTraits = UIAccessibilityTraitButton;
-    _accessibilityView.accessibilityLabel = @"Dismiss highlight button";
+    _accessibilityView.accessibilityLabel = @"Dismiss";
     [self addSubview:_accessibilityView];
 
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];


### PR DESCRIPTION
Currently the feature highlight didn't have a proper dismiss affordance when voiceover is on.

It will instead speak a hint of "double tap to dismiss" on the title but without allowing the user to dismiss even when double tapped.

This adds a dismiss affordance and passes the accessibility hint to dismiss to that view.

Frame of dismissal button in VO:
![IMG_2140](https://user-images.githubusercontent.com/4066863/68971016-95fc3e80-07b6-11ea-846d-e4219429a4d7.PNG)


Closes #8961 #8888 #8884 #8886 #8885