### PR TITLE
[AppBar] Add a shouldSetNavigationBarHiddenHideAppBar behavior flag.

### DIFF
--- a/components/AppBar/examples/AppBarNavigationControllerExample.swift
+++ b/components/AppBar/examples/AppBarNavigationControllerExample.swift
@@ -1,0 +1,137 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MaterialComponents.MaterialAppBar
+import MaterialComponents.MaterialAppBar_Theming
+import MaterialComponents.MaterialContainerScheme
+
+class AppBarNavigationControllerExampleViewController:
+    UIViewController,
+    MDCAppBarNavigationControllerDelegate {
+
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+
+    self.title = "Navigation Controller"
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor
+
+    self.navigationItem.rightBarButtonItem =
+      UIBarButtonItem(title: "Present", style: .done, target: self, action: #selector(presentModal))
+  }
+
+  @objc func presentModal() {
+    let contentViewController = PresentedViewController()
+    let navigationController = MDCAppBarNavigationController()
+    navigationController.shouldSetNavigationBarHiddenHideAppBar = true
+    navigationController.delegate = self
+    navigationController.pushViewController(contentViewController, animated: false)
+
+    contentViewController.navigationItem.rightBarButtonItem =
+        UIBarButtonItem(title: "Dismiss",
+                        style: .done,
+                        target: self,
+                        action: #selector(dismissModal))
+
+    // Explicitly use the full-screen style to validate safe area insets behavior.
+    navigationController.modalPresentationStyle = .fullScreen
+
+    self.present(navigationController, animated: true, completion: nil)
+  }
+
+  @objc func dismissModal() {
+    dismiss(animated: true)
+  }
+
+  // MARK: - MDCAppBarNavigationControllerDelegate
+
+  func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
+                                  willAdd appBarViewController: MDCAppBarViewController,
+                                  asChildOf viewController: UIViewController) {
+    appBarViewController.applyPrimaryTheme(withScheme: self.containerScheme)
+  }
+}
+
+private class PresentedViewController: UITableViewController {
+
+  init() {
+    super.init(nibName: nil, bundle: nil)
+
+    self.title = "Presented"
+
+    self.navigationItem.leftBarButtonItem =
+        UIBarButtonItem(title: "Toggle",
+                        style: .done,
+                        target: self,
+                        action: #selector(toggleVisibility))
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  // MARK - Actions
+
+  @objc func toggleVisibility() {
+    guard let navigationController = navigationController else {
+      return
+    }
+    navigationController.setNavigationBarHidden(!navigationController.isNavigationBarHidden,
+                                                animated: true)
+  }
+
+  // MARK: - UITableViewDataSource
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 50
+  }
+
+  override func tableView(_ tableView: UITableView,
+                          cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+    return self.tableView.dequeueReusableCell(withIdentifier: "cell") ??
+      UITableViewCell(style: .default, reuseIdentifier: "cell")
+  }
+
+  // MARK - UITableViewDelegate
+
+  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    toggleVisibility()
+
+    tableView.deselectRow(at: indexPath, animated: true)
+  }
+}
+
+// MARK: Catalog by convention
+extension AppBarNavigationControllerExampleViewController {
+
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["App Bar", "Navigation Controller"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
+  }
+}

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -116,6 +116,34 @@
 __attribute__((objc_subclassing_restricted)) @interface MDCAppBarNavigationController
     : UINavigationController
 
+#pragma mark - Changing app bar visibility
+
+/**
+ This property's getter and setter behavior are defined by the value of
+ @c shouldSetNavigationBarHiddenHideAppBar.
+
+ ## Getter behavior
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is enabled, this property will return the visibility
+ of the current view controller's injected app bar, if one exists. Otherwise it will always return
+ YES.
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is disabled, this property will return the
+ visibility of the UINavigationBar.
+
+ ## Setter behavior
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is enabled, invocations of this method will change
+ the visibility of the currently visible view controller's App Bar. This only affects visibility of
+ injected App Bar view controllers.
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is disabled, invocations of this method
+ will always result in the UIKit navigation bar being hidden, regardless of the provided value of @c
+ hidden, and the currently visible view controller's App Bar visibility will not be affected.
+ Attempting to set this property to @c YES will result in a runtime assertion.
+ */
+@property(nonatomic, getter=isNavigationBarHidden) BOOL navigationBarHidden;
+
 #pragma mark - Reacting to state changes
 
 /**
@@ -143,32 +171,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCAppBarNavigationContr
  Default value is NO.
  */
 @property(nonatomic, assign) BOOL shouldSetNavigationBarHiddenHideAppBar;
