### PR TITLE
[Tabs] Disable Ripple while scrolling TabBarView

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -226,6 +226,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
       mdcItemView.image = item.image;
       mdcItemView.selectedImage = item.selectedImage;
       mdcItemView.rippleTouchController.rippleView.rippleColor = self.rippleColor;
+      mdcItemView.rippleTouchController.shouldProcessRippleWithScrollViewGestures = NO;
       itemView = mdcItemView;
     }
     UITapGestureRecognizer *tapGesture =


### PR DESCRIPTION
When scrolling TabBarView, the Ripple should be disabled. The Ripple effect
communicates an activation/tap to the user but that is not the case while
scrolling.

|Before|After|
|---|---|
|![TabBarView example showing Ripple activation while scrolling.](https://user-images.githubusercontent.com/1753199/70330644-f4dc3300-180b-11ea-8a90-a15009c66101.gif)|![TabBarView example showing Ripple activation only when not scrolling.](https://user-images.githubusercontent.com/1753199/70330825-4f758f00-180c-11ea-8cd3-86fcd634c9c7.gif)|

## Testing
1. Launch the MDC Dragons app
2. Open the "TabBarView" example
3. Scroll slowly and tap on a Tab during the scroll.

Part of #9146 