### PR TITLE
[Chips] Add chipFieldShouldBeginEditing method to MDCChipFieldDelegate

### DIFF
--- a/components/Chips/src/MDCChipField.h
+++ b/components/Chips/src/MDCChipField.h
@@ -163,6 +163,13 @@ typedef NS_OPTIONS(NSUInteger, MDCChipFieldDelimiter) {
 @optional
 
 /**
+ Asks the delegate if editing should begin in the specified chip field.
+
+ @param chipField The @c MDCChipField where is about to begin.
+ */
+- (BOOL)chipFieldShouldBeginEditing:(nonnull MDCChipField *)chipField;
+
+/**
  Tells the delegate that editing began in the specified chip field.
 
  @param chipField The MDCChipField where editing began.

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -569,13 +569,19 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 #pragma mark - UITextFieldDelegate
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
-  if (textField == self.textField) {
-    [self deselectAllChips];
+  BOOL shouldBeginEditing = YES;
+  if ([self.delegate respondsToSelector:@selector(chipFieldShouldBeginEditing:)]) {
+    shouldBeginEditing = [self.delegate chipFieldShouldBeginEditing:self];
   }
-  if ([self.delegate respondsToSelector:@selector(chipFieldDidBeginEditing:)]) {
-    [self.delegate chipFieldDidBeginEditing:self];
+  if (shouldBeginEditing) {
+    if (textField == self.textField) {
+      [self deselectAllChips];
+    }
+    if ([self.delegate respondsToSelector:@selector(chipFieldDidBeginEditing:)]) {
+      [self.delegate chipFieldDidBeginEditing:self];
+    }
   }
-  return YES;
+  return shouldBeginEditing;
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField {

--- a/components/Chips/tests/unit/ChipsDelegateTests.m
+++ b/components/Chips/tests/unit/ChipsDelegateTests.m
@@ -72,7 +72,8 @@
   self.delegateShouldBeginEditing = NO;
 
   // When
-  BOOL shouldBeginEditing = [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
+  BOOL shouldBeginEditing =
+      [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
 
   // Then
   XCTAssertFalse(shouldBeginEditing);
@@ -84,7 +85,8 @@
   self.delegateShouldBeginEditing = YES;
 
   // When
-  BOOL shouldBeginEditing = [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
+  BOOL shouldBeginEditing =
+      [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
 
   // Then
   XCTAssertTrue(shouldBeginEditing);

--- a/components/Chips/tests/unit/ChipsDelegateTests.m
+++ b/components/Chips/tests/unit/ChipsDelegateTests.m
@@ -22,6 +22,8 @@
 
 @property(nonatomic, nullable) MDCChipField *chip;
 @property(nonatomic, copy, nullable) NSString *delegateTextInput;
+@property(nonatomic) BOOL delegateShouldBeginEditing;
+@property(nonatomic) BOOL delegateDidBeginEditingCalled;
 
 @end
 
@@ -32,12 +34,15 @@
   self.delegateTextInput = nil;
   self.chip = [[MDCChipField alloc] init];
   self.chip.delegate = self;
+  self.delegateShouldBeginEditing = YES;
 }
 
 - (void)tearDown {
   self.delegateTextInput = nil;
   self.chip.delegate = nil;
   self.chip = nil;
+  self.delegateShouldBeginEditing = YES;
+  self.delegateDidBeginEditingCalled = NO;
   [super tearDown];
 }
 
@@ -62,10 +67,42 @@
   XCTAssertEqual((unsigned long)self.delegateTextInput.length, 0UL);
 }
 
+- (void)testDelegateShouldNotBeginEditingDoesNotTriggerDidBeginEditing {
+  // Given
+  self.delegateShouldBeginEditing = NO;
+
+  // When
+  BOOL shouldBeginEditing = [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
+
+  // Then
+  XCTAssertFalse(shouldBeginEditing);
+  XCTAssertFalse(self.delegateDidBeginEditingCalled);
+}
+
+- (void)testShouldBeginEditingTriggersDidBeginEditing {
+  // Given
+  self.delegateShouldBeginEditing = YES;
+
+  // When
+  BOOL shouldBeginEditing = [self.chip.textField.delegate textFieldShouldBeginEditing:self.chip.textField];
+
+  // Then
+  XCTAssertTrue(shouldBeginEditing);
+  XCTAssertTrue(self.delegateDidBeginEditingCalled);
+}
+
 #pragma mark - MDCChipFieldDelegate
 
 - (void)chipField:(nonnull MDCChipField *)chipField didChangeInput:(nullable NSString *)input {
   self.delegateTextInput = input;
+}
+
+- (BOOL)chipFieldShouldBeginEditing:(MDCChipField *)chipField {
+  return self.delegateShouldBeginEditing;
+}
+
+- (void)chipFieldDidBeginEditing:(MDCChipField *)chipField {
+  self.delegateDidBeginEditingCalled = YES;
 }
 
 @end


### PR DESCRIPTION
Adds `chipFieldShouldBeginEditing` to `MDCChipFieldDelegate` to control whether a `MDCChipField` can begin editing.

Fixes #7106