### PR TITLE
[Dialogs] Snapshot tests for long action titles.

### DIFF
--- a/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
@@ -329,8 +329,8 @@ static NSString *const kMessageLongArabic =
 
 - (void)testAlertWithLongButtonTitlesRTL {
   // Given
-  MDCAlertController *controller = [MDCAlertController alertControllerWithTitle:kTitleShortArabic
-                                                                        message:kMessageLongArabic];
+  MDCAlertController *controller =
+      [MDCAlertController alertControllerWithTitle:kTitleShortArabic message:kMessageShortArabic];
 
   // When
   MDCAlertAction *shortAction = [MDCAlertAction actionWithTitle:kTitleShortArabic handler:nil];

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
@@ -311,6 +311,39 @@ static NSString *const kMessageLongArabic =
   [self generateSnapshotAndVerifyForView:self.alertController.view];
 }
 
+- (void)testAlertWithLongButtonTitlesLTR {
+  // Given
+  MDCAlertController *controller = [MDCAlertController alertControllerWithTitle:kTitleShortLatin
+                                                                        message:kMessageShortLatin];
+
+  // When
+  MDCAlertAction *shortAction = [MDCAlertAction actionWithTitle:kTitleShortLatin handler:nil];
+  MDCAlertAction *longAction = [MDCAlertAction actionWithTitle:kMessageLongLatin handler:nil];
+  [controller addAction:shortAction];
+  [controller addAction:longAction];
+  controller.view.frame = CGRectMake(0, 0, 300, 300);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
+- (void)testAlertWithLongButtonTitlesRTL {
+  // Given
+  MDCAlertController *controller = [MDCAlertController alertControllerWithTitle:kTitleShortArabic
+                                                                        message:kMessageLongArabic];
+
+  // When
+  MDCAlertAction *shortAction = [MDCAlertAction actionWithTitle:kTitleShortArabic handler:nil];
+  MDCAlertAction *longAction = [MDCAlertAction actionWithTitle:kMessageLongArabic handler:nil];
+  [controller addAction:shortAction];
+  [controller addAction:longAction];
+  controller.view.frame = CGRectMake(0, 0, 300, 300);
+  [self changeToRTL:controller];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:controller.view];
+}
+
 - (void)testDefaultPresentationStyleWithShortTitleShortMessageLatinOniOS13 {
   // When
   UIWindow *window = [[[UIApplication sharedApplication] delegate] window];

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60add62f5d669e46833d8ca7889fd41a44b9196ea150c9a53d4cc0fc86024fb4
+size 21399

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ff9b4e666d56c510df9d6cc43384f2c34d0a2e0070341dbb2c3f485b0d5563b
+size 47721

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerSnapshotTests/testAlertWithLongButtonTitlesRTL_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ff9b4e666d56c510df9d6cc43384f2c34d0a2e0070341dbb2c3f485b0d5563b
-size 47721
+oid sha256:7b2fd16226f8e4becfd6697b9a92f03936e4306d17379559224bc039c0566936
+size 28157


### PR DESCRIPTION
Adds snapshot tests for very long action titles. Issue #9150 documents that
the action buttons are not correctly truncated when the title is too long.

Preparation for #9150