### PR TITLE
[Banner] Fix height when no action button shows.

### DIFF
--- a/components/Banner/src/MDCBannerView.m
+++ b/components/Banner/src/MDCBannerView.m
@@ -358,17 +358,22 @@ static NSString *const kMDCBannerViewImageViewImageKeyPath = @"image";
   switch (layoutStyle) {
     case MDCBannerViewLayoutStyleSingleRow: {
       frameHeight += kTopPaddingSmall + kBottomPadding;
-      [self.leadingButton sizeToFit];
-      CGFloat buttonWidth = CGRectGetWidth(self.leadingButton.frame);
       CGFloat widthLimit = contentSize.width;
-      widthLimit -= (buttonWidth + kHorizontalSpaceBetweenTextViewAndButton);
+      if (!self.leadingButton.hidden) {
+        [self.leadingButton sizeToFit];
+        CGFloat buttonWidth = CGRectGetWidth(self.leadingButton.frame);
+        widthLimit -= (buttonWidth + kHorizontalSpaceBetweenTextViewAndButton);
+      }
       if (!self.imageView.hidden) {
         widthLimit -= kImageViewSideLength;
         widthLimit -= kSpaceBetweenIconImageAndTextView;
       }
       CGSize textViewSize = [self.textView sizeThatFits:CGSizeMake(widthLimit, CGFLOAT_MAX)];
-      CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
-      CGFloat maximumHeight = MAX(textViewSize.height, leadingButtonSize.height);
+      CGFloat maximumHeight = textViewSize.height;
+      if (!self.leadingButton.hidden) {
+        CGSize leadingButtonSize = [self.leadingButton sizeThatFits:CGSizeZero];
+        maximumHeight = MAX(leadingButtonSize.height, maximumHeight);
+      }
       if (!self.imageView.hidden) {
         maximumHeight = MAX(kImageViewSideLength, maximumHeight);
       }

--- a/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testShortTextWithNoAction_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBannerViewSnapshotTests/testShortTextWithNoAction_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:988a344bc6392ccbd980f291c8c324a4645038c7d31acb2482c55cdea84a903c
-size 6487
+oid sha256:aa7b9ab9a67ab85aaca11c33b676b9e3f311a6f53f34c331ffe02b10d85f4ab1
+size 5895


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/9217.

`leadingButton`'s height shouldn't be taken into consideration when it is hidden.