### PR TITLE
[Buttons] Delete MDCButton cornerRadius

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -258,12 +258,6 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
   if (!self.layer.shapeGenerator) {
     self.layer.shadowPath = [self boundingPath].CGPath;
   }
-  if ([self respondsToSelector:@selector(cornerRadius)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    self.layer.cornerRadius = [self cornerRadius];
-#pragma clang diagnostic pop
-  }
 
   // Center unbounded ink view frame taking into account possible insets using contentRectForBounds.
   if (_inkView.inkStyle == MDCInkStyleUnbounded && _inkView.usesLegacyInkRipple) {
@@ -853,15 +847,7 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 }
 
 - (UIBezierPath *)boundingPath {
-  CGFloat cornerRadius = self.layer.cornerRadius;
-
-  if ([self respondsToSelector:@selector(cornerRadius)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    cornerRadius = [self cornerRadius];
-#pragma clang diagnostic pop
-  }
-  return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:cornerRadius];
+  return [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:self.layer.cornerRadius];
 }
 
 - (UIEdgeInsets)defaultContentEdgeInsets {

--- a/components/Buttons/src/private/MDCButton+Subclassing.h
+++ b/components/Buttons/src/private/MDCButton+Subclassing.h
@@ -37,12 +37,6 @@
 /** The bounding path of the button. The shadow will follow that path. */
 - (nonnull UIBezierPath *)boundingPath;
 
-/**
- Previously used to set the corner radius of the button. This has been deprecated and the layer's
- |cornerRadius| property should be set directly.
- */
-- (CGFloat)cornerRadius __deprecated_msg("Set layer.cornerRadius explicitly");
-
 /** The default content edge insets of the button. They are set at initialization time. */
 - (UIEdgeInsets)defaultContentEdgeInsets;
 


### PR DESCRIPTION
This property is deprecated and has no internal usage.

Fixes #9118 