### PR TITLE
[TextControls] Add Outlined theming extension

### DIFF
--- a/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
+++ b/components/TextControls/examples/MDCTextControlTextFieldTypicalUseExample.m
@@ -148,6 +148,7 @@ static CGFloat const kDefaultPadding = 15.0;
   [super viewWillLayoutSubviews];
 
   [self.filledTextField applyThemeWithScheme:self.containerScheme];
+  [self.outlinedTextField applyThemeWithScheme:self.containerScheme];
   [self usePreferredFonts];
 
   [self.resignFirstResponderButton sizeToFit];

--- a/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.h
+++ b/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCOutlinedTextField.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCOutlinedTextField instances with an MDCContainerScheme.
+ */
+@interface MDCOutlinedTextField (MaterialTheming)
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver in a manner best suited to
+ convey an error state.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
@@ -14,9 +14,17 @@
 
 #import "MDCOutlinedTextField+MaterialTheming.h"
 
-#import <Foundation/Foundation.h>
-
 static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kOutlineColorNormalOpacity = (CGFloat)0.38;
+
+static const CGFloat kTextColorNormalErrorOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalErrorOpacity = (CGFloat)0.60;
 
 @implementation MDCOutlinedTextField (MaterialTheming)
 
@@ -37,30 +45,32 @@ static const CGFloat kDisabledOpacity = (CGFloat)0.60;
 }
 
 - (void)applyDefaultColorScheme:(id<MDCColorScheming>)colorScheme {
-  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
   UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kAssistiveLabelColorNormalOpacity];
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
   UIColor *assistiveLabelColorDisabled =
       [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFloatingLabelColorNormalOpacity];
   UIColor *floatingLabelColorEditing =
-      [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
+      [colorScheme.primaryColor colorWithAlphaComponent:kFloatingLabelColorEditingOpacity];
   UIColor *floatingLabelColorDisabled =
       [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
   UIColor *normalLabelColorDisabled =
       [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
-  UIColor *outlineColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38];
+  UIColor *outlineColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlineColorNormalOpacity];
   UIColor *outlineColorEditing = colorScheme.primaryColor;
   UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
@@ -93,14 +103,15 @@ static const CGFloat kDisabledOpacity = (CGFloat)0.60;
 }
 
 - (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
-  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalErrorOpacity];
   UIColor *textColorEditing = textColorNormal;
   UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
   UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal = colorScheme.errorColor;
   UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
