### PR TITLE
[ActionSheet] Delete inkColor and enableRippleBehavior properties

### DIFF
--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -38,7 +38,8 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   actionSheetController.actionTextColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
-  actionSheetController.rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
+  actionSheetController.rippleColor =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
 }
 
 @end

--- a/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
+++ b/components/ActionSheet/src/ColorThemer/MDCActionSheetColorThemer.m
@@ -38,12 +38,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   actionSheetController.actionTextColor =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
-  UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  actionSheetController.inkColor = rippleColor;
-#pragma clang diagnostic pop
-  actionSheetController.rippleColor = rippleColor;
+  actionSheetController.rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
 }
 
 @end

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -182,24 +182,6 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
 @property(nonatomic, strong, nullable) UIColor *actionTintColor;
 
 /**
- The ink color for the action items within an action sheet.
- */
-@property(nonatomic, strong, nullable)
-    UIColor *inkColor __deprecated_msg("Use rippleColor instead.");
-
-/**
- By setting this property to @c YES, the Ripple component will be used instead of Ink
- to display visual feedback to the user.
-
- @note This property is enabled by default. It will be deprecated and then deleted as part of our
- migration to Ripple. Learn more at
- https://github.com/material-components/material-components-ios/tree/develop/components/Ink#migration-guide-ink-to-ripple
-
- Defaults to YES.
- */
-@property(nonatomic, assign) BOOL enableRippleBehavior __deprecated;
-
-/**
  The ripple color for the action items within an action sheet.
  */
 @property(nonatomic, strong, nullable) UIColor *rippleColor;

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -140,7 +140,6 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
         [UIColor.blackColor colorWithAlphaComponent:kDividerDefaultAlpha];
     _mdc_overrideBaseElevation = -1;
     _elevation = MDCShadowElevationModalBottomSheet;
-    _enableRippleBehavior = YES;
   }
 
   return self;
@@ -325,11 +324,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   cell.backgroundColor = self.backgroundColor;
   cell.actionFont = self.actionFont;
   cell.accessibilityIdentifier = action.accessibilityIdentifier;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  cell.inkColor = self.inkColor;
-  cell.enableRippleBehavior = self.enableRippleBehavior;
-#pragma clang diagnostic pop
+  cell.enableRippleBehavior = YES;
   cell.rippleColor = self.rippleColor;
   cell.tintColor = action.tintColor ?: self.actionTintColor;
   cell.imageRenderingMode = self.imageRenderingMode;
@@ -513,26 +508,8 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   return NO;
 }
 
-- (UIColor *)inkColor {
-  return _inkColor;
-}
-
-- (void)setInkColor:(UIColor *)inkColor {
-  _inkColor = inkColor;
-  [self.tableView reloadData];
-}
-
 - (void)setRippleColor:(UIColor *)rippleColor {
   _rippleColor = rippleColor;
-  [self.tableView reloadData];
-}
-
-- (void)setEnableRippleBehavior:(BOOL)enableRippleBehavior {
-  if (_enableRippleBehavior == enableRippleBehavior) {
-    return;
-  }
-  _enableRippleBehavior = enableRippleBehavior;
-
   [self.tableView reloadData];
 }
 

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -19,7 +19,7 @@
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
-static const CGFloat kInkAlpha = (CGFloat)0.16;
+static const CGFloat kRippleAlpha = (CGFloat)0.16;
 
 @implementation MDCActionSheetController (MaterialTheming)
 
@@ -57,7 +57,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
   self.actionTintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   self.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
-  self.rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
+  self.rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kRippleAlpha];
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,

--- a/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
+++ b/components/ActionSheet/src/Theming/MDCActionSheetController+MaterialTheming.m
@@ -57,12 +57,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   self.imageRenderingMode = UIImageRenderingModeAlwaysTemplate;
   self.actionTintColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha];
   self.actionTextColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha];
