### PR TITLE
[Buttons] Fix dynamic type example.

### DIFF
--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -22,41 +22,36 @@ import MaterialComponents.MaterialTypography
 class ButtonsDynamicTypeViewController: UIViewController {
 
   @objc var containerScheme = MDCContainerScheme()
-  var flatButtonDynamic = MDCButton()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = UIColor(white: 0.9, alpha:1.0)
-    let titleColor = UIColor.white
-    let backgroundColor = UIColor(white: 0.1, alpha: 1.0)
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
 
     let flatButtonStatic = MDCButton()
     flatButtonStatic.applyContainedTheme(withScheme: containerScheme)
-    flatButtonStatic.setTitleColor(titleColor, for: .normal)
-    flatButtonStatic.setBackgroundColor(backgroundColor, for: .normal)
     flatButtonStatic.setTitle("Static", for: UIControl.State())
     flatButtonStatic.sizeToFit()
     flatButtonStatic.translatesAutoresizingMaskIntoConstraints = false
     flatButtonStatic.addTarget(self, action: #selector(tap), for: .touchUpInside)
     view.addSubview(flatButtonStatic)
 
-    containerScheme.typographyScheme = MDCTypographyScheme.init(defaults: .material201902)
+    let flatButtonDynamic = MDCButton()
     flatButtonDynamic.applyContainedTheme(withScheme: containerScheme)
-    flatButtonDynamic.setTitleColor(titleColor, for: .normal)
-    flatButtonDynamic.setBackgroundColor(backgroundColor, for: .normal)
+    let buttonFont = containerScheme.typographyScheme.button.mdc_scaledFont(for: view)
+    flatButtonDynamic.setTitleFont(buttonFont, for: .normal)
+    flatButtonDynamic.mdc_adjustsFontForContentSizeCategory = true
     flatButtonDynamic.setTitle("Dynamic", for: UIControl.State())
     flatButtonDynamic.sizeToFit()
     flatButtonDynamic.translatesAutoresizingMaskIntoConstraints = false
     flatButtonDynamic.addTarget(self, action: #selector(tap), for: .touchUpInside)
-    flatButtonDynamic.mdc_adjustsFontForContentSizeCategory = true
+
     view.addSubview(flatButtonDynamic)
 
-    containerScheme.typographyScheme = MDCTypographyScheme.init(defaults: .material201804)
     let flatButtonDynamicLegacy = MDCButton()
     flatButtonDynamicLegacy.applyContainedTheme(withScheme: containerScheme)
-    flatButtonDynamicLegacy.setTitleColor(titleColor, for: .normal)
-    flatButtonDynamicLegacy.setBackgroundColor(backgroundColor, for: .normal)
+    let buttonFont = MDCTypographyScheme(defaults: .material201804).button
+    flatButtonDynamicLegacy.setTitleFont(buttonFont, for: .normal)
     flatButtonDynamicLegacy.setTitle("Dynamic (legacy)", for: UIControl.State())
     flatButtonDynamicLegacy.sizeToFit()
     flatButtonDynamicLegacy.translatesAutoresizingMaskIntoConstraints = false
@@ -77,13 +72,6 @@ class ButtonsDynamicTypeViewController: UIViewController {
       NSLayoutConstraint.constraints(withVisualFormat:
           "V:[flatStatic]-40-[flatDynamic]-40-[flatDynamicLegacy]",
               options: .alignAllCenterX, metrics: nil, views: views))
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    let buttonFont = containerScheme.typographyScheme.button.mdc_scaledFont(for: view)
-    flatButtonDynamic.setTitleFont(buttonFont, for: .normal)
   }
 
   // MARK: Private

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -50,8 +50,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
 
     let flatButtonDynamicLegacy = MDCButton()
     flatButtonDynamicLegacy.applyContainedTheme(withScheme: containerScheme)
-    let buttonFont = MDCTypographyScheme(defaults: .material201804).button
-    flatButtonDynamicLegacy.setTitleFont(buttonFont, for: .normal)
+    let legacyButtonFont = MDCTypographyScheme(defaults: .material201804).button
+    flatButtonDynamicLegacy.setTitleFont(legacyButtonFont, for: .normal)
     flatButtonDynamicLegacy.setTitle("Dynamic (legacy)", for: UIControl.State())
     flatButtonDynamicLegacy.sizeToFit()
     flatButtonDynamicLegacy.translatesAutoresizingMaskIntoConstraints = false

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -28,7 +28,8 @@ class ButtonsDynamicTypeViewController: UIViewController {
     ]
   }
 
-  var containerScheme = MDCContainerScheme()
+  @objc var containerScheme = MDCContainerScheme()
+  var flatButtonDynamic = MDCButton()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -48,7 +49,6 @@ class ButtonsDynamicTypeViewController: UIViewController {
     view.addSubview(flatButtonStatic)
 
     containerScheme.typographyScheme = MDCTypographyScheme.init(defaults: .material201902)
-    let flatButtonDynamic = MDCButton()
     flatButtonDynamic.applyContainedTheme(withScheme: containerScheme)
     flatButtonDynamic.setTitleColor(titleColor, for: .normal)
     flatButtonDynamic.setBackgroundColor(backgroundColor, for: .normal)
@@ -84,6 +84,13 @@ class ButtonsDynamicTypeViewController: UIViewController {
       NSLayoutConstraint.constraints(withVisualFormat:
           "V:[flatStatic]-40-[flatDynamic]-40-[flatDynamicLegacy]",
               options: .alignAllCenterX, metrics: nil, views: views))
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    let buttonFont = containerScheme.typographyScheme.button.mdc_scaledFont(for: view)
+    flatButtonDynamic.setTitleFont(buttonFont, for: .normal)
   }
 
   // MARK: Private

--- a/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
+++ b/components/Buttons/examples/ButtonsDynamicTypeViewController.swift
@@ -15,18 +15,11 @@
 import UIKit
 
 import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialButtons_Theming
+import MaterialComponents.MaterialContainerScheme
+import MaterialComponents.MaterialTypography
 
 class ButtonsDynamicTypeViewController: UIViewController {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Buttons", "Buttons (DynamicType)"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
 
   @objc var containerScheme = MDCContainerScheme()
   var flatButtonDynamic = MDCButton()
@@ -118,5 +111,15 @@ class ButtonsDynamicTypeViewController: UIViewController {
   @objc func tap(_ sender: Any) {
     print("\(type(of: sender)) was tapped.")
   }
+}
 
+// MARK: Catalog by conventions
+extension ButtonsDynamicTypeViewController {
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Buttons", "Buttons (DynamicType)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
 }


### PR DESCRIPTION
This updates the buttons dynamic font example to use what we currently recommend for dynamic type support in MDCButton. This also updates the container scheme to be `@objc` so that Catalog by Conventions can inject the container scheme.

## Screenshots

#### XS 

| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPhone 5 - 2019-11-18 at 14 23 58](https://user-images.githubusercontent.com/7131294/69082993-42386200-0a0f-11ea-8cb0-694a95b9ce1f.png)|![Simulator Screen Shot - iPhone 5 - 2019-11-18 at 14 17 17](https://user-images.githubusercontent.com/7131294/69083166-93e0ec80-0a0f-11ea-8c96-056f2f003ca4.png)|

#### XXXL

| Before | After |
| --- | --- |
|![Simulator Screen Shot - iPhone 5 - 2019-11-18 at 14 23 45](https://user-images.githubusercontent.com/7131294/69083547-4ca72b80-0a10-11ea-965d-c8d83e0bf2c7.png)|![Simulator Screen Shot - iPhone 5 - 2019-11-18 at 14 17 23](https://user-images.githubusercontent.com/7131294/69083536-47e27780-0a10-11ea-9bf5-064928a4f833.png)|

Closes #8855 