### PR TITLE
[Snackbar] Adds elementToFocusOnDismiss to MDCSnackbar

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -171,8 +171,8 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic) BOOL focusOnShow;
 
 /**
- Element to focus on HUD message dismiss. Focuses the first element on screen
- after dismiss by default. The focus will change to the element only if the focus is on the HUD
+ Element to focus on snackbar message dismiss. Focuses the first element on screen
+ after dismiss by default. The focus will change to the element only if the focus is on the snackbar
  message.
 
  Defaults to nil.

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -172,7 +172,8 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
 
 /**
  Element to focus on HUD message dismiss. Focuses the first element on screen
- after dismiss by default. The focus will change to the element only if the focus is on the HUD message.
+ after dismiss by default. The focus will change to the element only if the focus is on the HUD
+ message.
 
  Defaults to nil.
  */

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -171,6 +171,14 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic) BOOL focusOnShow;
 
 /**
+ Element to focus on HUD message dismiss. Focuses the first element on screen
+ after dismiss by default. The focus will change to the element only if the focus is on the HUD message.
+
+ Defaults to nil.
+ */
+@property(nonatomic, weak, nullable) UIView *elementToFocusOnDismiss;
+
+/**
  A block that is invoked when the corresponding @c MDCSnackbarMessageView of the @c
  MDCSnackbarMessage instance will be presented. Use this to customize @c MDCSnackbarMessageView
  before presentation.

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -71,6 +71,7 @@ static BOOL _usesLegacySnackbar = NO;
 #pragma clang diagnostic pop
   copy.enableRippleBehavior = self.enableRippleBehavior;
   copy.focusOnShow = self.focusOnShow;
+  copy.elementToFocusOnDismiss = self.elementToFocusOnDismiss;
 
   // Unfortunately there's not really a concept of 'copying' a block (in the same way you would copy
   // a string, for example). A block's pointer is immutable once it is created and copied to the


### PR DESCRIPTION
As part of maintaining same functionality across our iterations of the Snackbar, this code was ported from the older iteration to allow users to choose focus on different views after Snackbar is dismissed.