### PR TITLE
[Chips] Mark MDCChipViewColorThemer and MDCChipViewShapeThemer as deprecated

### DIFF
--- a/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
+++ b/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
@@ -28,7 +28,7 @@
 
 @end
 
-@interface MDCChipViewColorThemer (ToBeDeprecated)
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewColorThemer (ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCChipView.

--- a/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
+++ b/components/Chips/src/ColorThemer/MDCChipViewColorThemer.h
@@ -20,15 +20,11 @@
 /**
  The Material Design color system's themer for instances of MDCChipView.
 
- @warning This API will eventually be deprecated. See the individual method documentation for
+ @warning This API will eventually be deleted. See the individual method documentation for
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCChipViewColorThemer : NSObject
-
-@end
-
-__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewColorThemer (ToBeDeprecated)
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCChipView.

--- a/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
+++ b/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
@@ -26,7 +26,7 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewShapeThemer: NSObject
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewShapeThemer : NSObject
 
 /**
  Applies a shape scheme's properties to an MDCChipView.

--- a/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
+++ b/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
@@ -29,7 +29,7 @@
 @interface MDCChipViewShapeThemer : NSObject
 @end
 
-@interface MDCChipViewShapeThemer (ToBeDeprecated)
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewShapeThemer
 
 /**
  Applies a shape scheme's properties to an MDCChipView.

--- a/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
+++ b/components/Chips/src/ShapeThemer/MDCChipViewShapeThemer.h
@@ -22,14 +22,11 @@
 /**
  The Material Design shape system's themer for instances of MDCChipView.
 
- @warning This API will eventually be deprecated. See the individual method documentation for
+ @warning This API will eventually be deleted. See the individual method documentation for
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCChipViewShapeThemer : NSObject
-@end
-
-__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewShapeThemer
+__deprecated_msg("Use Chips+Theming instead.") @interface MDCChipViewShapeThemer: NSObject
 
 /**
  Applies a shape scheme's properties to an MDCChipView.


### PR DESCRIPTION
Moves MDCChipViewColorThemer and MDCChipViewShapeThemer from a to-be-deprecated state to a deprecated state. 

Prework for #9027 