### PR TITLE
[BottomAppBar] Add intrinsicContentSize

### DIFF
--- a/components/BottomAppBar/src/MDCBottomAppBarView.m
+++ b/components/BottomAppBar/src/MDCBottomAppBarView.m
@@ -94,6 +94,10 @@ static const int kMDCButtonAnimationDuration = 200;
   _mdc_overrideBaseElevation = -1;
 }
 
+- (CGSize)intrinsicContentSize {
+  return CGSizeMake(UIViewNoIntrinsicMetric, kMDCBottomAppBarHeight);
+}
+
 - (void)addFloatingButton {
   MDCFloatingButton *floatingButton = [[MDCFloatingButton alloc] init];
   [self setFloatingButton:floatingButton];

--- a/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
+++ b/components/BottomAppBar/tests/snapshot/MDCBottomAppBarSnapshotTests.m
@@ -191,4 +191,24 @@
 #endif
 }
 
+- (void)testIntrinsicHeight {
+  // Given
+  self.appBar.translatesAutoresizingMaskIntoConstraints = NO;
+  UIView *containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 100)];
+  containerView.backgroundColor = [UIColor whiteColor];
+  [containerView addSubview:self.appBar];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [self.appBar.leadingAnchor constraintEqualToAnchor:containerView.leadingAnchor],
+    [self.appBar.trailingAnchor constraintEqualToAnchor:containerView.trailingAnchor],
+    [self.appBar.bottomAnchor constraintEqualToAnchor:containerView.bottomAnchor],
+  ]];
+
+  // When
+  [containerView layoutIfNeeded];
+
+  // Then
+  [self snapshotVerifyView:containerView];
+}
+
 @end

--- a/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0199ef47eb82dc04b9ab4d060770a5f417633a817718ebe1e191f964aa019606
+size 15266

--- a/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0199ef47eb82dc04b9ab4d060770a5f417633a817718ebe1e191f964aa019606
-size 15266
+oid sha256:5c267c79a9557ec347d7ca0ab52079ec22de2653f8d34f1c7b496c2d0638f327
+size 2801

--- a/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCBottomAppBarSnapshotTests/testIntrinsicHeight_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c267c79a9557ec347d7ca0ab52079ec22de2653f8d34f1c7b496c2d0638f327
-size 2801
+oid sha256:0199ef47eb82dc04b9ab4d060770a5f417633a817718ebe1e191f964aa019606
+size 15266


### PR DESCRIPTION
NOTE: this is a follow up to https://github.com/material-components/material-components-ios/pull/9289

Adds `intrinsicContentSize` implementation to `MDCBottomAppBarView`. This allows the MDCBottomAppBarView to lay out correctly in autolayout without a height constraint. 

Fixes #9288 