### PR TITLE
[Tabs] Don't use MDCTabBarColorThemer in examples

### DIFF
--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -109,7 +109,6 @@ mdc_examples_objc_library(
     name = "ObjcExamples",
     data = [":TabsExamplesAssets"],
     deps = [
-        ":ColorThemer",
         ":TabBarView",
         ":Tabs",
         ":Theming",
@@ -135,8 +134,8 @@ mdc_examples_objc_library(
 mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [
-        ":ColorThemer",
         ":Tabs",
+        ":Theming",
         "//components/AppBar",
         "//components/AppBar:ColorThemer",
         "//components/AppBar:TypographyThemer",

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -28,7 +28,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -39,7 +39,7 @@
   _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
   _bottomNavigationBar.translatesAutoresizingMaskIntoConstraints = NO;
   _bottomNavigationBar.delegate = self;
-  [_bottomNavigationBar applyPrimaryThemeWithScheme:_containerScheme];
+  [_bottomNavigationBar applyPrimaryThemeWithScheme:self.containerScheme];
 
   _bottomNavigationBar.inkColor = [UIColor colorWithRed:0
                                                   green:(CGFloat)0.5

--- a/components/Tabs/examples/BottomNavigationBarExample.m
+++ b/components/Tabs/examples/BottomNavigationBarExample.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MaterialColorScheme.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 
 @interface BottomNavigationBarExample : UIViewController <MDCTabBarDelegate>
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @implementation BottomNavigationBarExample {
@@ -28,8 +28,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -40,7 +39,7 @@
   _bottomNavigationBar = [[MDCTabBar alloc] initWithFrame:CGRectZero];
   _bottomNavigationBar.translatesAutoresizingMaskIntoConstraints = NO;
   _bottomNavigationBar.delegate = self;
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:_bottomNavigationBar];
+  [_bottomNavigationBar applyPrimaryThemeWithScheme:_containerScheme];
 
   _bottomNavigationBar.inkColor = [UIColor colorWithRed:0
                                                   green:(CGFloat)0.5

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -29,7 +29,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -15,12 +15,13 @@
 #import "supplemental/TabBarIconExampleSupplemental.h"
 
 #import "MaterialAppBar.h"
-#import "MaterialColorScheme.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 
 @interface TabBarIconExample ()
 @property(nonatomic, strong) UIBarButtonItem *addStarButtonItem;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @implementation TabBarIconExample
@@ -28,9 +29,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -92,7 +91,7 @@
   // Give the second item a badge
   [tabBar.items[1] setBadgeValue:@"1"];
 
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:tabBar];
+  [tabBar applyPrimaryThemeWithScheme:self.containerScheme];
 
   tabBar.inkColor = [[UIColor whiteColor] colorWithAlphaComponent:(CGFloat)0.1];
   tabBar.itemAppearance = MDCTabBarItemAppearanceTitledImages;

--- a/components/Tabs/examples/TabBarIconExample.swift
+++ b/components/Tabs/examples/TabBarIconExample.swift
@@ -19,7 +19,7 @@ import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialPalettes
 import MaterialComponents.MaterialTabs
-import MaterialComponents.MaterialTabs_ColorThemer
+import MaterialComponents.MaterialTabs_Theming
 import MaterialComponents.MaterialTypographyScheme
 
 class TabBarIconSwiftExample: UIViewController {
@@ -38,8 +38,7 @@ class TabBarIconSwiftExample: UIViewController {
   lazy var appBarViewController: MDCAppBarViewController = self.setupAppBar()
   lazy var scrollView: UIScrollView = self.setupScrollView()
   lazy var starPage: UIView = self.setupStarPage()
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  @objc var containerScheme = MDCContainerScheme()
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
@@ -54,7 +53,7 @@ class TabBarIconSwiftExample: UIViewController {
                     UITabBarItem(title: "Stars", image: star, tag:0)]
     tabBar.items[1].badgeValue = "1"
 
-    MDCTabBarColorThemer.applySemanticColorScheme(self.colorScheme, toTabs: tabBar);
+    tabBar.applyPrimaryTheme(withScheme: containerScheme)
 
     let blue = MDCPalette.blue.tint500
     tabBar.inkColor = blue

--- a/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
+++ b/components/Tabs/examples/TabBarIndicatorTemplateExample.swift
@@ -18,10 +18,9 @@ import CoreGraphics
 import MaterialComponents.MaterialAppBar_ColorThemer
 import MaterialComponents.MaterialAppBar_TypographyThemer
 import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialTypographyScheme
+import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTabs
-import MaterialComponents.MaterialTabs_ColorThemer
+import MaterialComponents.MaterialTabs_Theming
 
 class TabBarIndicatorTemplateExample: UIViewController {
 
@@ -50,14 +49,13 @@ class TabBarIndicatorTemplateExample: UIViewController {
   lazy var alignmentButton: MDCButton = self.makeAlignmentButton()
   lazy var appearanceButton: MDCButton = self.makeAppearanceButton()
   lazy var appBarViewController: MDCAppBarViewController = self.makeAppBar()
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  @objc var containerScheme = MDCContainerScheme()
 
   lazy var tabBar: MDCTabBar = {
     let tabBar = MDCTabBar()
     tabBar.alignment = .justified
 
-    MDCTabBarColorThemer.applySemanticColorScheme(self.colorScheme, toTabs: tabBar);
+    tabBar.applyPrimaryTheme(withScheme: containerScheme)
 
     let bundle = Bundle(for: TabBarIndicatorTemplateExample.self)
     let info = UIImage.init(named: "TabBarDemo_ic_info", in: bundle, compatibleWith:nil)
@@ -97,8 +95,8 @@ class TabBarIndicatorTemplateExample: UIViewController {
       action: #selector(changeAppearance),
       for: .touchUpInside)
 
-    MDCAppBarColorThemer.applyColorScheme(self.colorScheme, to: self.appBarViewController)
-    MDCAppBarTypographyThemer.applyTypographyScheme(self.typographyScheme,
+    MDCAppBarColorThemer.applyColorScheme(containerScheme.colorScheme, to: self.appBarViewController)
+    MDCAppBarTypographyThemer.applyTypographyScheme(containerScheme.typographyScheme,
                                                     to: self.appBarViewController)
   }
 

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -32,7 +32,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -14,16 +14,16 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialPalettes.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 
 @interface TabBarInterfaceBuilderExample : UIViewController <MDCTabBarDelegate>
 
 @property(weak, nonatomic) IBOutlet MDCTabBar *tabBar;
 @property(nonatomic) NSArray<UIColor *> *colors;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 
 @end
 
@@ -32,8 +32,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -53,7 +52,7 @@
     MDCPalette.greenPalette.tint500
   ];
 
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
+  [self.tabBar applyPrimaryThemeWithScheme:self.containerScheme];
 
   self.view.backgroundColor = self.colors[0];
 }

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -18,8 +18,8 @@
 #import "MaterialAppBar.h"
 #import "MaterialButtons.h"
 #import "MaterialCollections.h"
-#import "MaterialColorScheme.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialContainerScheme.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 #import "supplemental/TabBarTextOnlyExampleSupplemental.h"
 
@@ -29,8 +29,7 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     [self setupExampleViews:@[ @"Change Alignment", @"Toggle Case", @"Clear Selection" ]];
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -68,7 +67,7 @@
                                     tag:0],
   ];
 
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
+  [self.tabBar applyPrimaryThemeWithScheme:self.containerScheme];
 
   self.tabBar.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -29,7 +29,7 @@
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
     [self setupExampleViews:@[ @"Change Alignment", @"Toggle Case", @"Clear Selection" ]];
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -16,7 +16,7 @@
 
 #import "MaterialColorScheme.h"
 #import "MaterialSlider.h"
-#import "MaterialTabs+ColorThemer.h"
+#import "MaterialTabs+Theming.h"
 #import "MaterialTabs.h"
 #import "supplemental/TabBarViewControllerExampleSupplemental.h"
 
@@ -25,9 +25,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    self.typographyScheme = [[MDCTypographyScheme alloc] init];
+    self.containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }
@@ -46,7 +44,7 @@
   self.viewControllers = viewControllers;
   self.selectedViewController = self.viewControllers.firstObject;
   self.tabBar.enableRippleBehavior = YES;
-  [MDCTabBarColorThemer applySemanticColorScheme:self.colorScheme toTabs:self.tabBar];
+  [self.tabBar applyPrimaryThemeWithScheme:self.containerScheme];
 }
 
 @end

--- a/components/Tabs/examples/TabBarViewControllerExample.m
+++ b/components/Tabs/examples/TabBarViewControllerExample.m
@@ -25,7 +25,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    self.containerScheme = [[MDCContainerScheme alloc] init];
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.swift
@@ -30,8 +30,8 @@ extension TabBarIconSwiftExample {
     let alignmentButton = MDCButton()
 
     let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
+    buttonScheme.colorScheme = containerScheme.colorScheme
+    buttonScheme.typographyScheme = containerScheme.typographyScheme
     MDCContainedButtonThemer.applyScheme(buttonScheme, to: alignmentButton)
 
     alignmentButton.setTitle("Change Alignment", for: .normal)
@@ -65,8 +65,8 @@ extension TabBarIconSwiftExample {
     appBarViewController.headerView.minMaxHeightIncludesSafeArea = false
     appBarViewController.headerView.minimumHeight = 56 + 72
     appBarViewController.headerView.tintColor = MDCPalette.blue.tint500
-    MDCAppBarColorThemer.applyColorScheme(colorScheme, to: appBarViewController)
-    MDCAppBarTypographyThemer.applyTypographyScheme(typographyScheme, to: appBarViewController)
+    MDCAppBarColorThemer.applyColorScheme(containerScheme.colorScheme, to: appBarViewController)
+    MDCAppBarTypographyThemer.applyTypographyScheme(containerScheme.typographyScheme, to: appBarViewController)
 
     appBarViewController.headerStackView.bottomBar = self.tabBar
     appBarViewController.headerStackView.setNeedsLayout()

--- a/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
+++ b/components/Tabs/examples/supplemental/TabBarIndicatorTemplateExampleSupplemental.swift
@@ -22,8 +22,8 @@ extension TabBarIndicatorTemplateExample {
 
   private func themeButton(_ button: MDCButton) {
     let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
+    buttonScheme.colorScheme = containerScheme.colorScheme
+    buttonScheme.typographyScheme = containerScheme.typographyScheme
     MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
   }
 

--- a/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarTextOnlyExampleSupplemental.h
@@ -22,13 +22,13 @@
 #import "MDCTabBarDisplayDelegate.h"
 #import "MaterialAppBar.h"
 #import "MaterialCollections.h"
-#import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialTabs.h"
 
 @interface TabBarTextOnlyExample : MDCCollectionViewController <MDCTabBarDisplayDelegate>
 
 @property(nonatomic, nullable) MDCAppBarViewController *appBarViewController;
-@property(nonatomic, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, nullable) MDCContainerScheme *containerScheme;
 @property(nonatomic, nullable) MDCTabBar *tabBar;
 @property(nonatomic, nullable) NSArray *choices;
 @end

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.h
@@ -19,14 +19,14 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialButtons+ButtonThemer.h"
-#import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialTabs.h"
 #import "MaterialTypographyScheme.h"
 
 typedef void (^MDCButtonActionBlock)(void);
 
 @interface TabBarViewControllerExample : MDCTabBarViewController
-@property(nonatomic, strong, nullable) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong, nullable) MDCContainerScheme *containerScheme;
 @property(nonatomic, strong, nullable) MDCTypographyScheme *typographyScheme;
 @end
 

--- a/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarViewControllerExampleSupplemental.m
@@ -152,8 +152,8 @@
 - (nonnull NSArray *)constructExampleViewControllers {
   NSBundle *bundle = [NSBundle bundleForClass:[TabBarViewControllerExample class]];
   MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
+  buttonScheme.colorScheme = self.containerScheme.colorScheme;
+  buttonScheme.typographyScheme = self.containerScheme.typographyScheme;
 
   TBVCSampleViewController *child1 = [TBVCSampleViewController sampleWithTitle:@"One"
                                                                          color:UIColor.redColor];
@@ -169,7 +169,7 @@
                       TBVCSampleViewController *vc =
                           [TBVCSampleViewController sampleWithTitle:@"Push&Hide"
                                                               color:UIColor.grayColor];
-                      vc.colorScheme = strongSelf.colorScheme;
+                      vc.colorScheme = strongSelf.containerScheme.colorScheme;
                       vc.typographyScheme = strongSelf.typographyScheme;
                       [strongSelf.navigationController pushViewController:vc animated:YES];
                     }];
@@ -190,7 +190,7 @@
 
   NSArray *viewControllers = @[ child1, child2, child3 ];
   for (TBVCSampleViewController *vc in viewControllers) {
-    vc.colorScheme = self.colorScheme;
+    vc.colorScheme = self.containerScheme.colorScheme;
     vc.typographyScheme = self.typographyScheme;
   }
   return viewControllers;


### PR DESCRIPTION
This PR makes it so that Tabs examples use the theming extension instead of the themer.

Related to #9061.
Related to #9063.
Related to #9062.
