### PR TITLE
[ActionSheet] Name unit tests to match class.

### DIFF
--- a/components/ActionSheet/tests/unit/MDCActionSheetControllerTests.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetControllerTests.m
@@ -31,7 +31,7 @@ static const CGFloat kDefaultDividerOpacity = (CGFloat)0.12;
 @property(nonatomic, strong) UILabel *messageLabel;
 @end
 
-@interface MDCActionSheetTest : XCTestCase
+@interface MDCActionSheetControllerTests : XCTestCase
 @property(nonatomic, strong) MDCActionSheetController *actionSheet;
 @end
 
@@ -46,7 +46,7 @@ static const CGFloat kDefaultDividerOpacity = (CGFloat)0.12;
 
 @end
 
-@implementation MDCActionSheetTest
+@implementation MDCActionSheetControllerTests
 
 - (void)setUp {
   [super setUp];


### PR DESCRIPTION
MDCActionSheetController's unit tests were not easily discoverable because the
names did not match the expected pattern for Xcode.

Clean-up for #8709