-  UIColor *rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  self.inkColor = rippleColor;
-#pragma clang diagnostic pop
-  self.rippleColor = rippleColor;
+  self.rippleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha];
 #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
   if (@available(iOS 13.0, *)) {
     self.traitCollectionDidChangeBlock = ^(MDCActionSheetController *_Nonnull actionSheet,

--- a/components/ActionSheet/tests/unit/ActionSheetRippleTests.m
+++ b/components/ActionSheet/tests/unit/ActionSheetRippleTests.m
@@ -55,16 +55,11 @@
 /**
  Test to confirm behavior of initializing a @c MDCActionSheetController without any customization.
  */
-- (void)testRippleIsEnabledAndInkIsDisabledForAllCellsAndTheirPropertiesAreCorrect {
+- (void)testDefaultRipplePropertiesAreCorrect {
   // When
   NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheetController];
 
-// Then
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  XCTAssertTrue(self.actionSheetController.enableRippleBehavior);
-  XCTAssertEqualObjects(self.actionSheetController.inkColor, nil);
-#pragma clang diagnostic pop
+  // Then
   XCTAssertEqualObjects(self.actionSheetController.rippleColor, nil);
   for (MDCActionSheetItemTableViewCell *cell in cells) {
     XCTAssertTrue(cell.enableRippleBehavior);
@@ -83,60 +78,6 @@
     CGRect inkBounds = CGRectStandardize(cell.inkTouchController.defaultInkView.bounds);
     XCTAssertTrue(CGRectEqualToRect(cellBounds, inkBounds), @"%@ is not equal to %@",
                   NSStringFromCGRect(cellBounds), NSStringFromCGRect(inkBounds));
-  }
-}
-
-/**
- Test to confirm behavior of initializing a @c MDCActionSheetController with Ripple enabled.
- */
-- (void)
-    testRippleIsEnabledAndInkIsDisabledForAllCellsAndTheirPropertiesAreCorrectWhenRippleBehaviorIsEnabled {
-  // When
-  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheetController];
-
-// Then
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  XCTAssertTrue(self.actionSheetController.enableRippleBehavior);
-  XCTAssertEqualObjects(self.actionSheetController.inkColor, nil);
-#pragma clang diagnostic pop
-  XCTAssertEqualObjects(self.actionSheetController.rippleColor, nil);
-  for (MDCActionSheetItemTableViewCell *cell in cells) {
-    XCTAssertTrue(cell.enableRippleBehavior);
-    XCTAssertNotNil(cell.rippleTouchController);
-    XCTAssertNotNil(cell.inkTouchController);
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
-                          [[UIColor alloc] initWithWhite:0 alpha:(CGFloat)0.14]);
-    XCTAssertEqualObjects(cell.rippleTouchController.rippleView.rippleColor,
-                          [[UIColor alloc] initWithWhite:0 alpha:(CGFloat)0.14]);
-    XCTAssertEqual(cell.inkTouchController.defaultInkView.inkStyle, MDCInkStyleBounded);
-    XCTAssertEqual(cell.rippleTouchController.rippleView.rippleStyle, MDCRippleStyleBounded);
-    XCTAssertNotNil(cell.rippleTouchController.rippleView.superview);
-    XCTAssertNil(cell.inkTouchController.defaultInkView.superview);
-
-    CGRect cellBounds = CGRectStandardize(cell.bounds);
-    CGRect rippleBounds = CGRectStandardize(cell.rippleTouchController.rippleView.bounds);
-    XCTAssertTrue(CGRectEqualToRect(cellBounds, rippleBounds), @"%@ is not equal to %@",
-                  NSStringFromCGRect(cellBounds), NSStringFromCGRect(rippleBounds));
-  }
-}
-
-/**
- Test to confirm toggling @c enableRippleBehavior removes the @c rippleView as a subview.
- */
-- (void)testSetEnableRippleBehaviorToYesThenNoRemovesRippleViewAsSubviewOfCell {
-// When
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  self.actionSheetController.enableRippleBehavior = YES;
-  self.actionSheetController.enableRippleBehavior = NO;
-#pragma clang diagnostic pop
-  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheetController];
-
-  // Then
-  for (MDCActionSheetItemTableViewCell *cell in cells) {
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.superview, cell);
-    XCTAssertNil(cell.rippleTouchController.rippleView.superview);
   }
 }
 

