### PR TITLE
[FlexibleHeader] Remove uses of MDCFlexibleHeaderColorThemer

### DIFF
--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -117,8 +117,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
 
   @objc func themeDidChange(notification: NSNotification) {
     let colorScheme = AppTheme.containerScheme.colorScheme
-    MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
-                                                          to: headerViewController.headerView)
+    headerViewController.headerView.backgroundColor = colorScheme.primaryColor
     setNeedsStatusBarAppearanceUpdate()
 
     titleLabel.textColor = colorScheme.onPrimaryColor
@@ -184,8 +183,7 @@ class MDCCatalogComponentsController: UICollectionViewController, UICollectionVi
                    insets: titleInsets,
                    height: titleSize.height)
 
-    MDCFlexibleHeaderColorThemer.applySemanticColorScheme(colorScheme,
-                                                          to: headerViewController.headerView)
+    headerViewController.headerView.backgroundColor = colorScheme.primaryColor
 
     headerViewController.headerView.trackingScrollView = collectionView
 

--- a/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
+++ b/components/AppBar/src/ColorThemer/MDCAppBarColorThemer.m
@@ -21,22 +21,14 @@
 
 + (void)applyColorScheme:(nonnull id<MDCColorScheming>)colorScheme
     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme
-                                    toFlexibleHeaderView:appBarViewController.headerView];
-#pragma clang diagnostic pop
+  appBarViewController.headerView.backgroundColor = colorScheme.primaryColor;
   [MDCNavigationBarColorThemer applySemanticColorScheme:colorScheme
                                         toNavigationBar:appBarViewController.navigationBar];
 }
 
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                     toAppBarViewController:(nonnull MDCAppBarViewController *)appBarViewController {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCFlexibleHeaderColorThemer applySurfaceVariantWithColorScheme:colorScheme
-                                              toFlexibleHeaderView:appBarViewController.headerView];
-#pragma clang diagnostic pop
+  appBarViewController.headerView.backgroundColor = colorScheme.surfaceColor;
   [MDCNavigationBarColorThemer
       applySurfaceVariantWithColorScheme:colorScheme
                          toNavigationBar:appBarViewController.navigationBar];
@@ -45,33 +37,20 @@
 #pragma mark - To be deprecated
 
 + (void)applySemanticColorScheme:(id<MDCColorScheming>)colorScheme toAppBar:(MDCAppBar *)appBar {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCFlexibleHeaderColorThemer applySemanticColorScheme:colorScheme
-                                    toFlexibleHeaderView:appBar.headerViewController.headerView];
-#pragma clang diagnostic pop
+  appBar.headerViewController.headerView.backgroundColor = colorScheme.primaryColor;
   [MDCNavigationBarColorThemer applySemanticColorScheme:colorScheme
                                         toNavigationBar:appBar.navigationBar];
 }
 
 + (void)applySurfaceVariantWithColorScheme:(nonnull id<MDCColorScheming>)colorScheme
                                   toAppBar:(nonnull MDCAppBar *)appBar {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCFlexibleHeaderColorThemer
-      applySurfaceVariantWithColorScheme:colorScheme
-                    toFlexibleHeaderView:appBar.headerViewController.headerView];
-#pragma clang diagnostic pop
+  appBar.headerViewController.headerView.backgroundColor = colorScheme.surfaceColor;
   [MDCNavigationBarColorThemer applySurfaceVariantWithColorScheme:colorScheme
                                                   toNavigationBar:appBar.navigationBar];
 }
 
 + (void)applyColorScheme:(id<MDCColorScheme>)colorScheme toAppBar:(MDCAppBar *)appBar {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [MDCFlexibleHeaderColorThemer applyColorScheme:colorScheme
-                   toMDCFlexibleHeaderController:appBar.headerViewController];
-#pragma clang diagnostic pop
+  appBar.headerViewController.headerView.backgroundColor = colorScheme.primaryColor;
   [MDCNavigationBarColorThemer applyColorScheme:colorScheme toNavigationBar:appBar.navigationBar];
 }
 


### PR DESCRIPTION
Removes our use of the newly-deprecated `MDCFlexibleHeaderColorThemer`.

Part of:
#9284
#9285
#9286
#9287