### PR TITLE
[Buttons] Deprecating MDCButtonTypographyThemer

### DIFF
--- a/components/Buttons/src/TypographyThemer/MDCButtonTypographyThemer.h
+++ b/components/Buttons/src/TypographyThemer/MDCButtonTypographyThemer.h
@@ -24,10 +24,9 @@
  `MDCFloatingButton`'s Theming extensions.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCButtonTypographyThemer : NSObject
-@end
-
-@interface MDCButtonTypographyThemer (ToBeDeprecated)
+__deprecated_msg("Please use MDCButton+MaterialTheming instead. (Note: Typography theming"
+                 "is no longer available as an independent API.)")
+    @interface MDCButtonTypographyThemer : NSObject
 
 /**
  Applies a typography scheme's properties to an MDCButton.


### PR DESCRIPTION
## Description

Deprecate symbol MDCButtonTypographyThemer(ToBeDeprecated)::applyTypographyScheme:toButton:

## Issue

b/145204500 - Delete symbol "MDCButtonTypographyThemer(ToBeDeprecated)::applyTypographyScheme:toButton:"

TESTED=cl/284660452