### PR TITLE
[Catalog] Add close button to bottom drawer example header

### DIFF
--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -90,10 +90,8 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
   override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
     closeButton.sizeToFit()
-    closeButton.center =
-      CGPoint(x: 30, y: self.preferredHeight - 20)
-    titleLabel.center =
-      CGPoint(x: self.view.frame.size.width / 2, y: self.preferredHeight - 20)
+    closeButton.center = CGPoint(x: 30, y: self.preferredHeight - 20)
+    titleLabel.center = CGPoint(x: self.view.frame.size.width / 2, y: self.preferredHeight - 20)
   }
 
   @objc

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -68,6 +68,7 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
   let titleLabel : UILabel = {
     let label = UILabel(frame: .zero)
     label.text = "Example Header"
+    label.accessibilityTraits = .header
     label.sizeToFit()
     return label
   }()

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -56,6 +56,15 @@ class DrawerContentViewController: UIViewController {
 
 class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
   let preferredHeight: CGFloat = 80
+
+  lazy var closeButton: UIButton = {
+    let button = UIButton()
+    button.setTitle("Close", for: .normal)
+    button.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+    button.setTitleColor(.black, for: .normal)
+    return button
+  }()
+
   let titleLabel : UILabel = {
     let label = UILabel(frame: .zero)
     label.text = "Example Header"
@@ -72,23 +81,23 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
     }
   }
 
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
+    view.addSubview(closeButton)
     view.addSubview(titleLabel)
   }
 
   override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
+    closeButton.sizeToFit()
+    closeButton.center =
+      CGPoint(x: 30, y: self.preferredHeight - 20)
     titleLabel.center =
       CGPoint(x: self.view.frame.size.width / 2, y: self.preferredHeight - 20)
   }
 
+  @objc
+  func closeButtonTapped() {
+    dismiss(animated: true)
+  }
 }


### PR DESCRIPTION
Fixes #8895 and #8892

Before:
![before](https://user-images.githubusercontent.com/581764/68969221-7531ea00-07b2-11ea-91b9-a6272076f2f4.PNG)

After:
![after](https://user-images.githubusercontent.com/581764/68969227-795e0780-07b2-11ea-9676-153eed5925af.PNG)

