### PR TITLE
[Buttons] Deprecate MDCOutlinedButtonThemer

### DIFF
--- a/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MDCOutlinedButtonThemer.h
@@ -23,10 +23,8 @@
  `MDCButton`'s `-applyOutlinedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCOutlinedButtonThemer : NSObject
-@end
-
-@interface MDCOutlinedButtonThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCButton applyOutlinedThemeWithScheme:] instead.")
+    @interface MDCOutlinedButtonThemer : NSObject
 
 /**
  Applies a button scheme's properties to an MDCButton using the outlined button style.


### PR DESCRIPTION
## Description

Deprecate symbol: MDCOutlinedButtonThemer(ToBeDeprecated)::applyScheme:toButton:

## Issue

b/145204562 Delete symbol "MDCOutlinedButtonThemer(ToBeDeprecated)::applyScheme:toButton:"

Note: no internal dependencies, or dependencies are being migrated.