### PR TITLE
[MDCFloatingButton] Deprecate MDCFloatingButtonShapeThemer

### DIFF
--- a/components/Buttons/src/ShapeThemer/MDCFloatingButtonShapeThemer.h
+++ b/components/Buttons/src/ShapeThemer/MDCFloatingButtonShapeThemer.h
@@ -25,10 +25,9 @@
  `MDCFloatingButton`'s Theming extensions.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCFloatingButtonShapeThemer : NSObject
-@end
-
-@interface MDCFloatingButtonShapeThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCFloatingButton applySecondaryThemeWithScheme:] instead. (Note: "
+                 "Shape theming is no longer available as an independent API.)")
+    @interface MDCFloatingButtonShapeThemer : NSObject
 
 /**
  Applies a rounded rectangular shape to an MDCFloatingButton instance. Each corner has a radius of


### PR DESCRIPTION
## Description

Deprecate symbol MDCFloatingButtonShapeThemer(ToBeDeprecated)::applyShapeScheme:toButton:

## Issue

b/145205206 Delete symbol "MDCFloatingButtonShapeThemer(ToBeDeprecated)::applyShapeScheme:toButton:"