### PR TITLE
[FeatureHighlight] Don't use MDCFeatureHighlightTypographyThemer in examples

### DIFF
--- a/components/FeatureHighlight/BUILD
+++ b/components/FeatureHighlight/BUILD
@@ -100,7 +100,6 @@ mdc_examples_objc_library(
         ":ColorThemer",
         ":FeatureHighlight",
         ":FeatureHighlightAccessibilityMutator",
-        ":TypographyThemer",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
         "//components/Buttons:Theming",
@@ -119,7 +118,6 @@ mdc_examples_swift_library(
     deps = [
         ":ColorThemer",
         ":FeatureHighlight",
-        ":TypographyThemer",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
         "//components/schemes/Color",

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -16,7 +16,6 @@
 #import "MaterialButtons.h"
 #import "MaterialFeatureHighlight+ColorThemer.h"
 #import "MaterialFeatureHighlight+FeatureHighlightAccessibilityMutator.h"
-#import "MaterialFeatureHighlight+TypographyThemer.h"
 #import "MaterialFeatureHighlight.h"
 #import "supplemental/FeatureHighlightExampleSupplemental.h"
 

--- a/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightShownViewExample.m
@@ -58,8 +58,8 @@
   [MDCFeatureHighlightAccessibilityMutator mutate:vc];
   [MDCFeatureHighlightColorThemer applySemanticColorScheme:self.colorScheme
                           toFeatureHighlightViewController:vc];
-  [MDCFeatureHighlightTypographyThemer applyTypographyScheme:self.typographyScheme
-                            toFeatureHighlightViewController:vc];
+  vc.titleFont = self.typographyScheme.headline6;
+  vc.bodyFont = self.typographyScheme.body2;
   vc.titleText = @"Shown views can be interactive";
   vc.bodyText = @"The shown button has custom tap animations.";
   [self presentViewController:vc animated:YES completion:nil];

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "MaterialFeatureHighlight+ColorThemer.h"
-#import "MaterialFeatureHighlight+TypographyThemer.h"
 #import "MaterialFeatureHighlight.h"
 #import "supplemental/FeatureHighlightExampleSupplemental.h"
 

--- a/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
+++ b/components/FeatureHighlight/examples/FeatureHighlightTypicalUseViewController.m
@@ -34,9 +34,8 @@
       [[MDCFeatureHighlightViewController alloc] initWithHighlightedView:_button completion:nil];
   [MDCFeatureHighlightColorThemer applySemanticColorScheme:self.colorScheme
                           toFeatureHighlightViewController:vc];
-  [MDCFeatureHighlightTypographyThemer applyTypographyScheme:self.typographyScheme
-                            toFeatureHighlightViewController:vc];
-
+  vc.titleFont = self.typographyScheme.headline6;
+  vc.bodyFont = self.typographyScheme.body2;
   vc.mdc_adjustsFontForContentSizeCategory = YES;
 
   vc.titleText = @"Hey this is a multi-line title for the Feature Highlight";

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -60,7 +60,8 @@ class FeatureHighlightSwiftViewController: UIViewController {
     let vc = MDCFeatureHighlightViewController(highlightedView: featureButton,
                                                completion: nil)
     MDCFeatureHighlightColorThemer.applySemanticColorScheme(colorScheme, to: vc)
-    MDCFeatureHighlightTypographyThemer.applyTypographyScheme(typographyScheme, to: vc)
+    vc.titleFont = typographyScheme.headline6
+    vc.bodyFont = typographyScheme.body2
     vc.mdc_adjustsFontForContentSizeCategory = true
     vc.titleText = "Hey this is a title for the Feature Highlight"
     vc.bodyText = "This is the description of the feature highlight view controller"

--- a/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
+++ b/components/FeatureHighlight/examples/FeatureHightlightTypicalUseViewController.swift
@@ -17,7 +17,6 @@ import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialFeatureHighlight
 import MaterialComponents.MaterialFeatureHighlight_ColorThemer
-import MaterialComponents.MaterialFeatureHighlight_TypographyThemer
 import MaterialComponents.MaterialTypographyScheme
 
 /// Example to show how to use a feature highlight


### PR DESCRIPTION
Related to #9208. Removes usage of MDCFeatureHighlightTypographyThemer from examples.