### PR TITLE
[Demos] Resolve the jump in the animation when selecting a card on Pesto.

### DIFF
--- a/demos/Pesto/Pesto/PestoViewController.m
+++ b/demos/Pesto/Pesto/PestoViewController.m
@@ -110,6 +110,7 @@ static CGFloat kPestoInset = 5.f;
           detailVC.title = cell.title;
           detailVC.descText = cell.descText;
           detailVC.iconImageName = cell.iconImageName;
+          detailVC.modalPresentationStyle = UIModalPresentationOverFullScreen;
           [self presentViewController:detailVC
                              animated:NO
                            completion:^() {


### PR DESCRIPTION
Apple added a default UIModalPresentationStyle on iOS 13 that leaves a gap between the presentedViewController and the safe areas. This results in a jump in the animation.
Setting PestoDetailViewController.modalPresentationStyle to UIModalPresentationOverFullScreen removes this jump