### PR TITLE
[TextFields] Deprecate MDCTextFieldFontThemer

### DIFF
--- a/components/TextFields/src/FontThemer/MDCTextFieldFontThemer.h
+++ b/components/TextFields/src/FontThemer/MDCTextFieldFontThemer.h
@@ -23,15 +23,9 @@
 
 /**
  Used to apply a font scheme to theme a MDCTextField/MDCTextInputController.
-
- @warning This API will eventually be deprecated. See the individual method documentation for
- details on replacement APIs.
- Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCTextFieldFontThemer : NSObject
-@end
-
-@interface MDCTextFieldFontThemer (ToBeDeprecated)
+__deprecated_msg("Use MaterialTextFields+Theming instead.") @interface MDCTextFieldFontThemer
+    : NSObject
 
 /**
  Applies a font scheme to theme a MDCTextInputController instance.

--- a/components/TextFields/src/FontThemer/MDCTextFieldFontThemer.m
+++ b/components/TextFields/src/FontThemer/MDCTextFieldFontThemer.m
@@ -17,7 +17,10 @@
 #import "MaterialTextFields.h"
 #import "MaterialThemes.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCTextFieldFontThemer
+#pragma clang diagnostic pop
 
 + (void)applyFontScheme:(id<MDCFontScheme>)fontScheme
     toTextInputController:(id<MDCTextInputController>)textInputController {

--- a/components/TextFields/tests/unit/TextFieldsFontThemerTests.m
+++ b/components/TextFields/tests/unit/TextFieldsFontThemerTests.m
@@ -24,6 +24,9 @@
 
 @implementation TextFieldsFontThemerTests
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 - (void)tearDown {
   [super tearDown];
   // Reset class default values.
@@ -107,5 +110,7 @@
   XCTAssertEqual([floatingInputController.floatingPlaceholderScale doubleValue],
                  fontScheme.caption.pointSize / fontScheme.body1.pointSize);
 }
+
+#pragma clang diagnostic pop
 
 @end


### PR DESCRIPTION
Marks currently to-be-deprecated `MDCTextFieldFontThemer` as deprecated. There is no internal usage.

Part of #9088 