### PR TITLE
[ActionSheet] Delete inkColor and enableRippleBehavior from MDCActionSheetItemTableViewCell

### DIFF
--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -324,7 +324,6 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   cell.backgroundColor = self.backgroundColor;
   cell.actionFont = self.actionFont;
   cell.accessibilityIdentifier = action.accessibilityIdentifier;
-  cell.enableRippleBehavior = YES;
   cell.rippleColor = self.rippleColor;
   cell.tintColor = action.tintColor ?: self.actionTintColor;
   cell.imageRenderingMode = self.imageRenderingMode;

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
@@ -31,24 +31,12 @@
 
 @property(nonatomic, strong, nullable) UIColor *actionTextColor;
 
-@property(nonatomic, strong, nullable) UIColor *inkColor;
-
-/**
- By setting this property to @c YES, the Ripple component will be used instead of Ink
- to display visual feedback to the user.
-
- @note This property will eventually be enabled by default, deprecated, and then deleted as part
- of our migration to Ripple. Learn more at
- https://github.com/material-components/material-components-ios/tree/develop/components/Ink#migration-guide-ink-to-ripple
-
- Defaults to NO.
- */
-@property(nonatomic, assign) BOOL enableRippleBehavior;
-
 /**
  The ripple color for the action items within an action sheet.
+
+ @note Defaults and resets to black with a 14% opacity.
  */
