### PR TITLE
[ActionSheet] Remove equality check when setting rippleColor to prevent crashes stemming from CIColor

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -523,11 +523,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 }
 
 - (void)setRippleColor:(UIColor *)rippleColor {
-  if (_rippleColor == rippleColor || [_rippleColor isEqual:rippleColor]) {
-    return;
-  }
   _rippleColor = rippleColor;
-
   [self.tableView reloadData];
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -148,6 +148,20 @@
   }
 }
 
+- (void)testSetRippleColor {
+  // When
+  NSArray *colors = [MDCActionSheetTestHelper colorsToTest];
+
+  for (UIColor *color in colors) {
+    self.actionSheet.rippleColor = color;
+    NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
+    for (MDCActionSheetItemTableViewCell *cell in cells) {
+      // Then
+      XCTAssertEqualObjects(cell.rippleColor, color);
+    }
+  }
+}
+
 - (void)testSetActionFont {
   // Given
   UIFont *actionFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];


### PR DESCRIPTION
Comparing a non-`UICIColor` (e.g., a `UIExtendedSRGBColorSpace` UIColor) with a `UICIColor` crashes with the message:

> error: -[MDCActionSheetTableCellTest testSetRippleColor] : failed: caught "NSInvalidArgumentException", "-[UICIColor colorSpaceName]: unrecognized selector sent to instance 0x7ff1c02595b0"

Because of this, and the fact that this check is likely an unnecessary optimization (and because `isEqual:` does not return YES for UIColors from different color spaces, even if they have the same RGBA values), this PR removes the equality check.

Fixes #9236 