### PR TITLE
[Buttons] Deprecate MDCFloatingActionButtonThemer

### DIFF
--- a/components/Buttons/src/ButtonThemer/MDCFloatingActionButtonThemer.h
+++ b/components/Buttons/src/ButtonThemer/MDCFloatingActionButtonThemer.h
@@ -25,10 +25,8 @@
  `MDCFloatingButton`'s `-applySecondaryThemeWithScheme:`
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCFloatingActionButtonThemer : NSObject
-@end
-
-@interface MDCFloatingActionButtonThemer (ToBeDeprecated)
+__deprecated_msg("Please use [MDCFloatingButton applySecondaryThemeWithScheme:] instead.")
+    @interface MDCFloatingActionButtonThemer : NSObject
 
 /**
  Applies a button scheme's properties to an MDCRaisedButton using the floating button style.


### PR DESCRIPTION
## Description

Deprecate symbol MDCFloatingActionButtonThemer(ToBeDeprecated)::applyScheme:toButton:

## Issue

b/145205425 Delete symbol "MDCFloatingActionButtonThemer(ToBeDeprecated)::applyScheme:toButton:"

Note: no internal dependencies