### PR TITLE
[BottomSheet] Add API to not allow dragging of Bottom Sheet to dismiss.

### DIFF
--- a/components/BottomSheet/README.md
+++ b/components/BottomSheet/README.md
@@ -107,7 +107,6 @@ _button = [[UIButton alloc] initWithFrame:CGRectZero];
 ```
 <!--</div>-->
 
-
 ### Behavioral Customizations
 
 You can also choose to have your bottom sheet not be dismissable when dragged downards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.

--- a/components/BottomSheet/README.md
+++ b/components/BottomSheet/README.md
@@ -109,7 +109,7 @@ _button = [[UIButton alloc] initWithFrame:CGRectZero];
 
 ### Behavioral Customizations
 
-You can also choose to have your bottom sheet not be dismissable when dragged downards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
+You can also choose to have your bottom sheet not be dismissable when dragged downwards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/BottomSheet/README.md
+++ b/components/BottomSheet/README.md
@@ -107,6 +107,34 @@ _button = [[UIButton alloc] initWithFrame:CGRectZero];
 ```
 <!--</div>-->
 
+
+### Behavioral Customizations
+
+You can also choose to have your bottom sheet not be dismissable when dragged downards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let viewController: ViewController = ViewController()
+let bottomSheet: MDCBottomSheetController = MDCBottomSheetController(contentViewController: viewController)
+
+bottomSheet.dismissOnDraggingDownSheet = false
+
+present(bottomSheet, animated: true, completion: nil)
+```
+
+#### Objective-C
+```objc
+ViewController *viewController = [[ViewController alloc] init];
+MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+
+bottomSheet.dismissOnDraggingDownSheet = NO;
+
+[self presentViewController:bottomSheet animated:true completion:nil];
+```
+<!--</div>-->
+
+
 ## Extensions
 
 <!-- Extracted from docs/shape-theming.md -->

--- a/components/BottomSheet/docs/README.md
+++ b/components/BottomSheet/docs/README.md
@@ -95,6 +95,32 @@ _button = [[UIButton alloc] initWithFrame:CGRectZero];
 ```
 <!--</div>-->
 