@@ -108,7 +119,7 @@ static const CGFloat kDisabledOpacity = (CGFloat)0.60;
       [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalErrorOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
   UIColor *normalLabelColorDisabled =
       [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];

--- a/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
@@ -1,0 +1,148 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextField+MaterialTheming.h"
+
+#import <Foundation/Foundation.h>
+
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+@implementation MDCOutlinedTextField (MaterialTheming)
+
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyDefaultColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyErrorColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyTypographyScheme:(id<MDCTypographyScheming>)mdcTypographyScheming {
+  self.font = mdcTypographyScheming.subtitle1;
+  self.leadingAssistiveLabel.font = mdcTypographyScheming.caption;
+  self.trailingAssistiveLabel.font = mdcTypographyScheming.caption;
+}
+
+- (void)applyDefaultColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *floatingLabelColorEditing =
+      [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled =
+      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *outlineColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38];
+  UIColor *outlineColorEditing = colorScheme.primaryColor;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *tintColor = colorScheme.primaryColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [self setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [self setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+  self.tintColor = tintColor;
+}
+
+- (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+
+  UIColor *floatingLabelColorNormal = colorScheme.errorColor;
+  UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled =
+      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *outlineColorNormal = colorScheme.errorColor;
+  UIColor *outlineColorEditing = outlineColorNormal;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *tintColor = colorScheme.errorColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [self setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [self setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+  self.tintColor = tintColor;
+}
+
+@end

--- a/components/TextControls/src/Theming/MaterialTextControls+Theming.h
+++ b/components/TextControls/src/Theming/MaterialTextControls+Theming.h
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 #import "MDCFilledTextField+MaterialTheming.h"
+#import "MDCOutlinedTextField+MaterialTheming.h"

--- a/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
@@ -18,19 +18,19 @@
 #import "MaterialTextControls+Theming.h"
 #import "MaterialTextControls.h"
 
-@interface MDCFilledTextFieldThemingTest : XCTestCase
-@property(nonatomic, strong) MDCFilledTextField *textField;
+@interface MDCOutlinedTextFieldThemingTest : XCTestCase
+@property(nonatomic, strong) MDCOutlinedTextField *textField;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
 @property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
 @property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
-@implementation MDCFilledTextFieldThemingTest
+@implementation MDCOutlinedTextFieldThemingTest
 
 - (void)setUp {
   [super setUp];
 
-  self.textField = [[MDCFilledTextField alloc] init];
+  self.textField = [[MDCOutlinedTextField alloc] init];
   self.colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
   self.typographyScheme =
@@ -160,16 +160,10 @@
   UIColor *normalLabelColorDisabled =
       [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
 
-  UIColor *underlineColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.42];
-  UIColor *underlineColorEditing = self.colorScheme.primaryColor;
-  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:disabledOpacity];
-
-  UIColor *filledSublayerFillColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
-  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *outlineColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38];
+  UIColor *outlineColorEditing = self.colorScheme.primaryColor;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:disabledOpacity];
 
   UIColor *tintColor = self.colorScheme.primaryColor;
 
@@ -209,18 +203,12 @@
   XCTAssertEqualObjects(
       [self.textField trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
       assistiveLabelColorDisabled);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateNormal],
-                        underlineColorNormal);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateEditing],
-                        underlineColorEditing);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateDisabled],
-                        underlineColorDisabled);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateNormal],
-                        filledSublayerFillColorNormal);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateEditing],
-                        filledSublayerFillColorEditing);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateDisabled],
-                        filledSublayerFillColorDisabled);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateNormal],
+                        outlineColorNormal);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateEditing],
+                        outlineColorEditing);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateDisabled],
+                        outlineColorDisabled);
   XCTAssertEqualObjects(self.textField.tintColor, tintColor);
 
   // Typography
@@ -254,15 +242,9 @@
   UIColor *normalLabelColorDisabled =
       [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
 
-  UIColor *underlineColorNormal = self.colorScheme.errorColor;
-  UIColor *underlineColorEditing = underlineColorNormal;
-  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:disabledOpacity];
-
-  UIColor *filledSublayerFillColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
-  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *outlineColorNormal = self.colorScheme.errorColor;
+  UIColor *outlineColorEditing = outlineColorNormal;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:disabledOpacity];
 
   UIColor *tintColor = self.colorScheme.errorColor;
 
@@ -302,18 +284,12 @@
   XCTAssertEqualObjects(
       [self.textField trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
       assistiveLabelColorDisabled);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateNormal],
-                        underlineColorNormal);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateEditing],
-                        underlineColorEditing);
-  XCTAssertEqualObjects([self.textField underlineColorForState:MDCTextControlStateDisabled],
-                        underlineColorDisabled);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateNormal],
-                        filledSublayerFillColorNormal);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateEditing],
-                        filledSublayerFillColorEditing);
-  XCTAssertEqualObjects([self.textField filledBackgroundColorForState:MDCTextControlStateDisabled],
-                        filledSublayerFillColorDisabled);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateNormal],
+                        outlineColorNormal);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateEditing],
+                        outlineColorEditing);
+  XCTAssertEqualObjects([self.textField outlineColorForState:MDCTextControlStateDisabled],
+                        outlineColorDisabled);
   XCTAssertEqualObjects(self.textField.tintColor, tintColor);
 
   // Typography


### PR DESCRIPTION
This PR adds the theming extension for MDCOutlinedTextField.

Here's a screenshot:

<img width="370" alt="Screen Shot 2019-11-20 at 12 09 06 PM" src="https://user-images.githubusercontent.com/8020010/69260871-91f16780-0b8e-11ea-8e65-b6b8a373cf89.png">

Closes #8682.
