### PR TITLE
[TextFields] Correction to the accessibility label

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -828,7 +828,8 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
   NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityLabel].length > 0) {
     [accessibilityStrings addObject:[super accessibilityLabel]];
-  } else if (!self.hidesPlaceholderOnInput && self.placeholderLabel.accessibilityLabel.length > 0) {
+  } else if (!self.hidesPlaceholderOnInput && self.placeholderLabel.accessibilityLabel.length > 0 && [self hasTextContent]) {
+    // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
     [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -828,8 +828,11 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
   NSMutableArray *accessibilityStrings = [[NSMutableArray alloc] init];
   if ([super accessibilityLabel].length > 0) {
     [accessibilityStrings addObject:[super accessibilityLabel]];
-  } else if (!self.hidesPlaceholderOnInput && self.placeholderLabel.accessibilityLabel.length > 0 && [self hasTextContent]) {
-    // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
+  } else if (!self.hidesPlaceholderOnInput && self.placeholderLabel.accessibilityLabel.length > 0 &&
+             [self hasTextContent]) {
+    // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been
+    // entered on a UITextField. Therefore we do not also add the placeholder content when there is
+    // no user entered text.
     [accessibilityStrings addObject:self.placeholderLabel.accessibilityLabel];
   }
   if (self.leadingUnderlineLabel.accessibilityLabel.length > 0) {

--- a/components/TextFields/tests/unit/MDCTextFieldAccessibilityTests.m
+++ b/components/TextFields/tests/unit/MDCTextFieldAccessibilityTests.m
@@ -71,9 +71,10 @@
   field.text = @"";
 
   // Then
-  XCTAssertEqualObjects(field.accessibilityLabel,
-                        @"leading underline, trailing underline");
-  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
+  XCTAssertEqualObjects(field.accessibilityLabel, @"leading underline, trailing underline");
+  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered
+  // on a UITextField. Therefore we do not also add the placeholder content when there is no user
+  // entered text.
 }
 
 - (void)testAccessibilityLabelPlaceholderWithHiddenPlaceholderAndText {
@@ -90,7 +91,9 @@
 
   // Then
   XCTAssertEqualObjects(field.accessibilityLabel, @"leading underline, traling underline");
-  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
+  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered
+  // on a UITextField. Therefore we do not also add the placeholder content when there is no user
+  // entered text.
 }
 
 - (void)testAccessibilityLabelPlaceholderAndLabel {

--- a/components/TextFields/tests/unit/MDCTextFieldAccessibilityTests.m
+++ b/components/TextFields/tests/unit/MDCTextFieldAccessibilityTests.m
@@ -58,7 +58,7 @@
                         @"main accessibility label, leading underline, trailing underline");
 }
 
-- (void)testAccessibilityLabelPlaceholder {
+- (void)testAccessibilityLabelPlaceholderWithNotText {
   // Given
   MDCTextField *field = [[MDCTextField alloc] init];
   field.hidesPlaceholderOnInput = NO;
@@ -68,13 +68,15 @@
   field.placeholderLabel.accessibilityLabel = @"placeholder";
   field.leadingUnderlineLabel.accessibilityLabel = @"leading underline";
   field.trailingUnderlineLabel.accessibilityLabel = @"trailing underline";
+  field.text = @"";
 
   // Then
   XCTAssertEqualObjects(field.accessibilityLabel,
-                        @"placeholder, leading underline, trailing underline");
+                        @"leading underline, trailing underline");
+  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
 }
 
-- (void)testAccessibilityLabelPlaceholderWithHiddenPlaceholder {
+- (void)testAccessibilityLabelPlaceholderWithHiddenPlaceholderAndText {
   // Given
   MDCTextField *field = [[MDCTextField alloc] init];
   field.hidesPlaceholderOnInput = YES;
@@ -84,9 +86,11 @@
   field.placeholderLabel.accessibilityLabel = @"placeholder";
   field.leadingUnderlineLabel.accessibilityLabel = @"leading underline";
   field.trailingUnderlineLabel.accessibilityLabel = @"traling underline";
+  field.text = @"user entered text";
 
   // Then
   XCTAssertEqualObjects(field.accessibilityLabel, @"leading underline, traling underline");
+  // Note: UIKit verbalizes (in a lower tone) the placeholder content when no text has been entered on a UITextField. Therefore we do not also add the placeholder content when there is no user entered text.
 }
 
 - (void)testAccessibilityLabelPlaceholderAndLabel {


### PR DESCRIPTION
UITextField verbalizes the placeholder in a lower pitch when no text has been entered. This change incorporates this behavior into what values get added to the MDCTextField's accessibilityLabel.

Before after videos:
[singleFix.zip](https://github.com/material-components/material-components-ios/files/3853326/singleFix.zip)


QA=Notice that "state" is verbalized when it is not visible on screen in the after.
more info at #7513
