### PR TITLE
[Chips] Fix `contentPadding` API.

### DIFF
--- a/components/Chips/src/MDCChipView.m
+++ b/components/Chips/src/MDCChipView.m
@@ -76,8 +76,9 @@ static CGRect CGRectVerticallyCentered(CGRect rect,
 }
 
 static inline CGRect MDCChipBuildFrame(
-    UIEdgeInsets insets, CGSize size, CGFloat xOffset, CGFloat chipHeight, CGFloat pixelScale) {
-  CGRect frame = CGRectMake(xOffset + insets.left, insets.top, size.width, size.height);
+    UIEdgeInsets insets, CGSize size, CGPoint originPoint, CGFloat chipHeight, CGFloat pixelScale) {
+  CGRect frame =
+      CGRectMake(originPoint.x + insets.left, originPoint.y + insets.top, size.width, size.height);
   return CGRectVerticallyCentered(frame, insets, chipHeight, pixelScale);
 }
 
@@ -708,11 +709,13 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 }
 
 - (CGRect)frameForImageView:(UIImageView *)imageView visible:(BOOL)visible {
-  CGRect frame = CGRectMake(CGRectGetMinX(self.contentRect), CGRectGetMidY(self.contentRect), 0, 0);
+  CGRect contentRect = self.contentRect;
+  CGRect frame = CGRectMake(CGRectGetMinX(contentRect), CGRectGetMidY(contentRect), 0, 0);
   if (visible) {
-    CGSize selectedSize = [self sizeForImageView:imageView maxSize:self.contentRect.size];
-    frame = MDCChipBuildFrame(_imagePadding, selectedSize, CGRectGetMinX(self.contentRect),
-                              CGRectGetHeight(self.frame), self.pixelScale);
+    CGSize selectedSize = [self sizeForImageView:imageView maxSize:contentRect.size];
+    frame = MDCChipBuildFrame(_imagePadding, selectedSize,
+                              CGPointMake(CGRectGetMinX(contentRect), CGRectGetMinY(contentRect)),
+                              CGRectGetHeight(contentRect), self.pixelScale);
   }
   return frame;
 }
@@ -724,12 +727,14 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (CGRect)accessoryViewFrame {
   CGSize size = CGSizeZero;
+  CGRect contentRect = self.contentRect;
   if (self.showAccessoryView) {
-    size = [self sizeForAccessoryViewWithMaxSize:self.contentRect.size];
+    size = [self sizeForAccessoryViewWithMaxSize:contentRect.size];
   }
   CGFloat xOffset =
       CGRectGetMaxX(self.contentRect) - size.width - UIEdgeInsetsHorizontal(_accessoryPadding);
-  return MDCChipBuildFrame(_accessoryPadding, size, xOffset, CGRectGetHeight(self.frame),
+  CGPoint frameOrigin = CGPointMake(xOffset, CGRectGetMinY(contentRect));
+  return MDCChipBuildFrame(_accessoryPadding, size, frameOrigin, CGRectGetHeight(contentRect),
                            self.pixelScale);
 }
 
@@ -740,21 +745,22 @@ static inline CGSize CGSizeShrinkWithInsets(CGSize size, UIEdgeInsets edgeInsets
 
 - (CGRect)titleLabelFrame {
   CGRect imageFrame = CGRectUnion(_imageView.frame, _selectedImageView.frame);
-  CGFloat maximumTitleWidth = CGRectGetWidth(self.contentRect) - CGRectGetWidth(imageFrame) -
+  CGRect contentRect = self.contentRect;
+  CGFloat maximumTitleWidth = CGRectGetWidth(contentRect) - CGRectGetWidth(imageFrame) -
                               UIEdgeInsetsHorizontal(_titlePadding) +
                               UIEdgeInsetsHorizontal(_imagePadding);
   if (self.showAccessoryView) {
     maximumTitleWidth -=
         CGRectGetWidth(_accessoryView.frame) + UIEdgeInsetsHorizontal(_accessoryPadding);
   }
-  CGFloat maximumTitleHeight =
-      CGRectGetHeight(self.contentRect) - UIEdgeInsetsVertical(_titlePadding);
+  CGFloat maximumTitleHeight = CGRectGetHeight(contentRect) - UIEdgeInsetsVertical(_titlePadding);
   CGSize maximumSize = CGSizeMake(maximumTitleWidth, maximumTitleHeight);
   CGSize titleSize = [_titleLabel sizeThatFits:maximumSize];
   titleSize.width = MAX(0, maximumTitleWidth);
 
   CGFloat imageRightEdge = CGRectGetMaxX(imageFrame) + _imagePadding.right;
-  return MDCChipBuildFrame(_titlePadding, titleSize, imageRightEdge, CGRectGetHeight(self.frame),
+  CGPoint frameOrigin = CGPointMake(imageRightEdge, CGRectGetMinY(contentRect));
+  return MDCChipBuildFrame(_titlePadding, titleSize, frameOrigin, CGRectGetHeight(contentRect),
                            self.pixelScale);
 }
 

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesLTR_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7896af5dae1c0492e03b20e5e6f6e09d8ff817e18bcf0d644db0431a010a8f73
-size 5997
+oid sha256:640d0ad7e49ae7678a2e761d687170efe0ba1b13074dfd7a12ea76c616c0a22e
+size 5862

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesRTL_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:136e36a494f4595a75901aa666386b3d623991613a2de5d77960d1ee5dd98a70
-size 5871
+oid sha256:49cdc9ad21b382ed3d1f488dc26808822c1a97c37725e64e2873eafef7ea3566
+size 5922

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesLTR_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f99ab685678acaf0eda999a86c486050ebca6d4b3e3852a5d6d498b52ed4f3e
-size 8795
+oid sha256:770264fac4dd654a89e3e3197f97ead8e15ba9de7687c35ec89ad9779b02692e
+size 8726

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesRTL_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f71bf46c1ef41a83ef2944b3f5a887bbc37b829cd10f266164e1376ba9d11956
-size 8926
+oid sha256:b23ab4a7d4634d31417ea74b16800e19da6d74bd4613fdf72823ede2442587d0
+size 8838

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftDown_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftDown_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07fae752bdb3974f04476b74fe9edb4fa4d7f51e04192683156f59b8876361c7
-size 6087
+oid sha256:0dfbb32a6d4ba28714170748c127857689982969a3fea79ee7a402b3a393bafa
+size 6176

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftUp_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftUp_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:029e5f8b0c87251d84a12db039b0105faa4bd4e4dc29e78d020a0c043c8b09ab
-size 6064
+oid sha256:af19f093196d3361a70052b05c68efe688fcd4aa99372fc85e5215c4279bf06c
+size 6183


### PR DESCRIPTION
Corrects the behavior of `contentPadding` to ensure that it correctly
positions content within its padding bounds.

This change includes two corrections that addressed problems in layout:

*   Calculating subview bounding rectangles within the `MDCChipView` failed to account for `contentPadding.top` when determining the bounding rectangle origin.
*   Positioning the subviews vertically within the bounding rectangle was accidentally using the `MDCChipView` frame rather than the content rectangle. This resulted in the content padding being evenly "split" between the top and bottom rather than the actual values.

Closes #9249