### PR TITLE
[Dialogs] More Material Alerts examples is more accessible.

### DIFF
--- a/components/Dialogs/examples/DialogsAlertExampleViewController.m
+++ b/components/Dialogs/examples/DialogsAlertExampleViewController.m
@@ -286,6 +286,11 @@ static NSString *const kReusableIdentifierItem = @"cell";
       [collectionView dequeueReusableCellWithReuseIdentifier:kReusableIdentifierItem
                                                 forIndexPath:indexPath];
   cell.textLabel.text = self.modes[indexPath.row];
+  cell.textLabel.isAccessibilityElement = NO;
+  cell.isAccessibilityElement = YES;
+  cell.accessibilityLabel = cell.textLabel.text;
+  cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
+
   return cell;
 }
 


### PR DESCRIPTION
Provides accessibility traits to the cells and marks the cells as
accessibility elements.

|Before|After|
|---|---|
|![IMG_0104](https://user-images.githubusercontent.com/1753199/68968707-40716300-07b1-11ea-9227-539c7c6dfc3a.PNG)|![IMG_0103](https://user-images.githubusercontent.com/1753199/68968677-2cc5fc80-07b1-11ea-88db-1c0f5bb14652.PNG)|


Closes #8877
