### PR TITLE
[NavigationDrawer] Resolve runtime warning from example in iOS 13

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -97,10 +97,13 @@ class ExpandFullscreenContentViewController: UITableViewController {
     self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    self.tableView.layoutIfNeeded()
-    self.preferredContentSize = CGSize(width: view.bounds.width,
-                                       height: tableView.contentSize.height)
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    if self.preferredContentSize == .zero {
+      self.tableView.layoutIfNeeded()
+      self.preferredContentSize = CGSize(width: view.bounds.width,
+                                         height: tableView.contentSize.height)
+    }
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
We were laying out the tableview before it was added to the view hierarchy. Code was moved later in the lifecycle to resolve the warning.

Closes https://github.com/material-components/material-components-ios/issues/7690