### PR TITLE
[Dialogs] Revert Set dialog message accessibilityFrame based on visible message text (#8786)

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -673,12 +673,6 @@ static const CGFloat MDCDialogMessageOpacity = (CGFloat)0.54;
         CGRectGetHeight(self.bounds) - actionsScrollViewRect.size.height;
     self.contentScrollView.frame = contentScrollViewRect;
   }
-
-  CGRect messageFrameInWindow = [self convertRect:self.messageLabel.frame toView:self.window];
-  CGRect contentScrollFrameInWindow = [self convertRect:self.contentScrollView.frame
-                                                 toView:self.window];
-  CGRect visibleMessageRect = CGRectIntersection(messageFrameInWindow, contentScrollFrameInWindow);
-  self.messageLabel.accessibilityFrame = visibleMessageRect;
 }
 
 #pragma mark - Dynamic Type


### PR DESCRIPTION
This reverts commit c83333f56518399f374b1b8914eac0d853fa20da to address issue where dialog messages are not properly displayed during rotation while VoiceOver is on.

Fixes internal issue b/145722771