-
-/**
- This property's getter and setter behavior are defined by the value of @c
- shouldSetNavigationBarHiddenHideAppBar.
-
- ## Getter behavior
-
- When @c shouldSetNavigationBarHiddenHideAppBar is enabled, this property will return the visibility
- of the current view controller's injected app bar, if one exists. Otherwise it will always return
- YES.
-
- When @c shouldSetNavigationBarHiddenHideAppBar is disabled, this property will return the
- visibility of the UINavigationBar.
-
- ## Setter behavior
-
- When @c shouldSetNavigationBarHiddenHideAppBar is enabled, invocations of this method will change
- the visibility of the currently visible view controller's App Bar. This only affects visibility of
- injected App Bar view controllers.
-
- When @c shouldSetNavigationBarHiddenHideAppBar is disabled, invocations of this method
- will always result in the UIKit navigation bar being hidden, regardless of the provided value of @c
- hidden, and the currently visible view controller's App Bar visibility will not be affected.
- Attempting to set this property to @c YES will result in a runtime assertion.
- */
-@property(nonatomic, getter=isNavigationBarHidden) BOOL navigationBarHidden;
 
 #pragma mark - Getting App Bar view controller instances
 

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -123,6 +123,53 @@ __attribute__((objc_subclassing_restricted)) @interface MDCAppBarNavigationContr
  */
 @property(nonatomic, weak, nullable) id<MDCAppBarNavigationControllerDelegate> delegate;
 
