### PR TITLE
[List] Deprecae MDCListColorThemer

### DIFF
--- a/components/List/src/ColorThemer/MDCListColorThemer.h
+++ b/components/List/src/ColorThemer/MDCListColorThemer.h
@@ -24,10 +24,8 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCListColorThemer : NSObject
-@end
-
-@interface MDCListColorThemer (ToBeDeprecated)
+__deprecated_msg("Please use MaterialList+Theming instead.") @interface MDCListColorThemer
+    : NSObject
 
 /**
  Applies a color scheme's properties to an MDCSelfSizingStereoCell
@@ -40,7 +38,8 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
-          toSelfSizingStereoCell:(MDCSelfSizingStereoCell *)cell;
+          toSelfSizingStereoCell:(MDCSelfSizingStereoCell *)cell
+    __deprecated_msg("Please use the MDCSelfSizingStereoCell:applyThemeWithScheme: API instead.");
 
 /**
  Applies a color scheme's properties to an MDCBaseCell
@@ -52,6 +51,8 @@
  Track progress here: https://github.com/material-components/material-components-ios/issues/7172
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-+ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme toBaseCell:(MDCBaseCell *)cell;
++ (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
+                      toBaseCell:(MDCBaseCell *)cell
+    __deprecated_msg("Please use the MDCBaseCell:applyThemeWithScheme: API instead.");
 
 @end

--- a/components/List/src/ColorThemer/MDCListColorThemer.m
+++ b/components/List/src/ColorThemer/MDCListColorThemer.m
@@ -17,7 +17,10 @@
 static const CGFloat kHighAlpha = (CGFloat)0.87;
 static const CGFloat kInkAlpha = (CGFloat)0.16;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCListColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme
           toSelfSizingStereoCell:(MDCSelfSizingStereoCell *)cell {


### PR DESCRIPTION
# Description

Deprecating MDCListColorThemer.

# Issue

b/145204461 Delete symbol "MDCListColorThemer(ToBeDeprecated)::applySemanticColorScheme:toSelfSizingStereoCell:"