### PR TITLE
Release cut adjustment to generated change log

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -262,8 +262,8 @@ release candidate.
 
 ## Consider running `scripts/release notes` again
 
-Run `scripts/release notes` again and copy paste it into the `CHANGELOG.md` after `## Changes` if
-you
+Run `scripts/release notes` again and copy paste it into the `CHANGELOG.md` after
+`## Component changes` if you
 
 * cherry picked a change to add it to the release or
 * reverted any commit to rollback any PR.

--- a/scripts/release
+++ b/scripts/release
@@ -707,11 +707,6 @@ generate_release_notes() {
     if [[ $(changes_for_path "$folder" | filter_non_breaking_changes) ]]; then
       component=$(echo $folder | cut -d'/' -f2-)
 
-      if [ "$has_non_breaking_changes" = false ]; then
-        has_non_breaking_changes=true
-        echo
-        echo "## Changes"
-      fi
       echo
       echo "### $component"
       echo


### PR DESCRIPTION
Removed `## Changes` heading from the auto generated changes in release cut script because heading is a duplicate of the one above it.