### PR TITLE
[bazel] Update bazel_skylib to 0.7.0.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -210,14 +210,14 @@ upload_bazel_test_artifacts() {
   find -L . -name "sponge_log.xml" -type f | copy_to_artifacts
 }
 
-# Upgrades kokoro's current bazel version to at least 0.20.0
+# Upgrades kokoro's current bazel version to at least 0.28.1
 upgrade_kokoro_bazel_if_needed() {
   bazel version
 
   if [ -f "$KOKORO_GFILE_DIR/use_bazel.sh" ]; then
-    bash "$KOKORO_GFILE_DIR/use_bazel.sh" 0.20.0
+    bash "$KOKORO_GFILE_DIR/use_bazel.sh" 0.28.1
   else
-    use_bazel.sh 0.20.0
+    use_bazel.sh 0.28.1
   fi
   bazel version
 }
@@ -252,7 +252,7 @@ run_bazel_affected() {
     base_sha=$(git merge-base "$target_branch" HEAD)
 
     # We must upgrade bazel prior to running bazel query because we rely on features in bazel
-    # 0.20.
+    # 0.28.
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       upgrade_kokoro_bazel_if_needed
     fi

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.9.0",
+    commit = "6c9fcae7a3597aabd43f28be89466afe0eab18de",  # 0.18.0
 )
 
 load(
@@ -28,12 +28,6 @@ load(
 
 apple_rules_dependencies()
 
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.4.0",
-)
-
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
@@ -41,10 +35,18 @@ load(
 
 swift_rules_dependencies()
 
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
 git_repository(
     name = "bazel_skylib",
     remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.7.0",
+    commit = "2b38b2f8bd4b8603d610cfc651fcbb299498147f",  # 0.9.0
+    shallow_since = "1562957722 -0400"
 )
 
 git_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,30 +43,14 @@ load(
 apple_support_dependencies()
 
 git_repository(
-    name = "bazel_skylib",
-    remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    commit = "2b38b2f8bd4b8603d610cfc651fcbb299498147f",  # 0.9.0
-    shallow_since = "1562957722 -0400"
-)
-
-git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
     tag = "v3.0.0",
 )
 
-# TODO: https://github.com/material-components/material-components-ios/issues/8182
-# Restore this back to google/xctestrunner repository once Xcode 11's fix is in their new release
-http_file(
-    name = "xctestrunner",
-    executable = 1,
-    urls = ["https://github.com/material-foundation/xctestrunner/releases/download/0.2.9/ios_test_runner.par"],
-)
-
-git_repository(
+local_repository(
     name = "material_internationalization_ios",
-    remote = "https://github.com/material-foundation/material-internationalization-ios.git",
-    tag = "v2.0.1",
+    path = "/Users/featherless/workbench/material-internationalization-ios",
 )
 
 git_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,7 +44,7 @@ swift_rules_dependencies()
 git_repository(
     name = "bazel_skylib",
     remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.6.0",
+    tag = "0.7.0",
 )
 
 git_repository(

--- a/catalog/BUILD
+++ b/catalog/BUILD
@@ -57,13 +57,13 @@ ios_application(
 
 mdc_objc_library(
     name = "MDCCatalogObjcLib",
-    srcs = native.glob(["MDCCatalog/*.h"]),
+    srcs = glob(["MDCCatalog/*.h"]),
     visibility = ["//visibility:private"],
 )
 
 swift_library(
     name = "MDCCatalogLib",
-    srcs = native.glob(["MDCCatalog/*.swift"]),
+    srcs = glob(["MDCCatalog/*.swift"]),
     copts = [
         "-swift-version",
         "4.2",
@@ -108,8 +108,8 @@ swift_library(
 
 mdc_objc_library(
     name = "MaterialCatalog",
-    srcs = native.glob(["MaterialCatalog/*.m"]),
-    hdrs = native.glob(["MaterialCatalog/*.h"]),
+    srcs = glob(["MaterialCatalog/*.m"]),
+    hdrs = glob(["MaterialCatalog/*.h"]),
     deps = [
         "//components/Themes",
     ],
@@ -117,7 +117,7 @@ mdc_objc_library(
 
 swift_library(
     name = "MDCDragonsLib",
-    srcs = native.glob(["MDCDragons/*.swift"]),
+    srcs = glob(["MDCDragons/*.swift"]),
     copts = [
         "-swift-version",
         "4.2",
@@ -141,7 +141,7 @@ swift_library(
 
 mdc_objc_library(
     name = "MDCActionExtension",
-    srcs = native.glob(["MDCActionExtension/*.m"]),
-    hdrs = native.glob(["MDCActionExtension/*.h"]),
+    srcs = glob(["MDCActionExtension/*.m"]),
+    hdrs = glob(["MDCActionExtension/*.h"]),
     deps = ["@catalog_by_convention//:CatalogByConvention"],
 )

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -124,24 +124,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      codeCoverageEnabled = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "664524B21C6BA62A001ADBF8"
-            BuildableName = "MDCCatalog.app"
-            BlueprintName = "MDCCatalog"
-            ReferencedContainer = "container:MDCCatalog.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FB_REFERENCE_IMAGE_DIR"
-            value = "$(SOURCE_ROOT)/../snapshot_test_goldens/goldens"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -854,6 +838,24 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "664524B21C6BA62A001ADBF8"
+            BuildableName = "MDCCatalog.app"
+            BlueprintName = "MDCCatalog"
+            ReferencedContainer = "container:MDCCatalog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FB_REFERENCE_IMAGE_DIR"
+            value = "$(SOURCE_ROOT)/../snapshot_test_goldens/goldens"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -875,6 +877,8 @@
             ReferencedContainer = "container:MDCCatalog.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -83,7 +83,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "privateHeaders",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     deps = [":ActionSheet"],
 )
 

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -26,12 +26,13 @@ load(
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ActivityIndicator",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "QuartzCore",
         "UIKit",
@@ -52,7 +53,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -27,12 +27,13 @@ load(
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "AppBar",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "CoreGraphics",
         "UIKit",
@@ -59,7 +60,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -92,7 +93,7 @@ mdc_extension_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
 )
@@ -152,7 +153,7 @@ mdc_unit_test_suite(
 
 mdc_snapshot_objc_library(
     name = "snapshot_test_lib",
-    extra_srcs = native.glob(["tests/snapshot/Theming/*.m"]),
+    extra_srcs = glob(["tests/snapshot/Theming/*.m"]),
     deps = [
         ":AppBar",
         ":Theming",

--- a/components/BottomAppBar/BUILD
+++ b/components/BottomAppBar/BUILD
@@ -46,7 +46,7 @@ mdc_public_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -32,7 +32,7 @@ licenses(["notice"])  # Apache 2.0
 mdc_objc_library(
     name = "BottomNavigation",
     srcs =
-        native.glob(
+        glob(
             [
                 "src/*.m",
                 "src/private/*.h",
@@ -45,14 +45,14 @@ mdc_objc_library(
             ],
         ),
     hdrs =
-        native.glob(
+        glob(
             ["src/*.h"],
             exclude = [
                 "src/MDCBottomNavigationBarController.h",
                 "src/MaterialBottomNavigationBeta.h",
             ],
         ),
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     enable_modules = 1,
     includes = ["src"],
     sdk_frameworks = [
@@ -77,7 +77,7 @@ mdc_objc_library(
 # that can be rolled-up into the main target.
 mdc_objc_library(
     name = "privateHeaders",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 
@@ -116,7 +116,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -169,7 +169,7 @@ mdc_examples_swift_library(
 mdc_objc_library(
     name = "unit_test_sources",
     testonly = 1,
-    srcs = native.glob(
+    srcs = glob(
         [
             "tests/unit/*.m",
             "tests/unit/*.h",

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -72,7 +72,7 @@ mdc_examples_swift_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -107,7 +107,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = [":test_targets"],
 )
 
@@ -153,7 +153,7 @@ mdc_unit_test_objc_library(
         "tests/unit/supplemental/*.m",
         "tests/unit/supplemental/*.h",
     ]),
-    xibs = native.glob(["tests/unit/resources/*.xib"]),
+    xibs = glob(["tests/unit/resources/*.xib"]),
     deps = [
         ":ButtonThemer",
         ":Buttons",
@@ -169,7 +169,7 @@ mdc_unit_test_objc_library(
 
 mdc_unit_test_swift_library(
     name = "unit_test_swift_sources",
-    extra_srcs = native.glob([
+    extra_srcs = glob([
         "tests/unit/Theming/*.swift",
     ]),
     deps = [

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -21,12 +21,13 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "CollectionCells",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     deps = [
         "//components/CollectionLayoutAttributes",
         "//components/Ink",
@@ -60,7 +61,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/Collections/BUILD
+++ b/components/Collections/BUILD
@@ -22,12 +22,13 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Collections",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "CoreGraphics",
     ],
@@ -64,7 +65,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -72,7 +73,7 @@ objc_bundle(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
 )

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -27,12 +27,13 @@ load(
     "mdc_unit_test_suite",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Dialogs",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "QuartzCore",
         "UIKit",
@@ -60,7 +61,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -134,7 +135,7 @@ mdc_examples_swift_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
 )

--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -25,12 +25,13 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "FeatureHighlight",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "CoreGraphics",
         "UIKit",
@@ -49,7 +50,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -89,7 +90,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = ["//visibility:private"],
 )

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -56,7 +56,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = [":test_targets"],
 )

--- a/components/Ink/BUILD
+++ b/components/Ink/BUILD
@@ -48,7 +48,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
     deps = [":Ink"],
 )

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -50,7 +50,7 @@ mdc_extension_objc_library(
 mdc_objc_library(
     name = "private",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/PageControl/BUILD
+++ b/components/PageControl/BUILD
@@ -25,12 +25,13 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "PageControl",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "QuartzCore",
         "CoreGraphics",
@@ -47,7 +48,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -62,7 +63,7 @@ mdc_extension_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/ProgressView/BUILD
+++ b/components/ProgressView/BUILD
@@ -59,13 +59,13 @@ mdc_extension_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 
 mdc_unit_test_objc_library(
     name = "unit_test_sources",
-    extra_srcs = native.glob([
+    extra_srcs = glob([
         "tests/unit/Theming/*.m",
     ]),
     deps = [

--- a/components/Ripple/BUILD
+++ b/components/Ripple/BUILD
@@ -41,7 +41,7 @@ mdc_public_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
     deps = [":Ripple"],
 )

--- a/components/Slider/BUILD
+++ b/components/Slider/BUILD
@@ -50,7 +50,7 @@ mdc_extension_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -26,12 +26,13 @@ load(
     "mdc_unit_test_swift_library",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Snackbar",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = [
         "CoreGraphics",
         "QuartzCore",
@@ -59,7 +60,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -106,7 +107,7 @@ mdc_examples_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -25,12 +25,13 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "Tabs",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     deps = [
         "//components/AnimationTiming",
         "//components/Elevation",
@@ -51,7 +52,7 @@ filegroup(
     ]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )
@@ -149,13 +150,13 @@ mdc_examples_swift_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 
 mdc_objc_library(
     name = "privateTabBarView",
-    hdrs = native.glob(["src/TabBarView/private/*.h"]),
+    hdrs = glob(["src/TabBarView/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 
@@ -190,7 +191,7 @@ mdc_unit_test_suite(
 
 mdc_snapshot_objc_library(
     name = "snapshot_test_lib",
-    extra_srcs = native.glob(["tests/snapshot/*/*.m"]),
+    extra_srcs = glob(["tests/snapshot/*/*.m"]),
     deps = [
         ":TabBarView",
         ":Tabs",

--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -28,7 +28,7 @@ licenses(["notice"])
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = [":test_targets"],
 )

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -31,7 +31,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     includes = ["src/private"],
     visibility = [":test_targets"],
 )

--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -40,7 +40,7 @@ mdc_public_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/private/Icons/icons/ic_arrow_back/BUILD
+++ b/components/private/Icons/icons/ic_arrow_back/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_arrow_back",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_arrow_back.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_check/BUILD
+++ b/components/private/Icons/icons/ic_check/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_check",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_check.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_check_circle/BUILD
+++ b/components/private/Icons/icons/ic_check_circle/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_check_circle",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_check_circle.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_chevron_right/BUILD
+++ b/components/private/Icons/icons/ic_chevron_right/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_chevron_right",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_chevron_right.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_color_lens/BUILD
+++ b/components/private/Icons/icons/ic_color_lens/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_color_lens",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_color_lens.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_help_outline/BUILD
+++ b/components/private/Icons/icons/ic_help_outline/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_help_outline",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_help_outline.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_info/BUILD
+++ b/components/private/Icons/icons/ic_info/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_info",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_info.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_more_horiz/BUILD
+++ b/components/private/Icons/icons/ic_more_horiz/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_more_horiz",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_more_horiz.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_radio_button_unchecked/BUILD
+++ b/components/private/Icons/icons/ic_radio_button_unchecked/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_radio_button_unchecked",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_radio_button_unchecked.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_reorder/BUILD
+++ b/components/private/Icons/icons/ic_reorder/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_reorder",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_reorder.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Icons/icons/ic_settings/BUILD
+++ b/components/private/Icons/icons/ic_settings/BUILD
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_public_objc_library")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_bundle_import")
 
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(
     name = "ic_settings",
-    bundles = [":Bundle"],
+    data = [":Bundle"],
     sdk_frameworks = ["UIKit"],
     deps = ["//components/private/Icons"],
 )
@@ -29,7 +30,7 @@ filegroup(
     srcs = glob(["src/MaterialIcons_ic_settings.bundle/**"]),
 )
 
-objc_bundle(
+apple_bundle_import(
     name = "Bundle",
     bundle_imports = [":BundleFiles"],
 )

--- a/components/private/Overlay/BUILD
+++ b/components/private/Overlay/BUILD
@@ -33,7 +33,7 @@ mdc_public_objc_library(
 
 mdc_objc_library(
     name = "private",
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
 )
 

--- a/components/private/Snapshot/BUILD
+++ b/components/private/Snapshot/BUILD
@@ -24,7 +24,7 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_objc_library(
     name = "SnapshotSourceDummies",
-    srcs = native.glob([
+    srcs = glob([
         "src/SourceDummies/*.h",
         "src/SourceDummies/*.m",
     ]),

--- a/components/private/Snapshot/TestHost/BUILD
+++ b/components/private/Snapshot/TestHost/BUILD
@@ -18,10 +18,10 @@ licenses(["notice"])  # Apache 2.0
 
 mdc_objc_library(
     name = "test_host_lib",
-    srcs = native.glob([
+    srcs = glob([
         "src/*.m",
     ]),
-    hdrs = native.glob([
+    hdrs = glob([
         "src/*.h",
     ]),
     enable_modules = 1,

--- a/components/private/ThumbTrack/BUILD
+++ b/components/private/ThumbTrack/BUILD
@@ -42,7 +42,7 @@ mdc_public_objc_library(
 mdc_objc_library(
     name = "private_headers",
     testonly = 1,
-    hdrs = native.glob(["src/private/*.h"]),
+    hdrs = glob(["src/private/*.h"]),
     visibility = ["//visibility:private"],
     deps = [":ThumbTrack"],
 )

--- a/components/testing/runners/BUILD
+++ b/components/testing/runners/BUILD
@@ -45,7 +45,7 @@ ios_test_runner(
     visibility = ["//visibility:public"],
 )
 
-native.config_setting(
+config_setting(
     name = "xcode_9_0",
     values = {"xcode_version": "9.0"},
 )


### PR DESCRIPTION
This gives us access to `build_test` and sets us up to be able to remove our "build" CI target.

Part of https://github.com/material-components/material-components-ios/issues/8972
