### PR TITLE
[Cards] Migrate MDCCardsColorThemer to theming extensions

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -669,8 +669,6 @@ Pod::Spec.new do |mdc|
       "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/private/*.{h,m}"
     ]
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ColorThemer"
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}+ShapeThemer"
     extension.dependency "MaterialComponents/schemes/Container"
 
     extension.test_spec 'UnitTests' do |unit_tests|

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -87,6 +87,8 @@ mdc_unit_test_swift_library(
     ]),
     deps = [
         ":Cards",
+        ":ColorThemer",
+        ":ShapeThemer",
         ":Theming",
     ],
 )

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -51,8 +51,6 @@ mdc_extension_objc_library(
     name = "Theming",
     deps = [
         ":Cards",
-        ":ColorThemer",
-        ":ShapeThemer",
         "//components/schemes/Container",
     ],
 )
@@ -89,8 +87,6 @@ mdc_unit_test_swift_library(
     ]),
     deps = [
         ":Cards",
-        ":ColorThemer",
-        ":ShapeThemer",
         ":Theming",
     ],
 )

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -14,9 +14,6 @@
 
 #import "MDCCard+MaterialTheming.h"
 
-#import "MaterialCards+ColorThemer.h"
-#import "MaterialCards+ShapeThemer.h"
-
 static const MDCShadowElevation kNormalElevation = 1;
 static const MDCShadowElevation kHighlightedElevation = 1;
 static const CGFloat kBorderWidth = 1;

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -17,7 +17,7 @@
 static const MDCShadowElevation kNormalElevation = 1;
 static const MDCShadowElevation kHighlightedElevation = 1;
 static const CGFloat kBorderWidth = 1;
-static const CGFloat kStrokeVariantBorderOpacity = (CGFloat)0.37;
+static const CGFloat kOutlinedVariantBorderOpacity = (CGFloat)0.37;
 
 @implementation MDCCard (MaterialTheming)
 
@@ -90,7 +90,7 @@ static const CGFloat kStrokeVariantBorderOpacity = (CGFloat)0.37;
 
   self.backgroundColor = colorScheme.surfaceColor;
   UIColor *borderColor =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kStrokeVariantBorderOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlinedVariantBorderOpacity];
   [self setBorderColor:borderColor forState:UIControlStateNormal];
 }
 

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -29,7 +29,7 @@ static const CGFloat kOutlinedVariantBorderOpacity = (CGFloat)0.37;
     colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   }
-  [self applyThemeWithColorScheme:colorScheme];
+  self.backgroundColor = colorScheme.surfaceColor;
 
   id<MDCShapeScheming> shapeScheme = scheme.shapeScheme;
   if (shapeScheme) {
@@ -41,10 +41,6 @@ static const CGFloat kOutlinedVariantBorderOpacity = (CGFloat)0.37;
   [self setShadowElevation:kNormalElevation forState:UIControlStateNormal];
   [self setShadowElevation:kHighlightedElevation forState:UIControlStateHighlighted];
   self.interactable = YES;  // To achieve baseline themed, the card should be interactable.
-}
-
-- (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  self.backgroundColor = colorScheme.surfaceColor;
 }
 
 - (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {

--- a/components/Cards/src/Theming/MDCCard+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCard+MaterialTheming.m
@@ -20,6 +20,7 @@
 static const MDCShadowElevation kNormalElevation = 1;
 static const MDCShadowElevation kHighlightedElevation = 1;
 static const CGFloat kBorderWidth = 1;
+static const CGFloat kStrokeVariantBorderOpacity = (CGFloat)0.37;
 
 @implementation MDCCard (MaterialTheming)
 
@@ -46,7 +47,7 @@ static const CGFloat kBorderWidth = 1;
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCCardsColorThemer applySemanticColorScheme:colorScheme toCard:self];
+  self.backgroundColor = colorScheme.surfaceColor;
 }
 
 - (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
@@ -84,7 +85,16 @@ static const CGFloat kBorderWidth = 1;
 }
 
 - (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCCardsColorThemer applyOutlinedVariantWithColorScheme:colorScheme toCard:self];
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderColor:nil forState:state];
+  }
+
+  self.backgroundColor = colorScheme.surfaceColor;
+  UIColor *borderColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kStrokeVariantBorderOpacity];
+  [self setBorderColor:borderColor forState:UIControlStateNormal];
 }
 
 @end

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -21,6 +21,7 @@ static const MDCShadowElevation kNormalElevation = 1;
 static const MDCShadowElevation kHighlightedElevation = 1;
 static const MDCShadowElevation kSelectedElevation = 1;
 static const CGFloat kBorderWidth = 1;
+static const CGFloat kStrokeVariantBorderOpacity = (CGFloat)0.37;
 
 @implementation MDCCardCollectionCell (MaterialTheming)
 
@@ -48,7 +49,8 @@ static const CGFloat kBorderWidth = 1;
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCCardsColorThemer applySemanticColorScheme:colorScheme toCardCell:self];
+  self.backgroundColor = colorScheme.surfaceColor;
+  [self setImageTintColor:colorScheme.primaryColor forState:MDCCardCellStateNormal];
 }
 
 - (void)applyThemeWithShapeScheme:(id<MDCShapeScheming>)shapeScheme {
@@ -85,7 +87,16 @@ static const CGFloat kBorderWidth = 1;
 }
 
 - (void)applyOutlinedThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCCardsColorThemer applyOutlinedVariantWithColorScheme:colorScheme toCardCell:self];
+  NSUInteger maximumStateValue = UIControlStateNormal | UIControlStateSelected |
+                                 UIControlStateHighlighted | UIControlStateDisabled;
+  for (NSUInteger state = 0; state <= maximumStateValue; ++state) {
+    [self setBorderColor:nil forState:state];
+  }
+
+  self.backgroundColor = colorScheme.surfaceColor;
+  UIColor *borderColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kStrokeVariantBorderOpacity];
+  [self setBorderColor:borderColor forState:MDCCardCellStateNormal];
 }
 
 @end

--- a/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
+++ b/components/Cards/src/Theming/MDCCardCollectionCell+MaterialTheming.m
@@ -14,9 +14,6 @@
 
 #import "MDCCardCollectionCell+MaterialTheming.h"
 
-#import "MaterialCards+ColorThemer.h"
-#import "MaterialCards+ShapeThemer.h"
-
 static const MDCShadowElevation kNormalElevation = 1;
 static const MDCShadowElevation kHighlightedElevation = 1;
 static const MDCShadowElevation kSelectedElevation = 1;

--- a/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
+++ b/components/Cards/tests/unit/Theming/CardsMaterialThemingTests.swift
@@ -15,10 +15,8 @@
 import XCTest
 
 import MaterialComponents.MaterialCards
-import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialShapeLibrary
-import MaterialComponents.MaterialShapeScheme
 import MaterialComponents.MaterialCards_Theming
 
 class CardsMaterialThemingTests: XCTestCase {


### PR DESCRIPTION
Migrating Cards Themer code to theming extensions as part of the deprecation and deletion of `MDCCardsColorThemer`.

Part of #9098, #9097, #9096, and #9095