### PR TITLE
[FlexibleHeader] Add FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.

### DIFF
--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
@@ -19,8 +19,8 @@
 // Validates the behavior of isShiftedOffscreen and flexible header shifting when shiftBehavior
 // is MDCFlexibleHeaderShiftBehaviorDisabled.
 @interface FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests : XCTestCase
-@property (nonatomic, strong) MDCFlexibleHeaderView *fhvc;
-@property (nonatomic, strong) UIScrollView *scrollView;
+@property(nonatomic, strong) MDCFlexibleHeaderView *fhvc;
+@property(nonatomic, strong) UIScrollView *scrollView;
 @end
 
 @implementation FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests
@@ -85,7 +85,9 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  XCTAssertTrue(self.fhvc.isShiftedOffscreen); // TODO( https://github.com/material-components/material-components-ios/issues/9022 ): This should be false.
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);  // TODO(
+                                                // https://github.com/material-components/material-components-ios/issues/9022
+                                                // ): This should be false.
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }
 
@@ -105,7 +107,9 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  XCTAssertTrue(self.fhvc.isShiftedOffscreen); // TODO( https://github.com/material-components/material-components-ios/issues/9022 ): This should be false.
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);  // TODO(
+                                                // https://github.com/material-components/material-components-ios/issues/9022
+                                                // ): This should be false.
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
@@ -1,0 +1,114 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialFlexibleHeader.h"
+
+// Validates the behavior of isShiftedOffscreen and flexible header shifting when shiftBehavior
+// is MDCFlexibleHeaderShiftBehaviorDisabled.
+@interface FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests : XCTestCase
+@property (nonatomic, strong) MDCFlexibleHeaderView *fhvc;
+@property (nonatomic, strong) UIScrollView *scrollView;
+@end
+
+@implementation FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.fhvc = [[MDCFlexibleHeaderView alloc] init];
+  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
+  self.scrollView = [[UIScrollView alloc] init];
+  self.scrollView.frame = CGRectMake(0, 0, 100, 100);
+  self.scrollView.contentSize = CGSizeMake(100, 1000);
+  self.fhvc.trackingScrollView = self.scrollView;
+  [self.fhvc trackingScrollViewDidScroll];
+}
+
+- (void)tearDown {
+  self.fhvc = nil;
+  self.scrollView = nil;
+
+  [super tearDown];
+}
+
+- (void)testDefaultIsNotShifted {
+  // Then
+  XCTAssertFalse(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
+}
+
+- (void)testCanBeShiftedOffScreen {
+  // When
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+- (void)testStaysShiftedOffScreenWhenScrolledUpByHeaderHeight {
+  // Given
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+- (void)testShiftsBackOnScreenWhenDragged {
+  // Given
+  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  // Scroll up to match shifted amount.
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+  // Scroll down to pull header back on-screen.
+  self.scrollView.contentOffset = CGPointMake(0, 0);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen); // TODO( https://github.com/material-components/material-components-ios/issues/9022 ): This should be false.
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
+}
+
+- (void)testDoesNotShiftBackOffScreenWhenDragged {
+  // Given
+  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  // Scroll up to match shifted amount.
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+  // Scroll down to pull header back on-screen.
+  self.scrollView.contentOffset = CGPointMake(0, 0);
+  [self.fhvc trackingScrollViewDidScroll];
+  // Scroll up to attempt to shift the header again.
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen); // TODO( https://github.com/material-components/material-components-ios/issues/9022 ): This should be false.
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
+}
+
+@end

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
@@ -74,7 +74,6 @@
 
 - (void)testShiftsBackOnScreenWhenDragged {
   // Given
-  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
   [self.fhvc shiftHeaderOffScreenAnimated:NO];
 
   // When
@@ -92,7 +91,6 @@
 
 - (void)testDoesNotShiftBackOffScreenWhenDragged {
   // Given
-  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
   [self.fhvc shiftHeaderOffScreenAnimated:NO];
 
   // When

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
@@ -85,9 +85,8 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  XCTAssertTrue(self.fhvc.isShiftedOffscreen);  // TODO(
-                                                // https://github.com/material-components/material-components-ios/issues/9022
-                                                // ): This should be false.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should be false.
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }
 
@@ -107,9 +106,8 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  XCTAssertTrue(self.fhvc.isShiftedOffscreen);  // TODO(
-                                                // https://github.com/material-components/material-components-ios/issues/9022
-                                                // ): This should be false.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should be false.
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }
 

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorDisabledTests.m
@@ -85,7 +85,8 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should be false.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should
+  // be false.
   XCTAssertTrue(self.fhvc.isShiftedOffscreen);
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }
@@ -106,7 +107,8 @@
   [self.fhvc trackingScrollViewDidScroll];
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should be false.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should
+  // be false.
   XCTAssertTrue(self.fhvc.isShiftedOffscreen);
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
 }


### PR DESCRIPTION
These tests validate the behavior of the flexible header when the shift behavior is disabled.

Notably, these tests reveal a bug in the implementation of isShiftedOffscreen which can occur with the following repro steps:

1. Set the flexible header's shift behavior to disabled and that it has a tracking scroll view with a content size greater than its bounds by at least the height of the header (in order to allow the scroll view to be dragged).
2. Hide the flexible header with shiftHeaderOffScreenAnimated:
3. Drag the flexible header's tracking scroll view up and then down, revealing the flexible header.
4. Inspect the state of isShiftedOffscreen.

Expected value: false
Actual value: true

This is due to the fact that shiftHeaderOffScreenAnimated: sets an internal bit that indicates that the flexible header *wants* to be hidden, and this bit is not reset once the user starts interacting with the flexible header. The likely fix is to clear the "wants to be hidden" flag when the user starts interacting with the flexible header again. I've filed https://github.com/material-components/material-components-ios/issues/9022 to track this bug.

Discovered as part of https://github.com/material-components/material-components-ios/issues/5185