-@property(nonatomic, strong, nullable) UIColor *rippleColor;
+@property(nonatomic, strong, null_resettable) UIColor *rippleColor;
 
 @property(nonatomic) UIImageRenderingMode imageRenderingMode;
 

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -30,7 +30,6 @@ static inline UIColor *RippleColor() {
 @interface MDCActionSheetItemTableViewCell ()
 @property(nonatomic, strong) UILabel *actionLabel;
 @property(nonatomic, strong) UIImageView *actionImageView;
-@property(nonatomic, strong) MDCInkTouchController *inkTouchController;
 @property(nonatomic, strong) MDCRippleTouchController *rippleTouchController;
 /** Container view holding all custom content so it can be inset. */
 @property(nonatomic, strong) UIView *contentContainerView;
@@ -103,13 +102,10 @@ static inline UIColor *RippleColor() {
   [_contentContainerView.trailingAnchor constraintEqualToAnchor:_actionLabel.trailingAnchor]
       .active = YES;
 
-  if (!_inkTouchController) {
-    _inkTouchController = [[MDCInkTouchController alloc] initWithView:self];
-    [_inkTouchController addInkView];
-  }
-
+  _rippleColor = RippleColor();
   if (!_rippleTouchController) {
     _rippleTouchController = [[MDCRippleTouchController alloc] init];
+    _rippleTouchController.rippleView.rippleColor = _rippleColor;
   }
 
   _actionImageView = [[UIImageView alloc] init];
@@ -187,35 +183,11 @@ static inline UIColor *RippleColor() {
       actionTextColor ?: [UIColor.blackColor colorWithAlphaComponent:kLabelAlpha];
 }
 
-- (void)setInkColor:(UIColor *)inkColor {
-  _inkColor = inkColor;
-  // If no ink color then reset to the default ink color
-  self.inkTouchController.defaultInkView.inkColor = inkColor ?: RippleColor();
-}
-
 - (void)setRippleColor:(UIColor *)rippleColor {
-  if (rippleColor != nil && (_rippleColor == rippleColor || [_rippleColor isEqual:rippleColor])) {
-    return;
-  }
   _rippleColor = rippleColor;
 
   // If no ripple color then reset to the default ripple color.
   self.rippleTouchController.rippleView.rippleColor = rippleColor ?: RippleColor();
-}
-
-- (void)setEnableRippleBehavior:(BOOL)enableRippleBehavior {
-  if (_enableRippleBehavior == enableRippleBehavior) {
-    return;
-  }
-  _enableRippleBehavior = enableRippleBehavior;
-
-  if (enableRippleBehavior) {
-    [self.inkTouchController.defaultInkView removeFromSuperview];
-    [self.rippleTouchController addRippleToView:self];
-  } else {
-    [self.rippleTouchController.rippleView removeFromSuperview];
-    [self.inkTouchController addInkView];
-  }
 }
 
 - (void)setImageRenderingMode:(UIImageRenderingMode)imageRenderingMode {

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -105,6 +105,7 @@ static inline UIColor *RippleColor() {
   _rippleColor = RippleColor();
   if (!_rippleTouchController) {
     _rippleTouchController = [[MDCRippleTouchController alloc] init];
+    [_rippleTouchController addRippleToView:self];
     _rippleTouchController.rippleView.rippleColor = _rippleColor;
   }
 

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -185,10 +185,8 @@ static inline UIColor *RippleColor() {
 }
 
 - (void)setRippleColor:(UIColor *)rippleColor {
-  _rippleColor = rippleColor;
-
-  // If no ripple color then reset to the default ripple color.
-  self.rippleTouchController.rippleView.rippleColor = rippleColor ?: RippleColor();
+  _rippleColor = rippleColor ?: RippleColor();
+  self.rippleTouchController.rippleView.rippleColor = rippleColor;
 }
 
 - (void)setImageRenderingMode:(UIImageRenderingMode)imageRenderingMode {

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.m
@@ -186,7 +186,7 @@ static inline UIColor *RippleColor() {
 
 - (void)setRippleColor:(UIColor *)rippleColor {
   _rippleColor = rippleColor ?: RippleColor();
-  self.rippleTouchController.rippleView.rippleColor = rippleColor;
+  self.rippleTouchController.rippleView.rippleColor = _rippleColor;
 }
 
 - (void)setImageRenderingMode:(UIImageRenderingMode)imageRenderingMode {

--- a/components/ActionSheet/tests/unit/ActionSheetRippleTests.m
+++ b/components/ActionSheet/tests/unit/ActionSheetRippleTests.m
@@ -26,7 +26,6 @@
 
 @interface MDCActionSheetItemTableViewCell (TestingRipple)
 @property(nonatomic, strong) MDCRippleTouchController *rippleTouchController;
-@property(nonatomic, strong) MDCInkTouchController *inkTouchController;
 @end
 
 /**
@@ -62,22 +61,11 @@
   // Then
   XCTAssertEqualObjects(self.actionSheetController.rippleColor, nil);
   for (MDCActionSheetItemTableViewCell *cell in cells) {
-    XCTAssertTrue(cell.enableRippleBehavior);
     XCTAssertNotNil(cell.rippleTouchController);
-    XCTAssertNotNil(cell.inkTouchController);
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
-                          [[UIColor alloc] initWithWhite:0 alpha:(CGFloat)0.14]);
     XCTAssertEqualObjects(cell.rippleTouchController.rippleView.rippleColor,
                           [[UIColor alloc] initWithWhite:0 alpha:(CGFloat)0.14]);
-    XCTAssertEqual(cell.inkTouchController.defaultInkView.inkStyle, MDCInkStyleBounded);
     XCTAssertEqual(cell.rippleTouchController.rippleView.rippleStyle, MDCRippleStyleBounded);
     XCTAssertNotNil(cell.rippleTouchController.rippleView.superview);
-    XCTAssertNil(cell.inkTouchController.defaultInkView.superview);
-
-    CGRect cellBounds = CGRectStandardize(cell.bounds);
-    CGRect inkBounds = CGRectStandardize(cell.inkTouchController.defaultInkView.bounds);
-    XCTAssertTrue(CGRectEqualToRect(cellBounds, inkBounds), @"%@ is not equal to %@",
-                  NSStringFromCGRect(cellBounds), NSStringFromCGRect(inkBounds));
   }
 }
 

--- a/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetTableCellTest.m
@@ -20,7 +20,6 @@
 @interface MDCActionSheetItemTableViewCell (Testing)
 @property(nonatomic, strong) UILabel *actionLabel;
 @property(nonatomic, strong) UIImageView *actionImageView;
-@property(nonatomic, strong) MDCInkTouchController *inkTouchController;
 @end
 
 @interface MDCActionSheetTableCellTest : XCTestCase
@@ -120,17 +119,6 @@
       // Then
       XCTAssertEqualObjects(cell.actionImageView.tintColor, color);
     }
-  }
-}
-
-- (void)testDefaultInkColor {
-  // When
-  NSArray *cells = [MDCActionSheetTestHelper getCellsFromActionSheet:self.actionSheet];
-
-  // Then
-  for (MDCActionSheetItemTableViewCell *cell in cells) {
-    XCTAssertEqualObjects(cell.inkTouchController.defaultInkView.inkColor,
-                          [[UIColor alloc] initWithWhite:0 alpha:(CGFloat)0.14]);
   }
 }
 


### PR DESCRIPTION
Because inkColor and enableRippleBehavior no longer exist on MDCActionSheetController
and MDCActionSheetItemTableViewCell is private, these properties are unused and can safely be deleted. This change also properly marks MDCActionSheetItemTableViewCell's rippleColor as null_resettable.

Fixes #9239
