### PR TITLE
[TextFields] deprecate MDCOutlinedTextFieldColorThemer

### DIFF
--- a/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.h
+++ b/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.h
@@ -24,10 +24,9 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCOutlinedTextFieldColorThemer : NSObject
-@end
 
-@interface MDCOutlinedTextFieldColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use the Theming extension on MDCTextInputControllerOutlined instead.")
+    @interface MDCOutlinedTextFieldColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to a text field using the outlined style.

--- a/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.m
+++ b/components/TextFields/src/ColorThemer/MDCOutlinedTextFieldColorThemer.m
@@ -20,7 +20,10 @@ static CGFloat const kOutlinedTextFieldOnSurfaceAlpha = (CGFloat)0.6;
 static CGFloat const kOutlinedTextFieldDisabledAlpha = (CGFloat)0.38;
 static CGFloat const kOutlinedTextFieldIconAlpha = (CGFloat)0.54;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCOutlinedTextFieldColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
            toTextInputController:(id<MDCTextInputController>)textInputController {


### PR DESCRIPTION
Related to #9080, should be merged after #9214.