+#pragma mark - Behavioral flags
+
+/**
+ Controls whether the @c setNavigationBarHidden: and @c setNavigationBarHidden:animated: methods
+ will toggle visiblity of the currently visible injected App Bar.
+
+ When enabled, invocations to @c setNavigationBarHidden: and @c setNavigationBarHidden:animated:
+ will change the visibility of the currently visible view controller's App Bar. This only affects
+ visibility of injected App Bar view controllers.
+
+ When disabled, invocations to @c setNavigationBarHidden: and @c setNavigationBarHidden:animated:
+ will always result in the UIKit navigation bar being hidden, regardless of the provided value of @c
+ hidden, and the currently visible view controller's App Bar visibility will not be affected.
+
+ The result of changing this property after app bars have already been presented and/or hidden is
+ undefined.
+
+ Default value is NO.
+ */
+@property(nonatomic, assign) BOOL shouldSetNavigationBarHiddenHideAppBar;
+
+/**
+ This property's getter and setter behavior are defined by the value of @c
+ shouldSetNavigationBarHiddenHideAppBar.
+
+ ## Getter behavior
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is enabled, this property will return the visibility
+ of the current view controller's injected app bar, if one exists. Otherwise it will always return
+ YES.
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is disabled, this property will return the
+ visibility of the UINavigationBar.
+
+ ## Setter behavior
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is enabled, invocations of this method will change
+ the visibility of the currently visible view controller's App Bar. This only affects visibility of
+ injected App Bar view controllers.
+
+ When @c shouldSetNavigationBarHiddenHideAppBar is disabled, invocations of this method
+ will always result in the UIKit navigation bar being hidden, regardless of the provided value of @c
+ hidden, and the currently visible view controller's App Bar visibility will not be affected.
+ Attempting to set this property to @c YES will result in a runtime assertion.
+ */
+@property(nonatomic, getter=isNavigationBarHidden) BOOL navigationBarHidden;
+
 #pragma mark - Getting App Bar view controller instances
 
 /**

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -156,6 +156,9 @@
     return;
   }
 
+  // If the shift behavior is presently disabled (the default), then adjust it to be hideable
+  // instead, otherwise we do not make any adjustments to the shift behavior because it's likely
+  // that the shift behavior was explicitly set to something else.
   if (appBarViewController.headerView.shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled) {
     appBarViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorHideable;
   }

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
@@ -30,4 +30,28 @@
   XCTAssertTrue(appBarNavigationController.navigationBarHidden);
 }
 
+- (void)testStillHiddenAfterSettingNavigationBarHidden {
+  // Given
+  MDCAppBarNavigationController *appBarNavigationController =
+      [[MDCAppBarNavigationController alloc] init];
+
+  // When
+  appBarNavigationController.navigationBarHidden = YES;
+
+  // Then
+  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+}
+
+- (void)testStillHiddenAfterSettingNavigationBarHiddenAnimated {
+  // Given
+  MDCAppBarNavigationController *appBarNavigationController =
+  [[MDCAppBarNavigationController alloc] init];
+
+  // When
+  [appBarNavigationController setNavigationBarHidden:YES animated:YES];
+
+  // Then
+  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+}
+
 @end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
@@ -29,7 +29,8 @@
   self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
   self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = NO;
   [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
-  self.appBarViewController = [self.appBarNavigationController appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
+  self.appBarViewController = [self.appBarNavigationController
+      appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
 }
 
 - (void)tearDown {

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
@@ -17,41 +17,47 @@
 #import "MaterialAppBar.h"
 
 @interface AppBarNavigationControllerNavigationBarHiddenTests : XCTestCase
+@property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
 @end
 
 @implementation AppBarNavigationControllerNavigationBarHiddenTests
 
-- (void)testDefaultIsHidden {
-  // Given
-  MDCAppBarNavigationController *appBarNavigationController =
-      [[MDCAppBarNavigationController alloc] init];
+- (void)setUp {
+  [super setUp];
 
+  self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
+  self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = NO;
+  [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
+}
+
+- (void)tearDown {
+  self.appBarNavigationController = nil;
+
+  [super tearDown];
+}
+
+- (void)testDefaultIsHidden {
   // Then
-  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
 }
 
 - (void)testStillHiddenAfterSettingNavigationBarHidden {
-  // Given
-  MDCAppBarNavigationController *appBarNavigationController =
-      [[MDCAppBarNavigationController alloc] init];
-
   // When
-  appBarNavigationController.navigationBarHidden = YES;
+  self.appBarNavigationController.navigationBarHidden = YES;
 
   // Then
-  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
 }
 
 - (void)testStillHiddenAfterSettingNavigationBarHiddenAnimated {
-  // Given
-  MDCAppBarNavigationController *appBarNavigationController =
-  [[MDCAppBarNavigationController alloc] init];
-
   // When
-  [appBarNavigationController setNavigationBarHidden:YES animated:YES];
+  [self.appBarNavigationController setNavigationBarHidden:YES animated:YES];
 
   // Then
-  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
 }
+
+// Note: it is not possible to write tests for `navigationBarHidden = NO;` because this throws an
+// assertion.
 
 @end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
@@ -18,6 +18,7 @@
 
 @interface AppBarNavigationControllerNavigationBarHiddenTests : XCTestCase
 @property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 @end
 
 @implementation AppBarNavigationControllerNavigationBarHiddenTests
@@ -28,6 +29,7 @@
   self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
   self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = NO;
   [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
+  self.appBarViewController = [self.appBarNavigationController appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
 }
 
 - (void)tearDown {
@@ -39,6 +41,7 @@
 - (void)testDefaultIsHidden {
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
 }
 
 - (void)testStillHiddenAfterSettingNavigationBarHidden {
@@ -47,6 +50,7 @@
 
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
 }
 
 - (void)testStillHiddenAfterSettingNavigationBarHiddenAnimated {
@@ -55,6 +59,7 @@
 
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
 }
 
 // Note: it is not possible to write tests for `navigationBarHidden = NO;` because this throws an

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenTests.m
@@ -1,0 +1,33 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialAppBar.h"
+
+@interface AppBarNavigationControllerNavigationBarHiddenTests : XCTestCase
+@end
+
+@implementation AppBarNavigationControllerNavigationBarHiddenTests
+
+- (void)testDefaultIsHidden {
+  // Given
+  MDCAppBarNavigationController *appBarNavigationController =
+      [[MDCAppBarNavigationController alloc] init];
+
+  // Then
+  XCTAssertTrue(appBarNavigationController.navigationBarHidden);
+}
+
+@end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
@@ -16,7 +16,8 @@
 
 #import "MaterialAppBar.h"
 
-@interface AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests : XCTestCase
+@interface AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests
+    : XCTestCase
 @property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
 @property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 @end
@@ -29,7 +30,8 @@
   self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
   self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = YES;
   [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
-  self.appBarViewController = [self.appBarNavigationController appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
+  self.appBarViewController = [self.appBarNavigationController
+      appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
 }
 
 - (void)tearDown {
@@ -50,7 +52,8 @@
 
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
-  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), -self.appBarViewController.headerView.maximumHeight, 0.001);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame),
+                             -self.appBarViewController.headerView.maximumHeight, 0.001);
 }
 
 - (void)testBecomesHiddenAfterSettingNavigationBarHiddenAnimated {

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
@@ -18,6 +18,7 @@
 
 @interface AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests : XCTestCase
 @property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 @end
 
 @implementation AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests
@@ -28,6 +29,7 @@
   self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
   self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = YES;
   [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
+  self.appBarViewController = [self.appBarNavigationController appBarViewControllerForViewController:self.appBarNavigationController.visibleViewController];
 }
 
 - (void)tearDown {
@@ -39,6 +41,7 @@
 - (void)testDefaultIsVisible {
   // Then
   XCTAssertFalse(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
 }
 
 - (void)testBecomesHiddenAfterSettingNavigationBarHidden {
@@ -47,6 +50,7 @@
 
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), -self.appBarViewController.headerView.maximumHeight, 0.001);
 }
 
 - (void)testBecomesHiddenAfterSettingNavigationBarHiddenAnimated {
@@ -55,6 +59,17 @@
 
   // Then
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
+}
+
+- (void)testBecomesVisibleAfterTogglingTheVisibility {
+  // When
+  self.appBarNavigationController.navigationBarHidden = YES;
+  self.appBarNavigationController.navigationBarHidden = NO;
+
+  // Then
+  XCTAssertFalse(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.appBarViewController.headerView.frame), 0, 0.001);
 }
 
 @end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
@@ -1,0 +1,53 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialAppBar.h"
+
+@interface AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests : XCTestCase
+@property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
+@end
+
+@implementation AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
+  self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = YES;
+}
+
+- (void)testDefaultIsHidden {
+  // Then
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+}
+
+- (void)testStillHiddenAfterSettingNavigationBarHidden {
+  // When
+  self.appBarNavigationController.navigationBarHidden = YES;
+
+  // Then
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+}
+
+- (void)testStillHiddenAfterSettingNavigationBarHiddenAnimated {
+  // When
+  [self.appBarNavigationController setNavigationBarHidden:YES animated:YES];
+
+  // Then
+  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+}
+
+@end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerNavigationBarHiddenWhenNavigationBarHiddenHidesAppBarTests.m
@@ -27,14 +27,21 @@
 
   self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
   self.appBarNavigationController.shouldSetNavigationBarHiddenHideAppBar = YES;
+  [self.appBarNavigationController pushViewController:[[UIViewController alloc] init] animated:NO];
 }
 
-- (void)testDefaultIsHidden {
+- (void)tearDown {
+  self.appBarNavigationController = nil;
+
+  [super tearDown];
+}
+
+- (void)testDefaultIsVisible {
   // Then
-  XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
+  XCTAssertFalse(self.appBarNavigationController.navigationBarHidden);
 }
 
-- (void)testStillHiddenAfterSettingNavigationBarHidden {
+- (void)testBecomesHiddenAfterSettingNavigationBarHidden {
   // When
   self.appBarNavigationController.navigationBarHidden = YES;
 
@@ -42,7 +49,7 @@
   XCTAssertTrue(self.appBarNavigationController.navigationBarHidden);
 }
 
-- (void)testStillHiddenAfterSettingNavigationBarHiddenAnimated {
+- (void)testBecomesHiddenAfterSettingNavigationBarHiddenAnimated {
   // When
   [self.appBarNavigationController setNavigationBarHidden:YES animated:YES];
 


### PR DESCRIPTION
This new flag allows view controllers to control the visibility of their app bar via the standard UINavigationController setNavigationBarHidden: APIs. When enabled, calls to these APIs will result in the AppBar's visibility being adjusted.

Closes https://github.com/material-components/material-components-ios/issues/5185