+### Behavioral Customizations
+
+You can also choose to have your bottom sheet not be dismissable when dragged downards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+let viewController: ViewController = ViewController()
+let bottomSheet: MDCBottomSheetController = MDCBottomSheetController(contentViewController: viewController)
+
+bottomSheet.dismissOnDraggingDownSheet = false
+
+present(bottomSheet, animated: true, completion: nil)
+```
+
+#### Objective-C
+```objc
+ViewController *viewController = [[ViewController alloc] init];
+MDCBottomSheetController *bottomSheet = [[MDCBottomSheetController alloc] initWithContentViewController:viewController];
+
+bottomSheet.dismissOnDraggingDownSheet = NO;
+
+[self presentViewController:bottomSheet animated:true completion:nil];
+```
+<!--</div>-->
+
 ## Extensions
 
 - [Shape Theming](shape-theming.md)

--- a/components/BottomSheet/docs/README.md
+++ b/components/BottomSheet/docs/README.md
@@ -97,7 +97,7 @@ _button = [[UIButton alloc] initWithFrame:CGRectZero];
 
 ### Behavioral Customizations
 
-You can also choose to have your bottom sheet not be dismissable when dragged downards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
+You can also choose to have your bottom sheet not be dismissable when dragged downwards by using the dismissOnDraggingDownSheet property on MDCBottomSheetController.
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -61,6 +61,13 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.
+
+ Defaults to @c YES.
+ */
+@property(nonatomic, assign) BOOL dismissOnDraggingDownSheet;
+
+/**
  The color applied to the sheet's background when presented by MDCBottomSheetPresentationController.
 
  Defaults to a semi-transparent Black.

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -43,6 +43,7 @@
     _contentViewController = contentViewController;
     _transitionController = [[MDCBottomSheetTransitionController alloc] init];
     _transitionController.dismissOnBackgroundTap = YES;
+    _transitionController.dismissOnDraggingDownSheet = YES;
     super.transitioningDelegate = _transitionController;
     super.modalPresentationStyle = UIModalPresentationCustom;
     _shapeGenerators = [NSMutableDictionary dictionary];
@@ -77,6 +78,8 @@
 
   self.mdc_bottomSheetPresentationController.dismissOnBackgroundTap =
       _transitionController.dismissOnBackgroundTap;
+  self.mdc_bottomSheetPresentationController.dismissOnDraggingDownSheet =
+      _transitionController.dismissOnDraggingDownSheet;
 
   [self.contentViewController.view layoutIfNeeded];
 }
@@ -144,6 +147,15 @@
 - (void)setDismissOnBackgroundTap:(BOOL)dismissOnBackgroundTap {
   _transitionController.dismissOnBackgroundTap = dismissOnBackgroundTap;
   self.mdc_bottomSheetPresentationController.dismissOnBackgroundTap = dismissOnBackgroundTap;
+}
+
+- (BOOL)dismissOnDraggingDownSheet {
+  return _transitionController.dismissOnDraggingDownSheet;
+}
+
+- (void)setDismissOnDraggingDownSheet:(BOOL)dismissOnDraggingDownSheet {
+  _transitionController.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
+  self.mdc_bottomSheetPresentationController.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
 }
 
 - (void)bottomSheetWillChangeState:(MDCBottomSheetPresentationController *)bottomSheet

--- a/components/BottomSheet/src/MDCBottomSheetController.m
+++ b/components/BottomSheet/src/MDCBottomSheetController.m
@@ -155,7 +155,8 @@
 
 - (void)setDismissOnDraggingDownSheet:(BOOL)dismissOnDraggingDownSheet {
   _transitionController.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
-  self.mdc_bottomSheetPresentationController.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
+  self.mdc_bottomSheetPresentationController.dismissOnDraggingDownSheet =
+      dismissOnDraggingDownSheet;
 }
 
 - (void)bottomSheetWillChangeState:(MDCBottomSheetPresentationController *)bottomSheet

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -83,6 +83,8 @@
 
 /**
  When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.
+
+ Defaults to @c YES.
  */
 @property(nonatomic, assign) BOOL dismissOnDraggingDownSheet;
 

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -82,6 +82,11 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.
+ */
+@property(nonatomic, assign) BOOL dismissOnDraggingDownSheet;
+
+/**
  This is used to set a custom height on the sheet view.
 
  @note If a positive value is passed then the sheet view will be that height even if

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -104,6 +104,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.accessibilityLabel = _scrimAccessibilityLabel;
   _dimmingView.accessibilityHint = _scrimAccessibilityHint;
 
+  _dismissOnDraggingDownSheet = YES;
+
   UIScrollView *scrollView = self.trackingScrollView;
   if (scrollView == nil) {
     scrollView = MDCBottomSheetGetPrimaryScrollView(self.presentedViewController);

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -114,6 +114,7 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
                                                      scrollView:scrollView];
   self.sheetView.delegate = self;
   self.sheetView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+  self.sheetView.dismissOnDraggingDownSheet = self.dismissOnDraggingDownSheet;
 
   [containerView addSubview:_dimmingView];
   [containerView addSubview:self.sheetView];
@@ -282,6 +283,13 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
   if (self.traitCollectionDidChangeBlock) {
     self.traitCollectionDidChangeBlock(self, previousTraitCollection);
+  }
+}
+
+- (void)setDismissOnDraggingDownSheet:(BOOL)dismissOnDraggingDownSheet {
+  _dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
+  if (self.sheetView) {
+    self.sheetView.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
   }
 }
 

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -46,6 +46,11 @@
 @property(nonatomic, assign) BOOL dismissOnBackgroundTap;
 
 /**
+ When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.
+ */
+@property(nonatomic, assign) BOOL dismissOnDraggingDownSheet;
+
+/**
  This is used to set a custom height on the sheet view. This is can be used to set the initial
  height when the ViewController is presented.
 

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.m
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.m
@@ -50,6 +50,7 @@ static const NSTimeInterval MDCBottomSheetTransitionDuration = 0.25;
                                                            presentingViewController:presenting];
   presentationController.trackingScrollView = self.trackingScrollView;
   presentationController.dismissOnBackgroundTap = self.dismissOnBackgroundTap;
+  presentationController.dismissOnDraggingDownSheet = self.dismissOnDraggingDownSheet;
   presentationController.scrimColor = _scrimColor;
   presentationController.scrimAccessibilityTraits = _scrimAccessibilityTraits;
   presentationController.isScrimAccessibilityElement = _isScrimAccessibilityElement;

--- a/components/BottomSheet/src/private/MDCSheetContainerView.h
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.h
@@ -23,6 +23,11 @@
 @property(nonatomic, readonly) MDCSheetState sheetState;
 @property(nonatomic) CGFloat preferredSheetHeight;
 
+/**
+ When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.
+ */
+@property(nonatomic, assign) BOOL dismissOnDraggingDownSheet;
+
 - (nonnull instancetype)initWithFrame:(CGRect)frame
                           contentView:(nonnull UIView *)contentView
                            scrollView:(nullable UIScrollView *)scrollView NS_DESIGNATED_INITIALIZER;

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -343,6 +343,10 @@ static const CGFloat kSheetBounceBuffer = 150;
     shouldBeginDraggingWithVelocity:(CGPoint)velocity {
   [self updateSheetState];
 
+  if (!self.dismissOnDraggingDownSheet) {
+    return NO;
+  }
+
   switch (self.sheetState) {
     case MDCSheetStatePreferred:
       return YES;

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -192,9 +192,9 @@
   // Then
   XCTAssertNotNil(self.bottomSheet.presentationController);
   XCTAssertTrue([self.bottomSheet.presentationController
-                 isKindOfClass:[MDCBottomSheetPresentationController class]]);
-  XCTAssertFalse(((MDCBottomSheetPresentationController *)
-                  self.bottomSheet.presentationController).dismissOnDraggingDownSheet);
+      isKindOfClass:[MDCBottomSheetPresentationController class]]);
+  XCTAssertFalse(((MDCBottomSheetPresentationController *)self.bottomSheet.presentationController)
+                     .dismissOnDraggingDownSheet);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/BottomSheetTests.m
+++ b/components/BottomSheet/tests/unit/BottomSheetTests.m
@@ -41,6 +41,7 @@
   // Then
   XCTAssertFalse(self.bottomSheet.shouldFlashScrollIndicatorsOnAppearance);
   XCTAssertEqualWithAccuracy(self.bottomSheet.elevation, MDCShadowElevationModalBottomSheet, 0.001);
+  XCTAssertTrue(self.bottomSheet.dismissOnDraggingDownSheet);
 }
 
 - (void)testSetShowScrollIndicatorsResultsInCorrectValue {
@@ -180,6 +181,20 @@
 
   // Then
   XCTAssertFalse(blockCalled);
+}
+
+#pragma mark - dismissOnDraggingDownSheet
+
+- (void)testSettingDismissOnDraggingDownSheetOnBottomSheetController {
+  // Given
+  self.bottomSheet.dismissOnDraggingDownSheet = NO;
+
+  // Then
+  XCTAssertNotNil(self.bottomSheet.presentationController);
+  XCTAssertTrue([self.bottomSheet.presentationController
+                 isKindOfClass:[MDCBottomSheetPresentationController class]]);
+  XCTAssertFalse(((MDCBottomSheetPresentationController *)
+                  self.bottomSheet.presentationController).dismissOnDraggingDownSheet);
 }
 
 @end

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -346,7 +346,7 @@
 
   // When
   BOOL shouldBeginDragging = [self.sheetView draggableView:self.sheetView.sheet
-      shouldBeginDraggingWithVelocity:CGPointMake(0, 0)];
+                           shouldBeginDraggingWithVelocity:CGPointMake(0, 0)];
 
   // Then
   XCTAssertFalse(shouldBeginDragging);

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -58,6 +58,7 @@
 @property(nonatomic) MDCSheetState sheetState;
 - (CGPoint)targetPoint;
 - (void)draggableView:(MDCDraggableView *)view didPanToOffset:(CGFloat)offset;
+- (BOOL)draggableView:(MDCDraggableView *)view shouldBeginDraggingWithVelocity:(CGPoint)velocity;
 @end
 
 /**
@@ -87,13 +88,13 @@
 }
 @end
 
-@interface MDCBottomSheetPresentationControllerPreferredSheetHeightTests : XCTestCase
+@interface MDCBottomSheetPresentationControllerTests : XCTestCase
 @property(nonatomic, strong) FakeSheetView *sheetView;
 @property(nonatomic, strong) MDCBottomSheetPresentationController *presentationController;
 @property(nonatomic, strong, nullable) MDCBottomSheetDelegateTest *delegateTest;
 @end
 
-@implementation MDCBottomSheetPresentationControllerPreferredSheetHeightTests
+@implementation MDCBottomSheetPresentationControllerTests
 
 - (void)setUp {
   [super setUp];
@@ -327,6 +328,28 @@
 
   // Then
   XCTAssertEqual(self.delegateTest.delegateWasCalled, YES);
+}
+
+#pragma mark - dismissOnDraggingDownSheet
+
+- (void)testSettingDismissOnDraggingDownSheetOnPresentationController {
+  // Given
+  self.presentationController.dismissOnDraggingDownSheet = NO;
+
+  // Then
+  XCTAssertFalse(self.sheetView.dismissOnDraggingDownSheet);
+}
+
+- (void)testSettingDismissOnDraggingDownSheetViewBlocksGesture {
+  // Given
+  self.sheetView.dismissOnDraggingDownSheet = NO;
+
+  // When
+  BOOL shouldBeginDragging = [self.sheetView draggableView:self.sheetView.sheet
+      shouldBeginDraggingWithVelocity:CGPointMake(0, 0)];
+
+  // Then
+  XCTAssertFalse(shouldBeginDragging);
 }
 
 @end


### PR DESCRIPTION
BottomSheet at its default behavior allows clients to drag the bottom sheet downwards to dismiss it, and also allow it to be dismissed by tapping the scrim background when it is presented.

While there is an API to customize the behavior of tapping the scrim to not allow dismissal using dismissOnBackgroundTap. There is no way to customize the dragging behavior to not dismiss.

Therefore in this PR I have introduced a dismissOnDraggingDownSheet that does exactly that. It does so by returning NO in the gestureRecognizerShouldBegin if the MDCDraggableView if dismissOnDraggingDownSheet is set to NO.

Unit tests and documentation has been added along with the new API.

Closes https://github.com/material-components/material-components-ios/issues/8457