### PR TITLE
[FlexibleHeader] Add MDCFlexibleHeaderShiftBehaviorHideable.

### DIFF
--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -29,6 +29,7 @@ UIScrollViewDelegate events.
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Classes/MDCFlexibleHeaderView.html">MDCFlexibleHeaderView</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Classes/MDCFlexibleHeaderViewController.html">MDCFlexibleHeaderViewController</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderSafeAreaDelegate.html">MDCFlexibleHeaderSafeAreaDelegate</a></li>
+  <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderViewAnimationDelegate.html">MDCFlexibleHeaderViewAnimationDelegate</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderViewDelegate.html">MDCFlexibleHeaderViewDelegate</a></li>
   <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Protocols/MDCFlexibleHeaderViewLayoutDelegate.html">MDCFlexibleHeaderViewLayoutDelegate</a></li>
   <li class="icon-list-item icon-list-item--link">Enumeration: <a href="https://material.io/components/ios/catalog/flexible-headers/api-docs/Enums.html">Enumerations</a></li>
@@ -441,6 +442,40 @@ override func childViewControllerForStatusBarHidden() -> UIViewController? {
 #### Objective-C
 ```objc
 headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return _headerViewController;
+}
+```
+<!--</div>-->
+
+If you would like to be able to show and hide your flexible header similar to how UINavigationBar
+allows the navigation bar to be shown and hidden, you can use the `hideable` shift behavior. This
+behavior will allow you to toggle visibility of the header using the `shiftHeaderOffScreenAnimated:`
+and `shiftHeaderOnScreenAnimated:` APIs only; the user will not be able to drag the header either on
+or off-screen.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+headerViewController.headerView.shiftBehavior = .hideable
+
+// You can now toggle visibility of the header view using the following invocations:
+headerViewController.headerView.shiftHeaderOffScreen(animated: true)
+headerViewController.headerView.shiftHeaderOnScreen(animated: true)
+
+override func childViewControllerForStatusBarHidden() -> UIViewController? {
+  return headerViewController
+}
+```
+
+#### Objective-C
+```objc
+headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorHideable;
+
+// You can now toggle visibility of the header view using the following invocations:
+[headerViewController.headerView shiftHeaderOffScreenAnimated:YES];
+[headerViewController.headerView shiftHeaderOnScreenAnimated:YES];
 
 - (UIViewController *)childViewControllerForStatusBarHidden {
   return _headerViewController;

--- a/components/FlexibleHeader/docs/shift-behavior.md
+++ b/components/FlexibleHeader/docs/shift-behavior.md
@@ -44,3 +44,37 @@ headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEn
 }
 ```
 <!--</div>-->
+
+If you would like to be able to show and hide your flexible header similar to how UINavigationBar
+allows the navigation bar to be shown and hidden, you can use the `hideable` shift behavior. This
+behavior will allow you to toggle visibility of the header using the `shiftHeaderOffScreenAnimated:`
+and `shiftHeaderOnScreenAnimated:` APIs only; the user will not be able to drag the header either on
+or off-screen.
+
+<!--<div class="material-code-render" markdown="1">-->
+#### Swift
+```swift
+headerViewController.headerView.shiftBehavior = .hideable
+
+// You can now toggle visibility of the header view using the following invocations:
+headerViewController.headerView.shiftHeaderOffScreen(animated: true)
+headerViewController.headerView.shiftHeaderOnScreen(animated: true)
+
+override func childViewControllerForStatusBarHidden() -> UIViewController? {
+  return headerViewController
+}
+```
+
+#### Objective-C
+```objc
+headerViewController.headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorHideable;
+
+// You can now toggle visibility of the header view using the following invocations:
+[headerViewController.headerView shiftHeaderOffScreenAnimated:YES];
+[headerViewController.headerView shiftHeaderOnScreenAnimated:YES];
+
+- (UIViewController *)childViewControllerForStatusBarHidden {
+  return _headerViewController;
+}
+```
+<!--</div>-->

--- a/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
+++ b/components/FlexibleHeader/examples/FlexibleHeaderConfiguratorExample.m
@@ -27,6 +27,7 @@ typedef enum : NSUInteger {
   FlexibleHeaderConfiguratorFieldContentImportance,
   FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled,
   FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar,
+  FlexibleHeaderConfiguratorFieldShiftBehaviorHideable,
   FlexibleHeaderConfiguratorFieldShiftOffscreen,
   FlexibleHeaderConfiguratorFieldShiftOnscreen,
 
@@ -102,6 +103,8 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
                           animated:YES];
       } else {
         headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabled;
+        [self didChangeValueForField:FlexibleHeaderConfiguratorFieldShiftBehaviorHideable
+                            animated:YES];
       }
       break;
     }
@@ -114,6 +117,23 @@ static const UITableViewStyle kStyle = UITableViewStyleGrouped;
         headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar;
         [self didChangeValueForField:FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled
                             animated:YES];
+        [self didChangeValueForField:FlexibleHeaderConfiguratorFieldShiftBehaviorHideable
+                            animated:YES];
+      }
+      break;
+    }
+
+    case FlexibleHeaderConfiguratorFieldShiftBehaviorHideable: {
+      BOOL isOn = [value boolValue];
+      if (!isOn) {
+        headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorDisabled;
+      } else {
+        headerView.shiftBehavior = MDCFlexibleHeaderShiftBehaviorHideable;
+        [self didChangeValueForField:FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled
+                            animated:YES];
+        [self
+            didChangeValueForField:FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar
+                          animated:YES];
       }
       break;
     }
@@ -234,6 +254,12 @@ static const CGFloat kHeightScalar = 300;
     case FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar: {
       MDCFlexibleHeaderShiftBehavior behavior = self.fhvc.headerView.shiftBehavior;
       BOOL enabled = (behavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar);
+      return @(enabled);
+    }
+
+    case FlexibleHeaderConfiguratorFieldShiftBehaviorHideable: {
+      MDCFlexibleHeaderShiftBehavior behavior = self.fhvc.headerView.shiftBehavior;
+      BOOL enabled = (behavior == MDCFlexibleHeaderShiftBehaviorHideable);
       return @(enabled);
     }
 
@@ -388,6 +414,7 @@ static const CGFloat kHeightScalar = 300;
     switchItem(@"Enabled", FlexibleHeaderConfiguratorFieldShiftBehaviorEnabled),
     switchItem(@"Enabled with status bar",
                FlexibleHeaderConfiguratorFieldShiftBehaviorEnabledWithStatusBar),
+    switchItem(@"Hideable", FlexibleHeaderConfiguratorFieldShiftBehaviorHideable),
     switchItem(@"Header content is important", FlexibleHeaderConfiguratorFieldContentImportance),
     buttonItem(@"Shift header off-screen", FlexibleHeaderConfiguratorFieldShiftOffscreen),
     buttonItem(@"Shift header on-screen", FlexibleHeaderConfiguratorFieldShiftOnscreen)

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView+ShiftBehavior.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView+ShiftBehavior.h
@@ -38,6 +38,16 @@ typedef NS_ENUM(NSInteger, MDCFlexibleHeaderShiftBehavior) {
    MDCFlexibleHeaderShiftBehaviorEnabled.
    */
   MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar,
+
+  /**
+   Allows the header to be shifted on- and off-screen only via the @c shiftHeaderOnScreenAnimated:
+   and @c shiftHeaderOffScreenAnimated APIs. Scroll events will not affect the visibility of the
+   header.
+
+   Analogous to UINavigationController's setNavigationBarHidden: behavior, in that the visibility of
+   the navigation bar persists regardless of the user's subsequent interactions.
+   */
+  MDCFlexibleHeaderShiftBehaviorHideable,
 };
 
 /** The importance of content contained within the flexible header view. */

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -521,7 +521,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 
 - (BOOL)flexibleHeaderSafeAreaIsStatusBarShifted:(MDCFlexibleHeaderTopSafeArea *)safeAreas {
   return ([self fhv_canShiftOffscreen] &&
-          _shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar &&
+          (_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar ||
+           _shiftBehavior == MDCFlexibleHeaderShiftBehaviorHideable) &&
           _statusBarShifter.prefersStatusBarHidden);
 }
 
@@ -746,9 +747,11 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 - (BOOL)fhv_canShiftOffscreen {
-  return ((_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabled ||
-           _shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar) &&
-          !_trackingScrollView.pagingEnabled);
+  BOOL interactable = ((_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabled ||
+                        _shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar) &&
+                       !_trackingScrollView.pagingEnabled);
+  BOOL hideable = _shiftBehavior == MDCFlexibleHeaderShiftBehaviorHideable;
+  return interactable || hideable;
 }
 
 - (BOOL)fhv_isPartiallyShifted {
@@ -1049,7 +1052,12 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
     [self fhv_stopDisplayLink];
   }
 
-  if (_shiftAccumulatorLastContentOffsetIsValid) {
+  // When the shift behavior is MDCFlexibleHeaderShiftBehaviorHideable, we explicitly disable
+  // interactive shifting behaviors so that the header's visibility is controlled only via direct
+  // invocations to -shiftHeaderOnScreenAnimated: and shiftHeaderOffScreenAnimated:
+  BOOL allowsInteractiveShift = _shiftBehavior != MDCFlexibleHeaderShiftBehaviorHideable;
+
+  if (_shiftAccumulatorLastContentOffsetIsValid && allowsInteractiveShift) {
     // We track the last direction for our target offset behavior.
     CGFloat deltaY = [self fhv_boundedContentOffset].y - _shiftAccumulatorLastContentOffset.y;
 
@@ -1338,9 +1346,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
 }
 
 - (void)setObservesTrackingScrollViewScrollEvents:(BOOL)observesTrackingScrollViewScrollEvents {
-  NSAssert(self.shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled ||
-               !observesTrackingScrollViewScrollEvents,
-           @"Please set shiftBehavior to disabled prior to enabling this property.");
+  NSAssert(!observesTrackingScrollViewScrollEvents ||
+               (self.shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled ||
+                self.shiftBehavior == MDCFlexibleHeaderShiftBehaviorHideable),
+           @"Please set shiftBehavior to disabled or hideable prior to enabling this property.");
 
   if (_observesTrackingScrollViewScrollEvents == observesTrackingScrollViewScrollEvents) {
     return;
@@ -1674,7 +1683,8 @@ static BOOL isRunningiOS10_3OrAbove() {
 }
 
 - (BOOL)hidesStatusBarWhenCollapsed {
-  return (_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar &&
+  return ((_shiftBehavior == MDCFlexibleHeaderShiftBehaviorEnabledWithStatusBar ||
+           _shiftBehavior == MDCFlexibleHeaderShiftBehaviorHideable) &&
           !_trackingScrollView.pagingEnabled);
 }
 
@@ -1691,7 +1701,8 @@ static BOOL isRunningiOS10_3OrAbove() {
 
 - (void)setShiftBehavior:(MDCFlexibleHeaderShiftBehavior)shiftBehavior {
   NSAssert((self.observesTrackingScrollViewScrollEvents &&
-            shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled) ||
+            (shiftBehavior == MDCFlexibleHeaderShiftBehaviorDisabled ||
+             shiftBehavior == MDCFlexibleHeaderShiftBehaviorHideable)) ||
                !self.observesTrackingScrollViewScrollEvents,
            @"Flexible Header shift behavior must be disabled before content offset observation is"
            @" enabled.");

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests.m
@@ -1,0 +1,96 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialFlexibleHeader.h"
+
+// Validates the behavior of isShiftedOffscreen and flexible header shifting when shiftBehavior
+// is MDCFlexibleHeaderShiftBehaviorHideable. In particular, it demonstrates that calling
+// shiftHeaderOffScreenAnimated: causes the header to be permanently shifted off-screen; i.e. the
+// user cannot drag the header back on-screen.
+@interface FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests : XCTestCase
+@property(nonatomic, strong) MDCFlexibleHeaderView *fhvc;
+@property(nonatomic, strong) UIScrollView *scrollView;
+@end
+
+@implementation FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.fhvc = [[MDCFlexibleHeaderView alloc] init];
+  self.fhvc.shiftBehavior = MDCFlexibleHeaderShiftBehaviorHideable;
+  self.scrollView = [[UIScrollView alloc] init];
+  self.scrollView.frame = CGRectMake(0, 0, 100, 100);
+  self.scrollView.contentSize = CGSizeMake(100, 1000);
+  self.fhvc.trackingScrollView = self.scrollView;
+  [self.fhvc trackingScrollViewDidScroll];
+}
+
+- (void)tearDown {
+  self.fhvc = nil;
+  self.scrollView = nil;
+
+  [super tearDown];
+}
+
+- (void)testDefaultIsNotShifted {
+  // Then
+  XCTAssertFalse(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), 0, 0.001);
+}
+
+- (void)testCanBeShiftedOffScreen {
+  // When
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+- (void)testStaysShiftedOffScreenWhenScrolledUpByHeaderHeight {
+  // Given
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+- (void)testDoesNotShiftBackOnScreenWhenDragged {
+  // Given
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  // Scroll up to match shifted amount.
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+  // Scroll down to pull header back on-screen.
+  self.scrollView.contentOffset = CGPointMake(0, 0);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  // TODO(https://github.com/material-components/material-components-ios/issues/9022): This should
+  // be false.
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+@end


### PR DESCRIPTION
This new shift behavior mode enables the flexible header to mimic the behavior of UINavigationController's setNavigationBarHidden:. When the shift behavior is set to this new value, the flexible header can be hidden or shown using the shiftHeaderOnScreenAnimated: and shiftHeaderOffScreenAnimated: APIs, but user interactions will not affect the header's visibility.

Added an example to the configurator to demonstrate the behavior.

Part of https://github.com/material-components/material-components-ios/issues/5185