### PR TITLE
[BottomNavigation] Migrate MDCBottomNavigationBarColorThemer use to theming extension

### DIFF
--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -144,6 +144,7 @@ mdc_examples_objc_library(
         ":BottomNavigation",
         "//components/Palettes",
         "//components/schemes/Color",
+        "//components/schemes/Container",
         "//components/schemes/Typography",
     ],
 )

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -142,6 +142,7 @@ mdc_examples_objc_library(
     includes = ["examples/supplemental"],
     deps = [
         ":BottomNavigation",
+        ":Theming",
         "//components/Palettes",
         "//components/schemes/Color",
         "//components/schemes/Container",
@@ -154,8 +155,8 @@ mdc_examples_swift_library(
     deps = [
         ":BottomNavigation",
         ":BottomNavigationBeta",
-        ":Theming",
         ":ObjcExamples",
+        ":Theming",
         "//components/AppBar",
         "//components/Buttons",
         "//components/Palettes",

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -142,8 +142,6 @@ mdc_examples_objc_library(
     includes = ["examples/supplemental"],
     deps = [
         ":BottomNavigation",
-        ":ColorThemer",
-        ":TypographyThemer",
         "//components/Palettes",
         "//components/schemes/Color",
         "//components/schemes/Typography",
@@ -155,10 +153,8 @@ mdc_examples_swift_library(
     deps = [
         ":BottomNavigation",
         ":BottomNavigationBeta",
-        ":ColorThemer",
         ":Theming",
         ":ObjcExamples",
-        ":TypographyThemer",
         "//components/AppBar",
         "//components/Buttons",
         "//components/Palettes",

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -17,15 +17,10 @@ import UIKit
 import MaterialComponentsBeta.MaterialBottomNavigationBeta
 import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialBottomNavigation_TypographyThemer
-import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {
 
-  var containerScheme: MDCContainerScheming = {
-    let containerScheme = MDCContainerScheme()
-    containerScheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-    return containerScheme
-  }()
+  var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -21,13 +21,18 @@ import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {
 
-  var colorScheme: MDCColorScheming = MDCSemanticColorScheme(defaults: .material201804)
+  var containerScheme: MDCContainerScheming = {
+    let containerScheme = MDCContainerScheme()
+    containerScheme.colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    return containerScheme
+  }()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    self.view.backgroundColor = colorScheme.secondaryColor
+    self.view.backgroundColor = containerScheme.colorScheme.secondaryColor
   }
+
   override var prefersHomeIndicatorAutoHidden: Bool {
     return false
   }
@@ -87,15 +92,9 @@ class BottomNavigationControllerExampleScrollableChildViewController: UICollecti
 
 class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarController {
 
-  @objc public var colorScheme: MDCColorScheming  = MDCSemanticColorScheme() {
+  var containerScheme: MDCContainerScheming = MDCContainerScheme() {
     didSet {
-      apply(colorScheme: colorScheme)
-    }
-  }
-
-  @objc public var typographyScheme: MDCTypographyScheming = MDCTypographyScheme() {
-    didSet {
-      apply(typographyScheme: typographyScheme)
+      apply(containerScheme: containerScheme)
     }
   }
 
@@ -107,15 +106,15 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
     let flowLayout = UICollectionViewFlowLayout()
     flowLayout.estimatedItemSize = CGSize(width: 96, height: 48)
     let viewController1 = BottomNavigationControllerExampleScrollableChildViewController(collectionViewLayout: flowLayout)
-    viewController1.collectionView.backgroundColor = colorScheme.primaryColorVariant
+    viewController1.collectionView.backgroundColor = containerScheme.colorScheme.primaryColorVariant
     viewController1.tabBarItem = UITabBarItem(title: "Item 1", image: UIImage(named: "Home"), tag: 0)
 
     let viewController2 = BottomNavigationControllerExampleFixedChildViewController()
-    viewController2.colorScheme = self.colorScheme
+    viewController2.containerScheme = containerScheme
     viewController2.tabBarItem = UITabBarItem(title: "Item 2", image: UIImage(named: "Favorite"), tag: 1)
 
     let viewController3 = UIViewController()
-    viewController3.view.backgroundColor = colorScheme.surfaceColor
+    viewController3.view.backgroundColor = containerScheme.colorScheme.surfaceColor
     viewController3.tabBarItem = UITabBarItem(title: "Item 3", image: UIImage(named: "Search"), tag: 2)
 
     viewControllers = [ viewController1, viewController2, viewController3 ]
@@ -132,12 +131,7 @@ class BottomNavigationControllerExampleViewController: MDCBottomNavigationBarCon
 // MARK: Private Functions
 
 extension BottomNavigationControllerExampleViewController {
-  fileprivate func apply(colorScheme: MDCColorScheming) {
-    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme, toBottomNavigation: self.navigationBar)
-  }
-
-  fileprivate func apply(typographyScheme: MDCTypographyScheming) {
-    MDCBottomNavigationBarTypographyThemer.applyTypographyScheme(typographyScheme,
-                                                                 to: self.navigationBar)
+  fileprivate func apply(containerScheme: MDCContainerScheming) {
+    navigationBar.applyPrimaryTheme(withScheme: containerScheme)
   }
 }

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -15,7 +15,9 @@
 import UIKit
 
 import MaterialComponentsBeta.MaterialBottomNavigationBeta
+import MaterialComponents.MaterialBottomNavigation_Theming
 import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialContainerScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {
 

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -17,7 +17,6 @@ import UIKit
 import MaterialComponentsBeta.MaterialBottomNavigationBeta
 import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialBottomNavigation_Theming
-import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -15,6 +15,7 @@
 import UIKit
 
 import MaterialComponentsBeta.MaterialBottomNavigationBeta
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialBottomNavigation_Theming
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -15,8 +15,6 @@
 import UIKit
 
 import MaterialComponentsBeta.MaterialBottomNavigationBeta
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
-import MaterialComponents.MaterialBottomNavigation_TypographyThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
+++ b/components/BottomNavigation/examples/BottomNavigationBarControllerExampleViewController.swift
@@ -21,7 +21,7 @@ import MaterialComponents.MaterialContainerScheme
 
 class BottomNavigationControllerExampleFixedChildViewController: UIViewController {
 
-  var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/components/BottomNavigation/examples/BottomNavigationBlurExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationBlurExample.m
@@ -95,6 +95,8 @@
 
 - (void)applyTheming {
   [self.bottomNavBar applyPrimaryThemeWithScheme:self.containerScheme];
+  self.bottomNavBar.barTintColor =
+      [self.bottomNavBar.barTintColor colorWithAlphaComponent:(CGFloat)0.85];
   self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   self.collectionView.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 }

--- a/components/BottomNavigation/examples/BottomNavigationBlurExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationBlurExample.m
@@ -14,16 +14,14 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialBottomNavigation+ColorThemer.h"
-#import "MaterialBottomNavigation+TypographyThemer.h"
+#import "MDCBottomNavigationBar+MaterialTheming.h"
 #import "MaterialBottomNavigation.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
 
 @interface BottomNavigationBlurExample : UIViewController <UICollectionViewDataSource>
 
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @property(nonatomic, strong) MDCBottomNavigationBar *bottomNavBar;
 @property(nonatomic, strong) UICollectionView *collectionView;
 @property(nonatomic, strong) UIImage *blurOnIcon;
@@ -35,10 +33,11 @@
 - (id)init {
   self = [super init];
   if (self) {
-    _colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _typographyScheme =
-        [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
+    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    _containerScheme = containerScheme;
   }
   return self;
 }
@@ -95,17 +94,9 @@
 }
 
 - (void)applyTheming {
-  [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:self.typographyScheme
-                                          toBottomNavigationBar:self.bottomNavBar];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCBottomNavigationBarColorThemer applySemanticColorScheme:self.colorScheme
-                                           toBottomNavigation:self.bottomNavBar];
-#pragma clang diagnostic pop
-  self.bottomNavBar.barTintColor =
-      [self.bottomNavBar.barTintColor colorWithAlphaComponent:(CGFloat)0.85];
-  self.view.backgroundColor = self.colorScheme.backgroundColor;
-  self.collectionView.backgroundColor = self.colorScheme.backgroundColor;
+  [self.bottomNavBar applyPrimaryThemeWithScheme:self.containerScheme];
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
+  self.collectionView.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 }
 
 - (void)viewDidLoad {

--- a/components/BottomNavigation/examples/BottomNavigationBlurExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationBlurExample.m
@@ -33,11 +33,7 @@
 - (id)init {
   self = [super init];
   if (self) {
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    _containerScheme = containerScheme;
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/BottomNavigation/examples/BottomNavigationBlurExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationBlurExample.m
@@ -35,7 +35,7 @@
   if (self) {
     MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
     containerScheme.colorScheme =
-    [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
     containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
     _containerScheme = containerScheme;
   }

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialPalettes
 

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -19,7 +19,11 @@ import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 
-  @objc var colorScheme = MDCSemanticColorScheme()
+  let containerScheme: MDCContainerScheming = {
+    let containerScheme = MDCContainerScheme()
+    containerScheme.colorScheme = MDCSemanticColorScheme()
+    return containerScheme
+  }()
 
   let bottomNavBar = MDCBottomNavigationBar()
 
@@ -99,8 +103,7 @@ class BottomNavigationExplicitlySetColorExample: UIViewController {
     blueButton.addTarget(self, action: #selector(blueTheme), for: .touchUpInside)
     view.addSubview(blueButton)
 
-    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
-                                                               toBottomNavigation: bottomNavBar)
+    bottomNavBar.applyPrimaryTheme(withScheme: containerScheme)
     bottomNavBar.backgroundColor = MDCPalette.grey.tint700
   }
 

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -15,6 +15,7 @@
 import Foundation
 import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialPalettes
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -19,14 +19,8 @@ import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 
-  let containerScheme: MDCContainerScheming = {
-    let containerScheme = MDCContainerScheme()
-    containerScheme.colorScheme = MDCSemanticColorScheme()
-    return containerScheme
-  }()
-
+  let containerScheme = MDCContainerScheme()
   let bottomNavBar = MDCBottomNavigationBar()
-
   let redButton = MDCButton()
   let blueButton = MDCButton()
 

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -18,7 +18,7 @@ import MaterialComponents.MaterialPalettes
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 
-  let containerScheme = MDCContainerScheme()
+  @objc let containerScheme = MDCContainerScheme()
   let bottomNavBar = MDCBottomNavigationBar()
   let redButton = MDCButton()
   let blueButton = MDCButton()

--- a/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationExplicitlySetColorExample.swift
@@ -15,7 +15,6 @@
 import Foundation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialPalettes
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
 
 class BottomNavigationExplicitlySetColorExample: UIViewController {
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -22,8 +22,12 @@ import MaterialComponents.MaterialTypographyScheme
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {
 
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  let containerScheme: MDCContainerScheming = {
+    let containerScheme = MDCContainerScheme()
+    containerScheme.colorScheme = MDCSemanticColorScheme()
+    containerScheme.typographyScheme = MDCTypographyScheme()
+    return containerScheme
+  }()
 
   let bottomNavBar = MDCBottomNavigationBar()
 
@@ -82,7 +86,7 @@ class BottomNavigationResetExample: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
     view.addSubview(bottomNavBar)
 
     bottomNavBar.alignment = .centered
@@ -104,10 +108,7 @@ class BottomNavigationResetExample: UIViewController {
     buttonTwo.addTarget(self, action: #selector(reorderItemsAndSetSelected), for: .touchUpInside)
     view.addSubview(buttonTwo)
 
-    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
-                                                               toBottomNavigation: bottomNavBar)
-    MDCBottomNavigationBarTypographyThemer.applyTypographyScheme(typographyScheme,
-                                                                 to: bottomNavBar)
+    bottomNavBar.applyPrimaryTheme(withScheme: containerScheme)
   }
 
   @objc func reorderItems(_ button: UIButton) {

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialTypographyScheme
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {
 
-  let containerScheme = MDCContainerScheme()
+  @objc var containerScheme = MDCContainerScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
-import MaterialComponents.MaterialBottomNavigation_TypographyThemer
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialTypographyScheme

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -15,8 +15,7 @@
 import Foundation
 import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialTypographyScheme
+import MaterialComponents.MaterialContainerScheme
 
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
+++ b/components/BottomNavigation/examples/BottomNavigationResetButtons.swift
@@ -22,12 +22,7 @@ import MaterialComponents.MaterialTypographyScheme
 /// Example to showcase a reorder of the tabs from an user action
 class BottomNavigationResetExample: UIViewController {
 
-  let containerScheme: MDCContainerScheming = {
-    let containerScheme = MDCContainerScheme()
-    containerScheme.colorScheme = MDCSemanticColorScheme()
-    containerScheme.typographyScheme = MDCTypographyScheme()
-    return containerScheme
-  }()
+  let containerScheme = MDCContainerScheme()
 
   let bottomNavBar = MDCBottomNavigationBar()
 

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import MaterialComponents.MaterialBottomNavigation
+import MaterialComponents.MaterialContainerScheme
 import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -17,7 +17,7 @@ import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states
 class BottomNavigationSelectedIconExample: UIViewController {
-  let containerScheme: MDCContainerScheming = {
+  @objc var containerScheme: MDCContainerScheming = {
     let containerScheme = MDCContainerScheme()
     containerScheme.colorScheme.backgroundColor = .white
     return containerScheme

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -13,21 +13,24 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states
 class BottomNavigationSelectedIconExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme()
-  @objc var typographyScheme = MDCTypographyScheme()
+  let containerScheme: MDCContainerScheming = {
+    let containerScheme = MDCContainerScheme()
+    containerScheme.colorScheme = MDCSemanticColorScheme()
+    containerScheme.colorScheme.backgroundColor = .white
+    containerScheme.typographyScheme = MDCTypographyScheme()
+    return containerScheme
+  }()
 
   let bottomNavBar = MDCBottomNavigationBar()
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    colorScheme.backgroundColor = .white
-    view.backgroundColor = colorScheme.backgroundColor
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
 
     let tabBarItem1 = UITabBarItem(title: "Home", image: UIImage(named: "Home"), tag: 0)
     let tabBarItem2 = UITabBarItem(title: "Messages", image: UIImage(named: "Email"), tag: 1)
@@ -38,8 +41,7 @@ class BottomNavigationSelectedIconExample: UIViewController {
     bottomNavBar.selectedItem = tabBarItem1
     view.addSubview(bottomNavBar)
 
-    MDCBottomNavigationBarColorThemer.applySemanticColorScheme(colorScheme,
-                                                               toBottomNavigation: bottomNavBar)
+    bottomNavBar.applyPrimaryTheme(withScheme: containerScheme)
   }
 
   func layoutBottomNavBar() {

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -19,9 +19,7 @@ import MaterialComponents.MaterialTypographyScheme
 class BottomNavigationSelectedIconExample: UIViewController {
   let containerScheme: MDCContainerScheming = {
     let containerScheme = MDCContainerScheme()
-    containerScheme.colorScheme = MDCSemanticColorScheme()
     containerScheme.colorScheme.backgroundColor = .white
-    containerScheme.typographyScheme = MDCTypographyScheme()
     return containerScheme
   }()
 

--- a/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationSelectedIconExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialTypographyScheme
 
 // Example to show different icons for selected and unselected states

--- a/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTitleVisibilityChangeExample: UIViewController, MDCBottomNavigationBarDelegate {

--- a/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTitleVisibilityChangeExample.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTitleVisibilityChangeExample: UIViewController, MDCBottomNavigationBarDelegate {

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -16,8 +16,7 @@
 
 #import "BottomNavigationTypicalUseSupplemental.h"
 
-#import "MaterialBottomNavigation+ColorThemer.h"
-#import "MaterialBottomNavigation+TypographyThemer.h"
+#import "MDCBottomNavigationBar+MaterialTheming.h"
 #import "MaterialBottomNavigation.h"
 #import "MaterialPalettes.h"
 
@@ -25,6 +24,7 @@
 
 @property(nonatomic, assign) int badgeCount;
 @property(nonatomic, strong) MDCBottomNavigationBar *bottomNavBar;
+
 @end
 
 @implementation BottomNavigationTypicalUseExample
@@ -33,9 +33,11 @@
   self = [super init];
   if (self) {
     self.title = @"Bottom Navigation";
-    _colorScheme =
+    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+    containerScheme.colorScheme =
         [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    _typographyScheme = [[MDCTypographyScheme alloc] init];
+    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
+    _containerScheme = containerScheme;
   }
   return self;
 }
@@ -113,14 +115,8 @@
 
   [self commonBottomNavigationTypicalUseExampleViewDidLoad];
 
-  [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:self.typographyScheme
-                                          toBottomNavigationBar:self.bottomNavBar];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCBottomNavigationBarColorThemer applySemanticColorScheme:self.colorScheme
-                                           toBottomNavigation:self.bottomNavBar];
-#pragma clang diagnostic pop
-  self.view.backgroundColor = self.colorScheme.backgroundColor;
+  [self.bottomNavBar applyPrimaryThemeWithScheme:self.containerScheme];
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
 }
 
 - (void)viewDidLayoutSubviews {

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.m
@@ -33,11 +33,7 @@
   self = [super init];
   if (self) {
     self.title = @"Bottom Navigation";
-    MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
-    containerScheme.colorScheme =
-        [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-    containerScheme.typographyScheme = [[MDCTypographyScheme alloc] init];
-    _containerScheme = containerScheme;
+    _containerScheme = [[MDCContainerScheme alloc] init];
   }
   return self;
 }

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import MaterialComponents.MaterialBottomNavigation
 import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTypicalUseSwiftExample: UIViewController {

--- a/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
+++ b/components/BottomNavigation/examples/BottomNavigationTypicalUseExample.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import MaterialComponents.MaterialBottomNavigation_ColorThemer
 import MaterialComponents.MaterialColorScheme
 
 class BottomNavigationTypicalUseSwiftExample: UIViewController {

--- a/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.h
+++ b/components/BottomNavigation/examples/supplemental/BottomNavigationTypicalUseSupplemental.h
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #import <UIKit/UIKit.h>
-#import "MaterialColorScheme.h"
-#import "MaterialTypographyScheme.h"
+#import "MaterialContainerScheme.h"
 
 @interface BottomNavigationTypicalUseExample : UIViewController
-@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 @end

--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarSnapshotTests.m
@@ -17,8 +17,7 @@
 
 #import "../../src/private/MDCBottomNavigationItemView.h"
 
-#import "MaterialBottomNavigation+ColorThemer.h"
-#import "MaterialBottomNavigation+TypographyThemer.h"
+#import "MDCBottomNavigationBar+MaterialTheming.h"
 #import "MaterialBottomNavigation.h"
 #import "MaterialInk.h"
 #import "MaterialSnapshot.h"
@@ -270,16 +269,14 @@ static const CGFloat kHeightShort = 48;
 
 - (void)testMaterialBaselineTheme {
   // Given
-  MDCSemanticColorScheme *colorScheme =
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
+  containerScheme.colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
-  MDCTypographyScheme *typographyScheme =
+  containerScheme.typographyScheme =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
 
   // When
-  [MDCBottomNavigationBarColorThemer applySemanticColorScheme:colorScheme
-                                           toBottomNavigation:self.navigationBar];
-  [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:typographyScheme
-                                          toBottomNavigationBar:self.navigationBar];
+  [self.navigationBar applyPrimaryThemeWithScheme:containerScheme];
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;
@@ -293,6 +290,7 @@ static const CGFloat kHeightShort = 48;
 
 - (void)testCustomColorScheme {
   // Given
+  MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
   MDCSemanticColorScheme *colorScheme =
       [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
   colorScheme.primaryColor = UIColor.orangeColor;
@@ -305,15 +303,13 @@ static const CGFloat kHeightShort = 48;
   colorScheme.onBackgroundColor = UIColor.brownColor;
   colorScheme.errorColor = UIColor.greenColor;
   colorScheme.primaryColorVariant = UIColor.whiteColor;
+  containerScheme.colorScheme = colorScheme;
 
-  MDCTypographyScheme *typographyScheme =
+  containerScheme.typographyScheme =
       [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201804];
 
   // When
-  [MDCBottomNavigationBarColorThemer applySemanticColorScheme:colorScheme
-                                           toBottomNavigation:self.navigationBar];
-  [MDCBottomNavigationBarTypographyThemer applyTypographyScheme:typographyScheme
-                                          toBottomNavigationBar:self.navigationBar];
+  [self.navigationBar applyPrimaryThemeWithScheme:containerScheme];
   self.navigationBar.items = @[ self.tabItem1, self.tabItem2, self.tabItem3 ];
   self.navigationBar.titleVisibility = MDCBottomNavigationBarTitleVisibilityAlways;
   self.navigationBar.selectedItem = self.tabItem2;

--- a/snapshot_test_goldens/goldens_64/MDCBottomNavigationBarSnapshotTests/testCustomColorScheme_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomNavigationBarSnapshotTests/testCustomColorScheme_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51cdb90f16ae3dd72a021a2edd4d1ecbe5fbd62139f0f01f124122eb8407ad87
-size 17658
+oid sha256:4a780779d070296979e7944912f4eecdcd82b67fc5ad3470aba7b6c77b1d4fe4
+size 17644

--- a/snapshot_test_goldens/goldens_64/MDCBottomNavigationBarSnapshotTests/testMaterialBaselineTheme_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomNavigationBarSnapshotTests/testMaterialBaselineTheme_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e15f34b93060ddb135a206e7c8b585ee3779c3082d20c3fd275724989440ef4
-size 17554
+oid sha256:aa0182e3db4a3f53ddb397fab8e6c42fd447434f5b2f87ebc469f1394c1603af
+size 17568


### PR DESCRIPTION
Migrate `MDCBottomNavigationBarColorThemer` logic to theming extensions to prepare for the eventual deletion of `MDCBottomNavigationBarColorThemer`.

Part of #9130
Part of #9161 