### PR TITLE
[Buttons] Deprecate MDCOutlinedButtonColorThemer

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
@@ -25,7 +25,8 @@
 @interface MDCOutlinedButtonColorThemer : NSObject
 @end
 
-@interface MDCOutlinedButtonColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCButton applyOutlinedThemeWithScheme:] instead. (Note: Color theming is no longer available as an independent API.")
+    @interface MDCOutlinedButtonColorThemer(ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCButton using the outlined button style.

--- a/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
@@ -22,7 +22,8 @@
  `MDCButton`'s `-applyOutlinedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-__deprecated_msg("Please use [MDCButton applyOutlinedThemeWithScheme:] instead. (Note: Color theming is no longer available as an independent API.")
+__deprecated_msg("Please use [MDCButton applyOutlinedThemeWithScheme:] instead. (Note: Color "
+                 "theming is no longer available as an independent API.")
     @interface MDCOutlinedButtonColorThemer : NSObject
 
 /**

--- a/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCOutlinedButtonColorThemer.h
@@ -22,11 +22,8 @@
  `MDCButton`'s `-applyOutlinedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCOutlinedButtonColorThemer : NSObject
-@end
-
 __deprecated_msg("Please use [MDCButton applyOutlinedThemeWithScheme:] instead. (Note: Color theming is no longer available as an independent API.")
-    @interface MDCOutlinedButtonColorThemer(ToBeDeprecated)
+    @interface MDCOutlinedButtonColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCButton using the outlined button style.


### PR DESCRIPTION
## Description

Deprecate symbol MDCOutlinedButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145205092