### PR TITLE
[Snackbar] Delete snackbarMessageViewTextColor

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.h
+++ b/components/Snackbar/src/MDCSnackbarMessageView.h
@@ -136,13 +136,3 @@
      UITraitCollection *_Nullable previousTraitCollection);
 
 @end
-
-// clang-format off
-@interface MDCSnackbarMessageView ()
-
-/** @see messsageTextColor */
-@property(nonatomic, strong, nullable) UIColor *snackbarMessageViewTextColor UI_APPEARANCE_SELECTOR
-__deprecated_msg("Use messsageTextColor instead.");
-
-@end
-// clang-format on

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -475,14 +475,6 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
   self.layer.shadowColor = snackbarMessageViewShadowColor.CGColor;
 }
 
-- (void)setSnackbarMessageViewTextColor:(UIColor *)snackbarMessageViewTextColor {
-  self.messageTextColor = snackbarMessageViewTextColor;
-}
-
-- (UIColor *)snackbarMessageViewTextColor {
-  return self.messageTextColor;
-}
-
 - (void)setMessageTextColor:(UIColor *)messageTextColor {
   _messageTextColor = messageTextColor;
   if (_messageTextColor) {


### PR DESCRIPTION
This PR deletes `snackbarMessageViewTextColor` on MDCSnackbarMessageView.
Associated CL: [cl/283777183](http://cl/283777183)
Related to #9064.
Related to #9057.
Related to #9060.