### PR TITLE
[Tabs] Deprecate MDCTabBarColorThemer

### DIFF
--- a/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.h
+++ b/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.h
@@ -22,10 +22,9 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCTabBarColorThemer : NSObject
-@end
-
-@interface MDCTabBarColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use the Theming extension instead.") @interface MDCTabBarColorThemer
+    : NSObject
+;
 
 /**
  Applies a color scheme's properties to an MDCTabBar using the primary mapping.
@@ -40,7 +39,8 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-                          toTabs:(nonnull MDCTabBar *)tabBar;
+                          toTabs:(nonnull MDCTabBar *)tabBar
+    __deprecated_msg("Please use the Theming extension instead.");
 
 /**
  Applies a color scheme's properties to an MDCTabBar using the surface mapping.
@@ -55,7 +55,8 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-                                    toTabs:(nonnull MDCTabBar *)tabBar;
+                                    toTabs:(nonnull MDCTabBar *)tabBar
+    __deprecated_msg("Please use the Theming extension instead.");
 
 /**
  Applies a color scheme to theme a MDCTabBar.
@@ -68,6 +69,7 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-                toTabBar:(nonnull MDCTabBar *)tabBar;
+                toTabBar:(nonnull MDCTabBar *)tabBar
+    __deprecated_msg("Please use the Theming extension instead.");
 
 @end

--- a/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
+++ b/components/Tabs/src/ColorThemer/MDCTabBarColorThemer.m
@@ -18,7 +18,10 @@ static const CGFloat kUnselectedTitleOpacity = (CGFloat)0.6;
 static const CGFloat kUnselectedImageOpacity = (CGFloat)0.54;
 static const CGFloat kBottomDividerOpacity = (CGFloat)0.12;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCTabBarColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                           toTabs:(nonnull MDCTabBar *)tabBar {


### PR DESCRIPTION
This PR deprecates MDCTabBarColorThemer.
Associated CL removing internal usage: [cl/283807007](http://cl/283807007)
Related to #9061.
Related to #9063.
Related to #9062.
