### PR TITLE
[Banner] Fix pod name in README.md

### DIFF
--- a/components/Banner/README.md
+++ b/components/Banner/README.md
@@ -41,7 +41,7 @@ A banner displays a prominent message and related optional actions.
 Add the following to your `Podfile`:
 
 ```bash
-pod 'MaterialComponentsBeta/Banner'
+pod 'MaterialComponents/Banner'
 ```
 <!--{: .code-renderer.code-renderer--install }-->
 


### PR DESCRIPTION
I was getting:
[!] Unable to find a specification for `MaterialComponentsBeta/Banner`
because the pod name is wrong. I fixed it.
