### PR TITLE
[Buttons] Deprecate MDCTextButtonThemer

### DIFF
--- a/components/Buttons/src/ButtonThemer/MDCTextButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MDCTextButtonThemer.h
@@ -25,10 +25,8 @@
  `MDCButton`'s `-applyTextThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCTextButtonThemer : NSObject
-@end
-
-@interface MDCTextButtonThemer (ToBeDeprecated)
+__deprecated_msg("Please use MDCButton:applyTextThemeWithScheme: instead.")
+    @interface MDCTextButtonThemer : NSObject
 
 /**
  Applies a button scheme's properties to an MDCButton using the text button style.


### PR DESCRIPTION
## Description

Deprecate symbol MDCTextButtonThemer(ToBeDeprecated)::applySemanticColorScheme:toButton:

## Issue

b/145205089 - Delete symbol "MDCTextButtonThemer(ToBeDeprecated)::applyScheme:toButton:"