### PR TITLE
[PageControl] deprecate-MDCPageControlColorThemer-applyColorScheme-toPageControl

### DIFF
--- a/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.h
+++ b/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.h
@@ -19,27 +19,22 @@
 
 /**
  Used to apply a color scheme to theme MDCPageControl.
-
- @warning This API will eventually be deprecated. See the individual method documentation for
- details on replacement APIs.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCPageControlColorThemer : NSObject
-@end
-
-@interface MDCPageControlColorThemer (ToBeDeprecated)
+__deprecated_msg("No replacement exists. Please comment on"
+                 " https://github.com/material-components/material-components-ios/issues/7172"
+                 " in order to indicate interest in a replacement API.")
+    @interface MDCPageControlColorThemer : NSObject
 
 /**
  Applies a color scheme to theme a MDCPageControl.
 
  @param colorScheme The color scheme to apply to the component instance.
  @param pageControl A component instance to which the color scheme should be applied.
-
- @warning This API will eventually be deprecated. There is no replacement yet.
- Track progress here: https://github.com/material-components/material-components-ios/issues/7172
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-           toPageControl:(nonnull MDCPageControl *)pageControl;
+           toPageControl:(nonnull MDCPageControl *)pageControl
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 @end

--- a/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.m
+++ b/components/PageControl/src/ColorThemer/MDCPageControlColorThemer.m
@@ -14,7 +14,10 @@
 
 #import "MDCPageControlColorThemer.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCPageControlColorThemer
+#pragma clang diagnostic pop
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme
            toPageControl:(MDCPageControl *)pageControl {


### PR DESCRIPTION
Related to https://github.com/material-components/material-components-ios/issues/9082