### PR TITLE
[List] Remove usage of MDCListTypographyThemer within Theming Extension for Stereo Cell

### DIFF
--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -67,8 +67,8 @@ mdc_extension_objc_library(
     name = "Theming",
     deps = [
         ":List",
-        ":ColorThemer",
-        ":TypographyThemer",
+        "//components/Typography",
+        "//components/schemes/Color",
         "//components/schemes/Container",
     ],
 )

--- a/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
+++ b/components/List/src/Theming/MDCSelfSizingStereoCell+MaterialTheming.m
@@ -14,7 +14,7 @@
 
 #import "MDCSelfSizingStereoCell+MaterialTheming.h"
 
-#import "MaterialList+TypographyThemer.h"
+#import "MaterialTypography.h"
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kInkAlpha = (CGFloat)0.16;
@@ -49,7 +49,16 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
 }
 
 - (void)applyThemeWithTypographyScheme:(id<MDCTypographyScheming>)typographyScheme {
-  [MDCListTypographyThemer applyTypographyScheme:typographyScheme toSelfSizingStereoCell:self];
+  UIFont *titleFont = typographyScheme.subtitle1;
+  UIFont *detailFont = typographyScheme.body2;
+
+  if (typographyScheme.useCurrentContentSizeCategoryWhenApplied) {
+    titleFont = [titleFont mdc_scaledFontForTraitEnvironment:self];
+    detailFont = [detailFont mdc_scaledFontForTraitEnvironment:self];
+  }
+
+  self.titleLabel.font = titleFont;
+  self.detailLabel.font = detailFont;
 }
 
 @end


### PR DESCRIPTION
# Description

Removing calls to MDCListTypographyThemer from within our library. 

# Issue 

b/145204420 Delete symbol "MDCListTypographyThemer(ToBeDeprecated)::applyTypographyScheme:toSelfSizingStereoCell:"