### PR TITLE
[Banner] Add unit test to test background color change when user interface changes.

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -260,6 +260,8 @@ Pod::Spec.new do |mdc|
       "components/#{extension.base_name.split('+')[0]}/tests/unit/#{extension.base_name.split('+')[1]}/*.{h,m,swift}"
       ]
       unit_tests.dependency "MaterialComponents/schemes/Container"
+      unit_tests.dependency "MaterialComponents/private/Color"
+      unit_tests.dependency "MaterialComponents/private/Math"
     end
   end
 

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -85,6 +85,8 @@ mdc_unit_test_objc_library(
         ":Banner",
         ":Theming",
         "//components/Buttons",
+        "//components/private/Color",
+        "//components/private/Math",
         "//components/Typography",
     ],
 )

--- a/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
+++ b/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
@@ -242,7 +242,8 @@ This class is used for creating a @UIWindow with customized size category.
   }
 }
 
-// TODO(https://github.com/material-components/material-components-ios/issues/8532): Replace the usage of this method with generic macro when available.
+// TODO(https://github.com/material-components/material-components-ios/issues/8532): Replace the
+// usage of this method with generic macro when available.
 - (BOOL)compareColorsWithFloatPrecisionFirstColor:(UIColor *)firstColor
                                       secondColor:(UIColor *)secondColor {
   CGFloat fRed = 0.0, fGreen = 0.0, fBlue = 0.0, fAlpha = 0.0;

--- a/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
+++ b/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
@@ -209,6 +209,7 @@ This class is used for creating a @UIWindow with customized size category.
 }
 
 - (void)testBannerViewBackgroundColorChangeWhenUIUserInterfaceStyleChangeOnIOS13 {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     // Given
     UIColor *darkSurfaceColor = UIColor.blackColor;
@@ -229,6 +230,7 @@ This class is used for creating a @UIWindow with customized size category.
     XCTAssertTrue([self compareColorsWithFloatPrecisionFirstColor:self.bannerView.backgroundColor
                                                       secondColor:darkSurfaceColor]);
   }
+#endif
 }
 
 - (void)assertTraitCollectionAndElevationBlockForBannerView:(MDCBannerView *)bannerView

--- a/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
+++ b/components/Banner/tests/unit/Theming/MDCBannerViewThemingTests.m
@@ -208,7 +208,7 @@ This class is used for creating a @UIWindow with customized size category.
   }
 }
 
-- (void)testBannerViewBackgroundColorChangeWhenUIUserInterfaceStyleChangeOnIOS13 {
+- (void)testBannerViewBackgroundColorChangeWhenUIUserInterfaceStyleChangesOnIOS13 {
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     // Given


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/9058.

This test ensure not only the block exists when setting it (originally supported behavior), it adds the test to test the real behavior of what should happen to the background color of banner when user interface changes.