### PR TITLE
[Buttons] Deprecating MDCContainedButtonThemer

### DIFF
--- a/components/Buttons/src/ButtonThemer/MDCContainedButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MDCContainedButtonThemer.h
@@ -25,10 +25,8 @@
  `MDCButton`'s `-applyContainedThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCContainedButtonThemer : NSObject
-@end
-
-@interface MDCContainedButtonThemer (ToBeDeprecated)
+__deprecated_msg("Please use MDCButton:applyContainedThemeWithScheme: instead.")
+    @interface MDCContainedButtonThemer : NSObject
 
 /**
  Applies a button scheme's properties to an MDCButton using the contained button style.


### PR DESCRIPTION
## Description

Deprecate symbol MDCContainedButtonThemer(ToBeDeprecated)::applyScheme:toButton:

## Issue

b/145204044 - Delete symbol "MDCContainedButtonThemer(ToBeDeprecated)::applyScheme:toButton:"

TESTED=cl/284582939