### PR TITLE
[TextFields] Mark MDCTextFieldColorThemer as deprecated

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.h
+++ b/components/TextFields/src/ColorThemer/MDCTextFieldColorThemer.h
@@ -19,15 +19,9 @@
 
 /**
  The Material Design color system's text field themer.
-
- @warning This API will eventually be deprecated. See the individual method documentation for
- details on replacement APIs.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCTextFieldColorThemer : NSObject
-@end
-
-@interface MDCTextFieldColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use the MaterialTextFields+Theming instead.")
+    @interface MDCTextFieldColorThemer : NSObject
 
 /**
  Applies a color scheme to theme MDCTextField in MDCTextInputController.


### PR DESCRIPTION
The internal issues this addresses are:
b/145204538
b/145204499
b/145204498
b/145205091

GitHub issues do not seem to have been created for these, but I will add them to this PR once they're created.