### PR TITLE
[Buttons] Deprecating MDCContainedButtonColorThemer

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCContainedButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCContainedButtonColorThemer.h
@@ -24,10 +24,9 @@
  `MDCButton`'s `-applyContainedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCContainedButtonColorThemer : NSObject
-@end
-
-@interface MDCContainedButtonColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCButton applyContainedThemeWithScheme:] instead. (Note: Color "
+                 "theming is no longer available as an independent API.)")
+    @interface MDCContainedButtonColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCButton using the contained button style.

--- a/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
+++ b/components/Buttons/src/Theming/MDCButton+MaterialTheming.m
@@ -40,7 +40,19 @@
 }
 
 - (void)applyContainedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCContainedButtonColorThemer applySemanticColorScheme:colorScheme toButton:self];
+  [self resetButtonColorsForAllStates];
+
+  [self setBackgroundColor:colorScheme.primaryColor forState:UIControlStateNormal];
+  [self setBackgroundColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12]
+                  forState:UIControlStateDisabled];
+  [self setTitleColor:colorScheme.onPrimaryColor forState:UIControlStateNormal];
+  [self setTitleColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
+             forState:UIControlStateDisabled];
+  [self setImageTintColor:colorScheme.onPrimaryColor forState:UIControlStateNormal];
+  [self setImageTintColor:[colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38]
+                 forState:UIControlStateDisabled];
+  self.disabledAlpha = 1;
+  self.inkColor = [colorScheme.onPrimaryColor colorWithAlphaComponent:(CGFloat)0.32];
 }
 
 - (void)applyContainedThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {


### PR DESCRIPTION
## Description

Deprecate symbol MDCContainedButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145204991 Delete symbol "MDCContainedButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:"
