### PR TITLE
[Banner] Fix top layout constraint in Autolayout example on pre iOS 11 OSes.

### DIFF
--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -69,10 +69,11 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
   [self.view addSubview:bannerView];
   NSLayoutConstraint *bannerViewConstraintTop;
   if (@available(iOS 11.0, *)) {
-    bannerViewConstraintTop = [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
+    bannerViewConstraintTop =
+        [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
   } else {
     bannerViewConstraintTop =
-    [bannerView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor];
+        [bannerView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor];
   }
   bannerViewConstraintTop.active = YES;
   NSLayoutConstraint *bannerViewConstraintLeft =

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -68,7 +68,7 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
          forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:bannerView];
   NSLayoutConstraint *bannerViewConstraintTop =
-      [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
+      [bannerView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor];
   bannerViewConstraintTop.active = YES;
   NSLayoutConstraint *bannerViewConstraintLeft =
       [bannerView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor];

--- a/components/Banner/examples/BannerAutolayoutExampleViewController.m
+++ b/components/Banner/examples/BannerAutolayoutExampleViewController.m
@@ -67,8 +67,13 @@ static NSString *const exampleText = @"Lorem ipsum dolor";
                    action:@selector(didTapDismissOnBannerView)
          forControlEvents:UIControlEventTouchUpInside];
   [self.view addSubview:bannerView];
-  NSLayoutConstraint *bannerViewConstraintTop =
-      [bannerView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor];
+  NSLayoutConstraint *bannerViewConstraintTop;
+  if (@available(iOS 11.0, *)) {
+    bannerViewConstraintTop = [bannerView.topAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.topAnchor];
+  } else {
+    bannerViewConstraintTop =
+    [bannerView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor];
+  }
   bannerViewConstraintTop.active = YES;
   NSLayoutConstraint *bannerViewConstraintLeft =
       [bannerView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor];


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/8824.

Previously, the banner under autolayout constraints relied on `layoutMarginsGuide` which takes `addtionSafeAreaInsets` from flexibleHeader for iOS 11+. This fix switches it back to using `topLayoutGuide` to make it compatible with iOS 7+ when iOS11 is not avaliable.

| Screenshot on iPhone7 10.2 after the fix |
| --- |
| ![Simulator Screen Shot - iPhone 7 - 2019-12-02 at 16 06 01](https://user-images.githubusercontent.com/8836258/69995422-08db1880-151e-11ea-8ee9-23e580cccd79.png) |

