### PR TITLE
[Chips] Fix calculation of accessory frame.

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -727,7 +727,8 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
   if (self.showAccessoryView) {
     size = [self sizeForAccessoryViewWithMaxSize:self.contentRect.size];
   }
-  CGFloat xOffset = CGRectGetMaxX(self.contentRect) - size.width - _accessoryPadding.right;
+  CGFloat xOffset =
+      CGRectGetMaxX(self.contentRect) - size.width - UIEdgeInsetsHorizontal(_accessoryPadding);
   return MDCChipBuildFrame(_accessoryPadding, size, xOffset, CGRectGetHeight(self.frame),
                            self.pixelScale);
 }

--- a/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewSnapshotTests.m
@@ -183,6 +183,110 @@
   [self generateSnapshotAndVerifyForView:self.chip];
 }
 
+- (void)testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingLTR {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(10, 10, 0, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingRTL {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+  if (@available(iOS 10.0, *)) {
+    self.chip.traitCollectionOverride = [UITraitCollection
+        traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+  }
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(10, 10, 0, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingLTR {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(0, 0, 10, 10);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingRTL {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+  if (@available(iOS 10.0, *)) {
+    self.chip.traitCollectionOverride = [UITraitCollection
+        traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+  }
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(0, 0, 10, 10);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingLTR {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(-6, -6, 0, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingRTL {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+  if (@available(iOS 10.0, *)) {
+    self.chip.traitCollectionOverride = [UITraitCollection
+        traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+  }
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(-6, -6, 0, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingLTR {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(0, 0, -6, -6);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
+- (void)testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingRTL {
+  // Given
+  self.chip.accessoryView = [self deleteButton];
+  if (@available(iOS 10.0, *)) {
+    self.chip.traitCollectionOverride = [UITraitCollection
+        traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+  }
+
+  // When
+  self.chip.accessoryPadding = UIEdgeInsetsMake(0, 0, -6, -6);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chip];
+}
+
 - (void)testBaselineThemedChipWithAccessoryViewLTR {
   // When
   self.chip.accessoryView = [self deleteButton];

--- a/components/Chips/tests/unit/MDCChipViewTests.m
+++ b/components/Chips/tests/unit/MDCChipViewTests.m
@@ -22,6 +22,74 @@
 
 @implementation MDCChipViewTests
 
+- (void)testPositiveAccessoryPaddingTopIncreasesChipHeight {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  UIView *accessoryView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+  chipView.accessoryView = accessoryView;
+  CGSize originalSize = [chipView sizeThatFits:CGRectInfinite.size];
+
+  // When
+  chipView.accessoryPadding = UIEdgeInsetsMake(10, 0, 0, 0);
+  CGSize fitSize = [chipView sizeThatFits:CGRectInfinite.size];
+  CGSize expectedSize =
+      CGSizeMake(originalSize.width, originalSize.height + chipView.accessoryPadding.top);
+
+  // Then
+  XCTAssertEqualWithAccuracy(fitSize.height, expectedSize.height, 0.001);
+}
+
+- (void)testPositiveAccessoryPaddingLeftIncreasesChipWidth {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  UIView *accessoryView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+  chipView.accessoryView = accessoryView;
+  CGSize originalSize = [chipView sizeThatFits:CGRectInfinite.size];
+
+  // When
+  chipView.accessoryPadding = UIEdgeInsetsMake(0, 10, 0, 0);
+  CGSize fitSize = [chipView sizeThatFits:CGRectInfinite.size];
+  CGSize expectedSize =
+      CGSizeMake(originalSize.width + chipView.accessoryPadding.left, originalSize.height);
+
+  // Then
+  XCTAssertEqualWithAccuracy(fitSize.width, expectedSize.width, 0.001);
+}
+
+- (void)testPositiveAccessoryPaddingBottomIncreasesChipHeight {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  UIView *accessoryView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+  chipView.accessoryView = accessoryView;
+  CGSize originalSize = [chipView sizeThatFits:CGRectInfinite.size];
+
+  // When
+  chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 10, 0);
+  CGSize fitSize = [chipView sizeThatFits:CGRectInfinite.size];
+  CGSize expectedSize =
+      CGSizeMake(originalSize.width, originalSize.height + chipView.accessoryPadding.bottom);
+
+  // Then
+  XCTAssertEqualWithAccuracy(fitSize.height, expectedSize.height, 0.001);
+}
+
+- (void)testPositiveAccessoryPaddingRightIncreasesChipWidth {
+  // Given
+  MDCChipView *chipView = [[MDCChipView alloc] init];
+  UIView *accessoryView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+  chipView.accessoryView = accessoryView;
+  CGSize originalSize = [chipView sizeThatFits:CGRectInfinite.size];
+
+  // When
+  chipView.accessoryPadding = UIEdgeInsetsMake(0, 0, 0, 10);
+  CGSize fitSize = [chipView sizeThatFits:CGRectInfinite.size];
+  CGSize expectedSize =
+      CGSizeMake(originalSize.width + chipView.accessoryPadding.right, originalSize.height);
+
+  // Then
+  XCTAssertEqualWithAccuracy(fitSize.width, expectedSize.width, 0.001);
+}
+
 #pragma mark - MaterialElevation
 
 - (void)testDefaultValueForOverrideBaseElevationIsNegative {

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5e1dbca09885ebd3a99488a3b553b896b20afc5bbd35ae9a87d1eb2dfeb0b66
+size 4035

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeBottomRightAccessoryPaddingRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c67b5c79b197997c377c744ac65267363f02472dd2de491a765d3347ad6a5325
+size 4083

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18adf806eba37ce42ebc8afbb6c577eb3cb0c081c0f7228b6547dd258e6aa6b4
+size 4088

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndNegativeTopLeftAccessoryPaddingRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c383a323b39d2aed52ab10e78120ffd54c0f64482098a531ea97d143bee19a8
+size 4068

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bd4d20db32e821288057b6f3c9b58d687720059c820d4e2395136d005af025a
+size 4400

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveBottomRightAccessoryPaddingRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01619e29d0f55b814a7e3b9141daf66c8bcd5fea86ece68bba0439faf7468b99
+size 4434

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:465f93fa9bfd9bd3d5437323e5f22f90bf9772057f0ce562caae6255eac8cbc5
+size 4440

--- a/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewSnapshotTests/testDefaultChipWithAccessoryViewAndPositiveTopLeftAccessoryPaddingRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efd888d0f6d58feea401077a33af67625935e6ecc3cdb1a1d9285843d578f35a
+size 4459


### PR DESCRIPTION
The accessory view's frame was incorrectly calculated by ignoring its `.left`
padding value. This would result in the padding being added twice when the
Chip was sized and laid-out.

Preparation for #7940