### PR TITLE
[Buttons] Deprecate MDCButtonColorThemer

### DIFF
--- a/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
+++ b/components/Buttons/src/ColorThemer/MDCButtonColorThemer.h
@@ -26,10 +26,8 @@
  @c MDC*ButtonColorThemer classes instead. Learn more at
  components/schemes/Color/docs/migration-guide-semantic-color-scheme.md
  */
-@interface MDCButtonColorThemer : NSObject
-@end
-
-@interface MDCButtonColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use the MDCButton+MaterialTheming API instead.")
+    @interface MDCButtonColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCButton.


### PR DESCRIPTION
## Description

Deprecate symbol MDCButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145204560 - Delete symbol "MDCButtonColorThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:"

Tested=cl/284580146