### PR TITLE
[BottomAppBar] Add snapshot test to verify autolayout bug

### DIFF
--- a/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
+++ b/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
@@ -191,4 +191,24 @@
 #endif
 }
 
+- (void)testIntrinsicHeight {
+  // Given
+  self.appBar.translatesAutoresizingMaskIntoConstraints = NO;
+  UIView *containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 100)];
+  containerView.backgroundColor = [UIColor whiteColor];
+  [containerView addSubview:self.appBar];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [self.appBar.leadingAnchor constraintEqualToAnchor:containerView.leadingAnchor],
+    [self.appBar.trailingAnchor constraintEqualToAnchor:containerView.trailingAnchor],
+    [self.appBar.bottomAnchor constraintEqualToAnchor:containerView.bottomAnchor],
+  ]];
+
+  // When
+  [containerView layoutIfNeeded];
+
+  // Then
+  [self snapshotVerifyView:containerView];
+}
+
 @end

--- a/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0199ef47eb82dc04b9ab4d060770a5f417633a817718ebe1e191f964aa019606
+size 15266

--- a/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0199ef47eb82dc04b9ab4d060770a5f417633a817718ebe1e191f964aa019606
-size 15266
+oid sha256:5c267c79a9557ec347d7ca0ab52079ec22de2653f8d34f1c7b496c2d0638f327
+size 2801


### PR DESCRIPTION
Adds a snapshot test to verify that `MDCBottomAppBarView` does not lay out correctly using autolayout with no height constraint.

Part of #9288