### PR TITLE
[List] Remove usage of MDCListColorThemer before deprecating it.

### DIFF
--- a/components/List/src/Theming/MDCBaseCell+MaterialTheming.m
+++ b/components/List/src/Theming/MDCBaseCell+MaterialTheming.m
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #import "MDCBaseCell+MaterialTheming.h"
-#import "MaterialList+ColorThemer.h"
+
+static const CGFloat kInkAlpha = (CGFloat)0.16;
 
 @implementation MDCBaseCell (MaterialTheming)
 
@@ -27,7 +28,9 @@
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCListColorThemer applySemanticColorScheme:colorScheme toBaseCell:self];
+  UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
+  self.inkColor = rippleColor;
+  self.rippleColor = rippleColor;
 }
 
 @end

--- a/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
+++ b/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
@@ -14,8 +14,10 @@
 
 #import "MDCSelfSizingStereoCell+MaterialTheming.h"
 
-#import "MaterialList+ColorThemer.h"
 #import "MaterialList+TypographyThemer.h"
+
+static const CGFloat kHighAlpha = (CGFloat)0.87;
+static const CGFloat kInkAlpha = (CGFloat)0.16;
 
 @implementation MDCSelfSizingStereoCell (MaterialTheming)
 
@@ -36,7 +38,14 @@
 }
 
 - (void)applyThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
-  [MDCListColorThemer applySemanticColorScheme:colorScheme toSelfSizingStereoCell:self];
+  self.titleLabel.textColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  self.detailLabel.textColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  self.leadingImageView.tintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  self.trailingImageView.tintColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
+  UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
+  self.inkColor = rippleColor;
+  self.rippleColor = rippleColor;
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {


### PR DESCRIPTION
# Description

Removing calls to MDCListColorThemer from within our library.

# Issue

b/145204432 -Delete symbol "MDCListColorThemer(ToBeDeprecated)::applySemanticColorScheme:toBaseCell:"