### PR TITLE
[Shadow] Make Shadow Corner Radius example more accessible.

### DIFF
--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -45,6 +45,7 @@ mdc_examples_objc_library(
         "//components/AnimationTiming",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
+        "//components/private/Math",
         "//components/ShadowElevations",
         "//components/Slider",
     ],

--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -39,6 +39,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27;
     _elevationLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, frame.size.width, 100)];
     _elevationLabel.textAlignment = NSTextAlignmentCenter;
     _elevationLabel.text = @"8 pt";
+    _elevationLabel.textColor = UIColor.blackColor;
     [self addSubview:_elevationLabel];
 
     CGFloat paperDim = 200;
@@ -55,6 +56,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27;
     MDCSlider *sliderControl = [[MDCSlider alloc] initWithFrame:sliderRect];
     sliderControl.numberOfDiscreteValues = (NSUInteger)kShadowElevationsMax + 1;
     sliderControl.maximumValue = kShadowElevationsMax;
+    sliderControl.minimumValue = 0;
     sliderControl.value = kShadowElevationsDefault;
     sliderControl.delegate = self;
     sliderControl.autoresizingMask =
@@ -65,6 +67,7 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27;
             forControlEvents:UIControlEventValueChanged];
     sliderControl.accessibilityLabel = @"Change corner radius";
     sliderControl.accessibilityHint = @"Updates the corner radius of the example view";
+    sliderControl.accessibilityValue = [NSString stringWithFormat:@"%f", sliderControl.value];
     [self addSubview:sliderControl];
   }
   return self;

--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -14,6 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialMath.h"
 #import "MaterialShadowLayer.h"
 #import "MaterialSlider.h"
 #import "ShadowRadiusLabel.h"
@@ -74,15 +75,20 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27;
 }
 
 - (NSString *)slider:(MDCSlider *)slider displayedStringForValue:(CGFloat)value {
-  NSInteger points = (NSInteger)round(value);
+  NSInteger points = (NSInteger)MDCRound(value);
   return [NSString stringWithFormat:@"%ld pt", (long)points];
 }
 
 // TODO: (#4848) [ShadowLayer] cornerRadius changes don't render
 - (void)sliderValueChanged:(MDCSlider *)slider {
-  NSInteger points = (NSInteger)round(slider.value);
+  NSInteger points = (NSInteger)MDCRound(slider.value);
   _paper.cornerRadius = (CGFloat)points;
   _elevationLabel.text = [NSString stringWithFormat:@"%ld pt", (long)points];
+}
+
+- (NSString *)slider:(MDCSlider *)slider accessibilityLabelForValue:(CGFloat)value {
+  NSInteger points = (NSInteger)MDCRound(slider.value);
+  return [NSString stringWithFormat:@"%ld points", (long)points];
 }
 
 @end

--- a/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
+++ b/components/ShadowLayer/examples/ShadowCornerRadiusExample.m
@@ -63,6 +63,8 @@ static const CGFloat kShadowElevationsSliderFrameHeight = 27;
     [sliderControl addTarget:self
                       action:@selector(sliderValueChanged:)
             forControlEvents:UIControlEventValueChanged];
+    sliderControl.accessibilityLabel = @"Change corner radius";
+    sliderControl.accessibilityHint = @"Updates the corner radius of the example view";
     [self addSubview:sliderControl];
   }
   return self;


### PR DESCRIPTION
This updates the Shadow Corner Radius example to be more accessible by adding accessibility label and hint to the slider in this example.

Closes #8928  