### PR TITLE
Revert "[FeatureHighlight] Add a voiceover dismissal affordance for the feature highlight. (#8959)"

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -57,6 +57,8 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
 
     _displayedView.accessibilityTraits = UIAccessibilityTraitButton;
 
+    _viewAccessiblityHint = [[self class] dismissAccessibilityHint];
+
     super.transitioningDelegate = self;
     super.modalPresentationStyle = UIModalPresentationCustom;
   }
@@ -348,6 +350,14 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
 
 - (NSString *)accessibilityHint {
   return _viewAccessiblityHint;
+}
+
++ (NSString *)dismissAccessibilityHint {
+  NSString *key =
+      kMaterialFeatureHighlightStringTable[kStr_MaterialFeatureHighlightDismissAccessibilityHint];
+  NSString *localizedString = NSLocalizedStringFromTableInBundle(
+      key, kMaterialFeatureHighlightStringsTableName, [self bundle], @"Double-tap to dismiss.");
+  return localizedString;
 }
 
 #pragma mark - Private

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -75,7 +75,6 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   MDCFeatureHighlightLayer *_pulseLayer;
   MDCFeatureHighlightLayer *_innerLayer;
   MDCFeatureHighlightLayer *_displayMaskLayer;
-  UIView *_accessibilityView;
 
   BOOL _mdc_adjustsFontForContentSizeCategory;
 
@@ -108,15 +107,6 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 
     _displayMaskLayer = [[MDCFeatureHighlightLayer alloc] init];
     _displayMaskLayer.fillColor = [UIColor whiteColor].CGColor;
-
-    _accessibilityView = [[UIView alloc] initWithFrame:self.bounds];
-    _accessibilityView.autoresizingMask =
-        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _accessibilityView.isAccessibilityElement = YES;
-    _accessibilityView.accessibilityTraits = UIAccessibilityTraitButton;
-    _accessibilityView.accessibilityLabel = @"Dismiss";
-    [self addSubview:_accessibilityView];
-    [self sendSubviewToBack:_accessibilityView];
 
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _titleLabel.textAlignment = NSTextAlignmentNatural;
@@ -318,13 +308,6 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _displayedView = displayedView;
   [self addSubview:_displayedView];
   _displayedView.layer.mask = _displayMaskLayer;
-}
-
-- (NSArray *)accessibilityElements {
-  if (_displayedView) {
-    return @[ _titleLabel, _bodyLabel, _displayedView, _accessibilityView ];
-  }
-  return @[ _titleLabel, _bodyLabel, _accessibilityView ];
 }
 
 - (void)setHighlightPoint:(CGPoint)highlightPoint {
@@ -717,11 +700,11 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
 #pragma mark - UIAccessibility
 
 - (void)setAccessibilityHint:(NSString *)accessibilityHint {
-  _accessibilityView.accessibilityHint = accessibilityHint;
+  _titleLabel.accessibilityHint = accessibilityHint;
 }
 
 - (NSString *)accessibilityHint {
-  return _accessibilityView.accessibilityHint;
+  return _titleLabel.accessibilityHint;
 }
 
 @end


### PR DESCRIPTION
This reverts commit 4c7402857c173db101f846409ad716fac8ada4a3, which broke tests.

```
Test Suite 'Selected tests' started at 2019-11-21 18:34:10.629
Test Suite 'MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest' started at 2019-11-21 18:34:10.630
Test Suite 'FeatureHighlightAccessibilityTests' started at 2019-11-21 18:34:10.630
Test Case '-[FeatureHighlightAccessibilityTests testAccessibilityHintDefaultAfterLoadingView]' started.
/Users/featherless/workbench/material-components-ios/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m:45: error: -[FeatureHighlightAccessibilityTests testAccessibilityHintDefaultAfterLoadingView] : ((controller.accessibilityHint) != nil) failed
/Users/featherless/workbench/material-components-ios/components/FeatureHighlight/tests/unit/FeatureHighlightAccessibilityTests.m:46: error: -[FeatureHighlightAccessibilityTests testAccessibilityHintDefaultAfterLoadingView] : ((controller.view.accessibilityHint) != nil) failed
Test Case '-[FeatureHighlightAccessibilityTests testAccessibilityHintDefaultAfterLoadingView]' failed (0.044 seconds).
Test Case '-[FeatureHighlightAccessibilityTests testSetAccessibilityHint]' started.
Test Case '-[FeatureHighlightAccessibilityTests testSetAccessibilityHint]' passed (0.001 seconds).
Test Case '-[FeatureHighlightAccessibilityTests testSetAccessibilityHintNil]' started.
Test Case '-[FeatureHighlightAccessibilityTests testSetAccessibilityHintNil]' passed (0.001 seconds).
Test Suite 'FeatureHighlightAccessibilityTests' failed at 2019-11-21 18:34:10.677.
	 Executed 3 tests, with 2 failures (0 unexpected) in 0.046 (0.047) seconds
Test Suite 'MaterialComponents-Unit-FeatureHighlight-UnitTests.xctest' failed at 2019-11-21 18:34:10.677.
	 Executed 3 tests, with 2 failures (0 unexpected) in 0.046 (0.048) seconds
Test Suite 'Selected tests' failed at 2019-11-21 18:34:10.678.
	 Executed 3 tests, with 2 failures (0 unexpected) in 0.046 (0.049) seconds
Program ended with exit code: 1
```