### PR TITLE
[Buttons] Deprecating MDCTextButtonColorThemer

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.h
@@ -27,7 +27,8 @@
 @interface MDCTextButtonColorThemer : NSObject
 @end
 
-@interface MDCTextButtonColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCButton applyTextThemeWithScheme:] instead. (Note: Color theming is no longer available as an independent API.)")
+    @interface MDCTextButtonColorThemer(ToBeDeprecated)
 
 /**
  Applies a color scheme's properties to an MDCButton using the text button style.

--- a/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCTextButtonColorThemer.h
@@ -24,11 +24,9 @@
  `MDCButton`'s `-applyTextThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCTextButtonColorThemer : NSObject
-@end
-
-__deprecated_msg("Please use [MDCButton applyTextThemeWithScheme:] instead. (Note: Color theming is no longer available as an independent API.)")
-    @interface MDCTextButtonColorThemer(ToBeDeprecated)
+__deprecated_msg("Please use [MDCButton applyTextThemeWithScheme:] instead. (Note: Color theming "
+                 "is no longer available as an independent API.)")
+    @interface MDCTextButtonColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCButton using the text button style.

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -128,7 +128,18 @@
 }
 
 - (void)applyTextThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCTextButtonColorThemer applySemanticColorScheme:colorScheme toButton:self];
+  [self resetUIControlStatesForButtonTheming];
+
+  [self setBackgroundColor:UIColor.clearColor forState:UIControlStateNormal];
+  [self setBackgroundColor:UIColor.clearColor forState:UIControlStateDisabled];
+  [self setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [self setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
+               forState:UIControlStateDisabled];
+  [self setImageTintColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [self setImageTintColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
+                   forState:UIControlStateDisabled];
+  self.disabledAlpha = 1;
+  self.inkColor = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.16];
 }
 
 - (void)applyTextThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
@@ -162,6 +173,15 @@
     [self setTitleColor:nil forState:state];
     [self setImageTintColor:nil forState:state];
     [self setBorderColor:nil forState:state];
+  }
+}
+
+- (void)resetUIControlStatesForButtonTheming {
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+  UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBackgroundColor:nil forState:state];
+    [self setTitleColor:nil forState:state];
   }
 }
 

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -134,10 +134,10 @@
   [self setBackgroundColor:UIColor.clearColor forState:UIControlStateDisabled];
   [self setTitleColor:colorScheme.primaryColor forState:UIControlStateNormal];
   [self setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
-               forState:UIControlStateDisabled];
+             forState:UIControlStateDisabled];
   [self setImageTintColor:colorScheme.primaryColor forState:UIControlStateNormal];
   [self setImageTintColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
-                   forState:UIControlStateDisabled];
+                 forState:UIControlStateDisabled];
   self.disabledAlpha = 1;
   self.inkColor = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.16];
 }
@@ -178,7 +178,7 @@
 
 - (void)resetUIControlStatesForButtonTheming {
   NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
-  UIControlStateHighlighted | UIControlStateDisabled;
+                                 UIControlStateHighlighted | UIControlStateDisabled;
   for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
     [self setBackgroundColor:nil forState:state];
     [self setTitleColor:nil forState:state];


### PR DESCRIPTION
## Description

Deprecate symbol MDCTextButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145204496 -  Delete symbol "MDCTextButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:"
