### PR TITLE
[AppBar] Rename test cases to match component conventions.

### DIFF
--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.m
@@ -16,13 +16,13 @@
 
 #import "MaterialAppBar.h"
 
-@interface MDCAppBarNavigationControllerTests : XCTestCase
+@interface AppBarNavigationControllerTests : XCTestCase
 
 @property(nonatomic, strong) MDCAppBarNavigationController *navigationController;
 
 @end
 
-@implementation MDCAppBarNavigationControllerTests
+@implementation AppBarNavigationControllerTests
 
 - (void)setUp {
   [super setUp];

--- a/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerTests.swift
@@ -25,7 +25,7 @@ private class MockAppBarNavigationControllerDelegate:
   }
 }
 
-class MDCAppBarNavigationControllerTests: XCTestCase {
+class AppBarNavigationControllerTests: XCTestCase {
 
   var navigationController: MDCAppBarNavigationController!
   override func setUp() {

--- a/components/AppBar/tests/unit/AppBarViewControllerTests.m
+++ b/components/AppBar/tests/unit/AppBarViewControllerTests.m
@@ -16,11 +16,11 @@
 
 #import "MDCAppBarViewController.h"
 
-@interface MDCAppBarViewControllerTests : XCTestCase
+@interface AppBarViewControllerTests : XCTestCase
 
 @end
 
-@implementation MDCAppBarViewControllerTests
+@implementation AppBarViewControllerTests
 
 - (void)testTraitCollectionDidChangeBlockCalledWhenTraitCollectionChanges {
   // Given


### PR DESCRIPTION
Dropping the MDC prefix to match the majority of the other test cases.

Part of https://github.com/material-components/material-components-ios/issues/5185