### PR TITLE
[Buttons] Deprecating MDCFloatingButtonColorThemer

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCFloatingButtonColorThemer.h
@@ -24,10 +24,9 @@
  `MDCFloatingButton`'s `-applySecondaryThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCFloatingButtonColorThemer : NSObject
-@end
-
-@interface MDCFloatingButtonColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCFloatingButton applySecondaryThemeWithScheme:] instead. (Note: "
+                 "Color theming is no longer available as an independent API.)")
+    @interface MDCFloatingButtonColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCFloatingButton using the floating button style.

--- a/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCFloatingButton+MaterialTheming.m
@@ -14,7 +14,6 @@
 
 #import "MDCFloatingButton+MaterialTheming.h"
 
-#import <MaterialComponents/MaterialButtons+ColorThemer.h>
 #import <MaterialComponents/MaterialButtons+ShapeThemer.h>
 
 @implementation MDCFloatingButton (MaterialTheming)
@@ -45,8 +44,13 @@
   [self setElevation:MDCShadowElevationNone forState:UIControlStateDisabled];
 }
 
-- (void)applySecondaryThemeWithColorScheme:(id<MDCColorScheming>)scheme {
-  [MDCFloatingButtonColorThemer applySemanticColorScheme:scheme toButton:self];
+- (void)applySecondaryThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  [self resetUIControlStatesForButtonTheming];
+  [self setBackgroundColor:colorScheme.secondaryColor forState:UIControlStateNormal];
+  [self setTitleColor:colorScheme.onSecondaryColor forState:UIControlStateNormal];
+  [self setImageTintColor:colorScheme.onSecondaryColor forState:UIControlStateNormal];
+
+  self.disabledAlpha = 1;
 }
 
 - (void)applySecondaryThemeWithShapeScheme:(id<MDCShapeScheming>)scheme {
@@ -60,6 +64,19 @@
     [self setTitleFont:nil forState:state];
   }
   [self setTitleFont:scheme.button forState:UIControlStateNormal];
+}
+
++ (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
+                        toButton:(nonnull MDCFloatingButton *)button {
+}
+
+- (void)resetUIControlStatesForButtonTheming {
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBackgroundColor:nil forState:state];
+    [self setTitleColor:nil forState:state];
+  }
 }
 
 @end


### PR DESCRIPTION
## Description

Deprecate symbol MDCFloatingButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145204873 Delete symbol "MDCFloatingButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:"
