### PR TITLE
[Tabs] Improve accessibility for TabBar example.

### DIFF
--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -112,6 +112,7 @@ mdc_examples_objc_library(
         ":ColorThemer",
         ":TabBarView",
         ":Tabs",
+        ":Theming",
         ":TypographyThemer",
         "//components/ActionSheet",
         "//components/ActionSheet:Theming",

--- a/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarViewControllerInterfaceBuilderExample.m
@@ -14,12 +14,12 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialColorScheme.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 
 @interface TabBarViewControllerInterfaceBuilderExample : MDCTabBarViewController
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end
 
 @implementation TabBarViewControllerInterfaceBuilderExample
@@ -27,8 +27,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -40,22 +39,11 @@
     [self.storyboard instantiateViewControllerWithIdentifier:@"blue"],
     [self.storyboard instantiateViewControllerWithIdentifier:@"green"],
   ];
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
-}
-
-@end
-
-@implementation TabBarViewControllerInterfaceBuilderExample (Supplemental)
-
-- (UIStatusBarStyle)preferredStatusBarStyle {
-  // Ensure that our status bar is white.
-  return UIStatusBarStyleLightContent;
-}
-
-// TabBarViewControllerInterfaceBuilderExample expect that appBars be inside the tabs,
-// so don't stick an appBarViewController on it.
-- (BOOL)catalogShouldHideNavigation {
-  return YES;
+  if (!self.containerScheme) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+  [self.tabBar applyPrimaryThemeWithScheme:self.containerScheme];
+  self.selectedViewController = self.viewControllers.firstObject;
 }
 
 @end

--- a/components/Tabs/examples/resources/TabBarViewControllerInterfaceBuilderExample.storyboard
+++ b/components/Tabs/examples/resources/TabBarViewControllerInterfaceBuilderExample.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="oR6-Dz-GRE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="oR6-Dz-GRE">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,19 +20,7 @@
                     <view key="view" contentMode="scaleToFill" id="xVI-gP-gga">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a tab, below." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbq-he-jBj">
-                                <rect key="frame" x="83" y="186" width="208" height="33.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="28"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="lbq-he-jBj" firstAttribute="top" secondItem="p4q-kg-ckN" secondAttribute="bottom" constant="166" id="1tZ-N0-XQe"/>
-                            <constraint firstItem="lbq-he-jBj" firstAttribute="centerX" secondItem="xVI-gP-gga" secondAttribute="centerX" id="mQk-AC-wln"/>
-                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eIf-pi-l9p" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -50,11 +38,31 @@
                     <view key="view" contentMode="scaleToFill" id="I60-0j-fFx">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a tab, below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JUg-eW-HJU">
+                                <rect key="frame" x="0.0" y="321.5" width="375" height="24"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" red="0.039215687659999998" green="0.40000003579999999" blue="0.79607850309999995" alpha="1" colorSpace="deviceRGB"/>
+                        <constraints>
+                            <constraint firstItem="JUg-eW-HJU" firstAttribute="width" secondItem="I60-0j-fFx" secondAttribute="width" id="2RX-Zc-LR5"/>
+                            <constraint firstItem="JUg-eW-HJU" firstAttribute="centerY" secondItem="I60-0j-fFx" secondAttribute="centerY" id="E7h-bg-M7r"/>
+                            <constraint firstItem="JUg-eW-HJU" firstAttribute="centerX" secondItem="I60-0j-fFx" secondAttribute="centerX" id="ETR-eP-C6o"/>
+                        </constraints>
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3d9-sl-CkD" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a tab, below." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="D96-we-5mX">
+                    <rect key="frame" x="0.0" y="0.0" width="198" height="33.5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </objects>
             <point key="canvasLocation" x="1446" y="-474"/>
         </scene>
@@ -69,7 +77,19 @@
                     <view key="view" contentMode="scaleToFill" id="ada-NZ-6V9">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a tab, below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S8B-r3-iBx">
+                                <rect key="frame" x="0.0" y="321.5" width="375" height="24"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" red="0.53333333329999999" green="0.78039215689999997" blue="0.25098039220000001" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="S8B-r3-iBx" firstAttribute="width" secondItem="ada-NZ-6V9" secondAttribute="width" id="Kgo-29-6GR"/>
+                            <constraint firstItem="S8B-r3-iBx" firstAttribute="centerX" secondItem="ada-NZ-6V9" secondAttribute="centerX" id="N4F-Gc-0Fs"/>
+                            <constraint firstItem="S8B-r3-iBx" firstAttribute="centerY" secondItem="ada-NZ-6V9" secondAttribute="centerY" id="k1e-54-pl3"/>
+                        </constraints>
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
@@ -88,7 +108,20 @@
                     <view key="view" contentMode="scaleToFill" id="am7-Ek-75B">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a tab, below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PX2-sm-wK0">
+                                <rect key="frame" x="0.0" y="321.5" width="375" height="24"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" red="0.66352897879999995" green="0.031058075009999998" blue="0.028557975190000001" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="PX2-sm-wK0" firstAttribute="width" secondItem="am7-Ek-75B" secondAttribute="width" id="bYL-Rc-X4m"/>
+                            <constraint firstItem="PX2-sm-wK0" firstAttribute="centerY" secondItem="am7-Ek-75B" secondAttribute="centerY" id="odK-Fb-p1f"/>
+                            <constraint firstItem="PX2-sm-wK0" firstAttribute="centerX" secondItem="am7-Ek-75B" secondAttribute="centerX" id="wzC-nW-eYe"/>
+                        </constraints>
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>


### PR DESCRIPTION
The Tab Bar View Controller with Interface Builder example had no way to
dismiss with Voice Over, disappearing labels, and too much code.  Provides an
AppBar with back button, labels on every child view controller, and better
support for Dynamic Type.

|Before|After 1 AXXXL|After 2 XS|
|---|---|---|
|![IMG_0110](https://user-images.githubusercontent.com/1753199/68987915-134aa200-07fd-11ea-8424-277e0b6eb1ee.PNG)|![IMG_0114](https://user-images.githubusercontent.com/1753199/68987917-1d6ca080-07fd-11ea-8a1c-d1c372665fe5.PNG)|![IMG_0115](https://user-images.githubusercontent.com/1753199/68987918-22c9eb00-07fd-11ea-8b74-ec85cb602e93.PNG)|

Closes #8978
