### PR TITLE
[FlexibleHeader] Deprecate MDCFlexibleHeaderColorThemer

### DIFF
--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
@@ -21,16 +21,22 @@
 
 + (void)applyColorScheme:(nonnull id<MDCColorScheming>)colorScheme
     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme
                                     toFlexibleHeaderView:appBarViewController.headerView];
+#pragma clang diagnostic pop
   [MDCNavigationBarColorThemer applySemanticColorScheme:colorScheme
                                         toNavigationBar:appBarViewController.navigationBar];
 }
 
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCFlexibleHeaderColorThemer applySurfaceVariantWithColorScheme:colorScheme
                                               toFlexibleHeaderView:appBarViewController.headerView];
+#pragma clang diagnostic pop
   [MDCNavigationBarColorThemer
       applySurfaceVariantWithColorScheme:colorScheme
                          toNavigationBar:appBarViewController.navigationBar];
@@ -39,24 +45,33 @@
 #pragma mark - To be deprecated
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme toAppBar:(MDCAppBar *)appBar {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme
                                     toFlexibleHeaderView:appBar.headerViewController.headerView];
+#pragma clang diagnostic pop
   [MDCNavigationBarColorThemer applySemanticColorScheme:colorScheme
                                         toNavigationBar:appBar.navigationBar];
 }
 
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                   toAppBar:(nonnull MDCAppBar *)appBar {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCFlexibleHeaderColorThemer
       applySurfaceVariantWithColorScheme:colorScheme
                     toFlexibleHeaderView:appBar.headerViewController.headerView];
+#pragma clang diagnostic pop
   [MDCNavigationBarColorThemer applySurfaceVariantWithColorScheme:colorScheme
                                                   toNavigationBar:appBar.navigationBar];
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme toAppBar:(MDCAppBar *)appBar {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [MDCFlexibleHeaderColorThemer applyColorScheme:colorScheme
                    toMDCFlexibleHeaderController:appBar.headerViewController];
+#pragma clang diagnostic pop
   [MDCNavigationBarColorThemer applyColorScheme:colorScheme toNavigationBar:appBar.navigationBar];
 }
 

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.h
@@ -24,10 +24,10 @@
  details on replacement APIs.
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
-@interface MDCFlexibleHeaderColorThemer : NSObject
-@end
-
-@interface MDCFlexibleHeaderColorThemer (ToBeDeprecated)
+__deprecated_msg("No replacement exists. Please comment on"
+                 " https://github.com/material-components/material-components-ios/issues/7172"
+                 " in order to indicate interest in a replacement API.")
+    @interface MDCFlexibleHeaderColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCFlexibleHeaderView using the primary mapping.
@@ -42,7 +42,10 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-            toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
+            toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 /**
  Applies a color scheme's properties to an MDCFlexibleHeaderView using the surface mapping.
@@ -57,7 +60,10 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
-                      toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
+                      toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 /**
  Applies a color scheme to theme a MDCFlexibleHeaderView.
@@ -70,7 +76,10 @@
  Learn more at docs/theming.md#migration-guide-themers-to-theming-extensions
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
-    toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
+    toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 /**
  Applies a color scheme to theme a MDCFlexibleHeaderViewController.
@@ -84,6 +93,9 @@
  */
 + (void)applyColorScheme:(nonnull id<MDCColorScheme>)colorScheme
     toMDCFlexibleHeaderController:
-        (nonnull MDCFlexibleHeaderViewController *)flexibleHeaderController;
+        (nonnull MDCFlexibleHeaderViewController *)flexibleHeaderController
+    __deprecated_msg("No replacement exists. Please comment on"
+                     " https://github.com/material-components/material-components-ios/issues/7172"
+                     " in order to indicate interest in a replacement API.");
 
 @end

--- a/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
+++ b/components/FlexibleHeader/src/ColorThemer/MDCFlexibleHeaderColorThemer.m
@@ -14,7 +14,10 @@
 
 #import "MDCFlexibleHeaderColorThemer.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation MDCFlexibleHeaderColorThemer
+#pragma clang diagnostic pop
 
 + (void)applySemanticColorScheme:(nonnull id<MDCColorScheming>)colorScheme
             toFlexibleHeaderView:(nonnull MDCFlexibleHeaderView *)flexibleHeaderView {


### PR DESCRIPTION
`MDCFlexibleHeaderColorThemer` was marked as "ToBeDeprecated". This PR performs that deprecation.

TODO: Replace the following with github issue links
b/145204583
b/145204876
b/145204992
b/145205326