### PR TITLE
[Tabs] Removed build file dep for TabFontThemer that was deleted

### DIFF
--- a/components/Tabs/BUILD
+++ b/components/Tabs/BUILD
@@ -161,7 +161,6 @@ mdc_unit_test_objc_library(
     ]),
     deps = [
         ":ColorThemer",
-        ":FontThemer",
         ":TabBarView",
         ":Tabs",
         ":Theming",


### PR DESCRIPTION
TabFontThemer  that was deleted but the colorThemer revert accidentally readd it

Here is the botched revert:
https://github.com/material-components/material-components-ios/commit/5de47f883ca7be62c7ed11ac373bf04d7886ab75#diff-eac85c81daeac71b652d1a98c5bf5bbc