--- a/components/ActionSheet/tests/unit/ActionSheetThemer/MDCActionSheetThemeTest.m
+++ b/components/ActionSheet/tests/unit/ActionSheetThemer/MDCActionSheetThemeTest.m
@@ -23,7 +23,6 @@
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
-static const CGFloat kInkAlpha = (CGFloat)0.16;
 
 @interface MDCActionSheetHeaderView (Testing)
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -193,8 +192,6 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
                           [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
     XCTAssertEqualObjects(cell.actionLabel.textColor,
                           [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
-                          [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha]);
   }
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -134,20 +134,6 @@
   }
 }
 
-- (void)testSetInkColor {
-  // When
-  NSArray *colors = [MDCActionSheetTestHelper colorsToTest];
-
-  for (UIColor *color in colors) {
-    self.actionSheet.inkColor = color;
-    NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
-    for (MDCActionSheetItemTableViewCell *cell in cells) {
-      // Then
-      XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor, color);
-    }
-  }
-}
-
 - (void)testSetRippleColor {
   // When
   NSArray *colors = [MDCActionSheetTestHelper colorsToTest];

--- a/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
@@ -35,7 +35,9 @@
   CIColor *ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
   UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
   UIColor *whiteColor = [UIColor colorWithWhite:(CGFloat)0.5 alpha:(CGFloat)0.5];
-  return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
+  NSArray *tmp = @[  rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
+  (void)tmp;
+  return @[ black, uiColorFromCIColor];
 }
 
 + (void)addNumberOfActions:(NSUInteger)actionsCount

--- a/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTestHelper.m
@@ -35,9 +35,7 @@
   CIColor *ciColor = [[CIColor alloc] initWithColor:UIColor.blackColor];
   UIColor *uiColorFromCIColor = [UIColor colorWithCIColor:ciColor];
   UIColor *whiteColor = [UIColor colorWithWhite:(CGFloat)0.5 alpha:(CGFloat)0.5];
-  NSArray *tmp = @[  rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
-  (void)tmp;
-  return @[ black, uiColorFromCIColor];
+  return @[ rgbColor, hsbColor, blackWithAlpha, black, uiColorFromCIColor, whiteColor ];
 }
 
 + (void)addNumberOfActions:(NSUInteger)actionsCount

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -21,7 +21,6 @@
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
-static const CGFloat kRippleAlpha = (CGFloat)0.16;
 
 @interface MDCActionSheetController (Testing)
 @property(nonatomic, strong) UITableView *tableView;
@@ -94,8 +93,6 @@ static const CGFloat kRippleAlpha = (CGFloat)0.16;
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kMediumAlpha]);
   XCTAssertEqualObjects(actionSheetCell.actionLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
-  XCTAssertEqualObjects(actionSheetCell.inkTouchController.defaultInkView.inkColor,
-                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kRippleAlpha]);
   XCTAssertEqualObjects(actionSheetCell.actionLabel.font, typographyScheme.subtitle1);
 
   // Elevation

--- a/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
+++ b/components/ActionSheet/tests/unit/Theming/MDCActionSheetThemingTest.m
@@ -21,7 +21,7 @@
 
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kMediumAlpha = (CGFloat)0.6;
-static const CGFloat kInkAlpha = (CGFloat)0.16;
+static const CGFloat kRippleAlpha = (CGFloat)0.16;
 
 @interface MDCActionSheetController (Testing)
 @property(nonatomic, strong) UITableView *tableView;
@@ -95,7 +95,7 @@ static const CGFloat kInkAlpha = (CGFloat)0.16;
   XCTAssertEqualObjects(actionSheetCell.actionLabel.textColor,
                         [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kHighAlpha]);
   XCTAssertEqualObjects(actionSheetCell.inkTouchController.defaultInkView.inkColor,
-                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kInkAlpha]);
+                        [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kRippleAlpha]);
   XCTAssertEqualObjects(actionSheetCell.actionLabel.font, typographyScheme.subtitle1);
 
   // Elevation


### PR DESCRIPTION
MDCActionSheetController's inkColor and enableRippleBehavior properties are deprecated and have no internal usage. inkColor and enableRippleBehavior properties still exist in MDCActionSheetItemTableViewCell and will be deleted in a future PR.

Fixes #9128