### PR TITLE
[Snackbar] Add snapshot test showing reported shadow bug

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -131,6 +131,7 @@ static const CGFloat kMaximumHeight = 80;
     _watcher = watcher;
     _containingView = [[UIView alloc] initWithFrame:frame];
     _containingView.translatesAutoresizingMaskIntoConstraints = NO;
+    _containingView.clipsToBounds = YES;
     [self addSubview:_containingView];
 
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -131,7 +131,6 @@ static const CGFloat kMaximumHeight = 80;
     _watcher = watcher;
     _containingView = [[UIView alloc] initWithFrame:frame];
     _containingView.translatesAutoresizingMaskIntoConstraints = NO;
-    _containingView.clipsToBounds = YES;
     [self addSubview:_containingView];
 
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -221,7 +221,9 @@ static NSString *const kItemTitleLong2Arabic =
 
   // When
   messageView.elevation = 24;
-  [self.testManager.internalManager.overlayView showSnackbarView:messageView animated:NO completion:nil];
+  [self.testManager.internalManager.overlayView showSnackbarView:messageView
+                                                        animated:NO
+                                                      completion:nil];
 
   // Then
   [self generateSnapshotAndVerifyForView:self.testManager.internalManager.overlayView];

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -19,6 +19,8 @@
 // clang-format off
 #import "MaterialSnackbar.h"
 #import "../../src/private/MDCSnackbarMessageViewInternal.h"
+#import "../../src/private/MDCSnackbarManagerInternal.h"
+#import "../../src/private/MDCSnackbarOverlayView.h"
 // clang-format on
 
 /** The width of the Snackbar for testing. */
@@ -41,6 +43,14 @@ static NSString *const kItemTitleLong1Arabic =
     @"عل أخذ استطاعوا الانجليزية. قد وحتّى بزمام التبرعات مكن.";
 static NSString *const kItemTitleLong2Arabic =
     @"وتم عل والقرى إتفاقية, عن هذا وباءت الغالي وفرنسا.";
+
+@interface MDCSnackbarManagerInternal (SnackbarManagerSnapshotTesting)
+@property(nonatomic) MDCSnackbarOverlayView *overlayView;
+@end
+
+@interface MDCSnackbarManager (SnackbarManagerSnapshotTesting)
+@property(nonnull, nonatomic, strong) MDCSnackbarManagerInternal *internalManager;
+@end
 
 /** Snapshot tests for MDCSnackbarMessageView. */
 @interface MDCSnackbarMessageViewSnapshotTests : MDCSnapshotTestCase
@@ -201,6 +211,20 @@ static NSString *const kItemTitleLong2Arabic =
 
   // Then
   [self generateSnapshotAndVerifyForView:messageView];
+}
+
+- (void)testSnackbarOverlayViewWithHighElevation {
+  // Given
+  MDCSnackbarMessageView *messageView = [self snackbarMessageViewWithText:kItemTitleShort1Latin
+                                                              actionTitle:kItemTitleShort2Latin];
+  messageView.frame = CGRectMake(0, 0, kWidth, kHeightSingleLineText);
+
+  // When
+  messageView.elevation = 24;
+  [self.testManager.internalManager.overlayView showSnackbarView:messageView animated:NO completion:nil];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.testManager.internalManager.overlayView];
 }
 
 @end

--- a/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d14750ed3de7e60062d67d7c08c00971bb0c5110e0446c40dd2bdb0d6e4e2d2
-size 42610
+oid sha256:c01d670be277cb300e24f96d8320b912253ff58dd48188a973c813fd607fb984
+size 31671

--- a/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d14750ed3de7e60062d67d7c08c00971bb0c5110e0446c40dd2bdb0d6e4e2d2
+size 42610


### PR DESCRIPTION
This snapshot test for the Snackbar exposes the bug as seen in https://github.com/material-components/material-components-ios/issues/9308