### PR TITLE
[Tabs] Fix examples.

### DIFF
--- a/components/Tabs/examples/TabBarIconExample.m
+++ b/components/Tabs/examples/TabBarIconExample.m
@@ -21,7 +21,6 @@
 
 @interface TabBarIconExample ()
 @property(nonatomic, strong) UIBarButtonItem *addStarButtonItem;
-@property(nonatomic, strong) MDCContainerScheme *containerScheme;
 @end
 
 @implementation TabBarIconExample

--- a/components/Tabs/examples/TabBarInterfaceBuilderExample.m
+++ b/components/Tabs/examples/TabBarInterfaceBuilderExample.m
@@ -29,8 +29,8 @@
 
 @implementation TabBarInterfaceBuilderExample
 
-- (id)init {
-  self = [super init];
+- (id)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
   if (self) {
     _containerScheme = [[MDCContainerScheme alloc] init];
   }

--- a/components/Tabs/examples/TabBarTextOnlyExample.m
+++ b/components/Tabs/examples/TabBarTextOnlyExample.m
@@ -28,8 +28,8 @@
 - (id)initWithCollectionViewLayout:(UICollectionViewLayout *)layout {
   self = [super initWithCollectionViewLayout:layout];
   if (self) {
-    [self setupExampleViews:@[ @"Change Alignment", @"Toggle Case", @"Clear Selection" ]];
     _containerScheme = [[MDCContainerScheme alloc] init];
+    [self setupExampleViews:@[ @"Change Alignment", @"Toggle Case", @"Clear Selection" ]];
   }
   return self;
 }

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.h
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.h
@@ -22,6 +22,7 @@
 #import "MaterialAppBar.h"
 #import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
+#import "MaterialContainerScheme.h"
 #import "MaterialTabs.h"
 #import "MaterialTypographyScheme.h"
 
@@ -30,8 +31,7 @@
 @property(nonatomic, nullable) MDCTabBar *tabBar;
 @property(nonatomic, nullable) MDCButton *alignmentButton;
 @property(nonatomic, nullable) MDCAppBarViewController *appBarViewController;
-@property(nonatomic, nullable) MDCSemanticColorScheme *colorScheme;
-@property(nonatomic, nullable) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, nullable) MDCContainerScheme *containerScheme;
 @property(nonatomic, nullable) UIScrollView *scrollView;
 @property(nonatomic, nullable) UIView *starPage;
 @end

--- a/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
+++ b/components/Tabs/examples/supplemental/TabBarIconExampleSupplemental.m
@@ -40,15 +40,16 @@
 
   [self setupAlignmentButton];
 
-  [MDCTabBarTypographyThemer applyTypographyScheme:self.typographyScheme toTabBar:self.tabBar];
+  [MDCTabBarTypographyThemer applyTypographyScheme:self.containerScheme.typographyScheme
+                                          toTabBar:self.tabBar];
 }
 
 - (void)setupAlignmentButton {
   self.alignmentButton = [[MDCButton alloc] init];
 
   MDCButtonScheme *buttonScheme = [[MDCButtonScheme alloc] init];
-  buttonScheme.colorScheme = self.colorScheme;
-  buttonScheme.typographyScheme = self.typographyScheme;
+  buttonScheme.colorScheme = self.containerScheme.colorScheme;
+  buttonScheme.typographyScheme = self.containerScheme.typographyScheme;
   [MDCContainedButtonThemer applyScheme:buttonScheme toButton:self.alignmentButton];
 
   [self.view addSubview:self.alignmentButton];
@@ -90,9 +91,9 @@
   [self.view addSubview:self.appBarViewController.view];
   [self.appBarViewController didMoveToParentViewController:self];
 
-  [MDCAppBarColorThemer applyColorScheme:self.colorScheme
+  [MDCAppBarColorThemer applyColorScheme:self.containerScheme.colorScheme
                   toAppBarViewController:self.appBarViewController];
-  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.containerScheme.typographyScheme
                             toAppBarViewController:self.appBarViewController];
 }
 


### PR DESCRIPTION
Mostly crash fixes. Corrects button theming for the `TabBarIconExample` as
well.

|Before|After|
|---|---|
|![Tabs Icon example showing white-on-white text.](https://user-images.githubusercontent.com/1753199/70561186-fda86e00-1b57-11ea-8510-d5295f3ec265.png)|![Tabs Icon example showing white-on-purple text](https://user-images.githubusercontent.com/1753199/70561201-07ca6c80-1b58-11ea-80b7-c74d263dbe75.png)|

Found after #9125