### PR TITLE
[Ink] Delete deprecated MDCInkTouchControllerLegacyDelegate

### DIFF
--- a/components/Ink/src/MDCInkTouchController.m
+++ b/components/Ink/src/MDCInkTouchController.m
@@ -26,20 +26,6 @@ static const NSTimeInterval kInkTouchDelayInterval = 0.1;
 @property(nonatomic, assign) CGPoint previousLocation;
 @end
 
-@protocol MDCInkTouchControllerLegacyDelegate <NSObject>
-@optional
-
-/**
- This protocol is private and declares an old method signature that will be removed once legacy code
- has been migrated to the new delegate protocol.
- */
-- (BOOL)shouldInkTouchControllerProcessInkTouches:
-    (nonnull MDCInkTouchController *)inkTouchController
-    __deprecated_msg("shouldInkTouchControllerProcessInkTouches has been replaced with "
-                     "inkTouchController:shouldProcessInkTouchesAtTouchLocation.");
-
-@end
-
 @implementation MDCInkTouchController
 
 - (CGFloat)dragCancelDistance {
@@ -211,15 +197,6 @@ static const NSTimeInterval kInkTouchDelayInterval = 0.1;
                                         shouldProcessInkTouchesAtTouchLocation:)]) {
     CGPoint touchLocation = [gestureRecognizer locationInView:_view];
     return [_delegate inkTouchController:self shouldProcessInkTouchesAtTouchLocation:touchLocation];
-  } else if ([_delegate respondsToSelector:@selector(shouldInkTouchControllerProcessInkTouches:)]) {
-    // Please use inkTouchController:shouldProcessInkTouchesAtTouchLocation. The delegate call below
-    // is deprecated and only provided for legacy support.
-    id<MDCInkTouchControllerLegacyDelegate> legacyDelegate =
-        (id<MDCInkTouchControllerLegacyDelegate>)_delegate;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    return [legacyDelegate shouldInkTouchControllerProcessInkTouches:self];
-#pragma clang diagnostic pop
   }
   return YES;
 }


### PR DESCRIPTION
A github issue does not seem to have been created to mirror the internal issue, but the internal issue is b/145205049