### PR TITLE
[Dialogs] Fix bug in "Dismissing Dialogs" dialogs where the buttons were not themed.

### DIFF
--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -37,9 +37,11 @@
 @end
 
 @interface ProgrammaticViewController : UIViewController
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @interface OpenURLViewController : UIViewController
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 #pragma mark - DialogsDismissingExampleViewController Implementation
@@ -84,10 +86,11 @@
 }
 
 - (IBAction)didTapProgrammatic {
-  UIViewController *viewController = [[ProgrammaticViewController alloc] initWithNibName:nil
-                                                                                  bundle:nil];
+  ProgrammaticViewController *viewController =
+      [[ProgrammaticViewController alloc] initWithNibName:nil bundle:nil];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
+  viewController.containerScheme = self.containerScheme;
 
   // Apply a presentation theme to the custom view controller
   [viewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
@@ -95,10 +98,11 @@
 }
 
 - (IBAction)didTapModalProgrammatic {
-  UIViewController *viewController = [[ProgrammaticViewController alloc] initWithNibName:nil
-                                                                                  bundle:nil];
+  ProgrammaticViewController *viewController =
+      [[ProgrammaticViewController alloc] initWithNibName:nil bundle:nil];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
+  viewController.containerScheme = self.containerScheme;
 
   MDCDialogPresentationController *presentationController =
       viewController.mdc_dialogPresentationController;
@@ -108,9 +112,11 @@
 }
 
 - (IBAction)didTapOpenURL {
-  UIViewController *viewController = [[OpenURLViewController alloc] initWithNibName:nil bundle:nil];
+  OpenURLViewController *viewController =
+      [[OpenURLViewController alloc] initWithNibName:nil bundle:nil];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
+  viewController.containerScheme = self.containerScheme;
 
   [viewController.mdc_dialogPresentationController applyThemeWithScheme:self.containerScheme];
   [self presentViewController:viewController animated:YES completion:NULL];
@@ -182,8 +188,6 @@ static NSString *const kReusableIdentifierItem = @"cell";
 
 @property(nonatomic, strong) MDCButton *dismissButton;
 
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
-
 @end
 
 @implementation ProgrammaticViewController
@@ -210,6 +214,13 @@ static NSString *const kReusableIdentifierItem = @"cell";
   [self.view addSubview:self.dismissButton];
 }
 
+- (void)setContainerScheme:(id<MDCContainerScheming>)containerScheme {
+  _containerScheme = containerScheme;
+
+  [self.dismissButton applyTextThemeWithScheme:_containerScheme];
+  self.view.backgroundColor = _containerScheme.colorScheme.backgroundColor;
+}
+
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
   [_dismissButton sizeToFit];
@@ -232,8 +243,6 @@ static NSString *const kReusableIdentifierItem = @"cell";
 @interface OpenURLViewController ()
 
 @property(nonatomic, strong) MDCButton *dismissButton;
-
-@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 

--- a/components/Dialogs/examples/DialogsDismissingExampleViewController.m
+++ b/components/Dialogs/examples/DialogsDismissingExampleViewController.m
@@ -112,8 +112,8 @@
 }
 
 - (IBAction)didTapOpenURL {
-  OpenURLViewController *viewController =
-      [[OpenURLViewController alloc] initWithNibName:nil bundle:nil];
+  OpenURLViewController *viewController = [[OpenURLViewController alloc] initWithNibName:nil
+                                                                                  bundle:nil];
   viewController.modalPresentationStyle = UIModalPresentationCustom;
   viewController.transitioningDelegate = self.transitionController;
   viewController.containerScheme = self.containerScheme;


### PR DESCRIPTION
The dialog view controllers were not being provided with the container scheme.

Fixes https://github.com/material-components/material-components-ios/issues/8878

| Before | After |
|:--|:--|
| ![Simulator Screen Shot - iPhone Xʀ - 2019-11-15 at 14 41 13](https://user-images.githubusercontent.com/45670/68970747-fe96eb80-07b5-11ea-8c69-8e0df6ffd64e.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-11-15 at 14 40 46](https://user-images.githubusercontent.com/45670/68970733-f5a61a00-07b5-11ea-81c4-b7fa75a29f84.png) |


