### PR TITLE
[scripts/release] Always branch off of stable.

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -6,8 +6,9 @@ These instructions describe how to cut a new release.
 
 MDC follows the ["git flow"](http://nvie.com/posts/a-successful-git-branching-model/) style of 
 development, where the default branch is called `develop`. `stable` (instead of the traditional
-`master`) is reserved for releases. The `develop` branch is periodically copied to a release candidate,
-tested, and then merged into `stable`, which serves as the stable "vetted" branch.
+`master`) is reserved for releases. The `develop` branch is periodically merged into a release
+candidate that is cut from `stable`. The release candidate is then tested and release notes are
+added. Once validated, the release-candidate is merged into `stable`, which serves as the stable "vetted" branch, and into `develop`.
 
 ## A note on the role of the release engineer
 

--- a/scripts/README-release.md
+++ b/scripts/README-release.md
@@ -21,8 +21,8 @@ version tag.
 
 When a stable release is ready to be cut, a `release-candidate` branch is `cut`
 from the latest `origin/stable` commit and `origin/develop` is merged into the
-`release-candidate`, unless the release is a hotfix in which case nothing is
-merged into the branch by default.
+`release-candidate` branch in preparation for cherry picks, unless the release
+is a hotfix in which case nothing is merged into the branch by default.
 
     release cut
 

--- a/scripts/README-release.md
+++ b/scripts/README-release.md
@@ -20,7 +20,9 @@ version tag.
 ## Cut the release
 
 When a stable release is ready to be cut, a `release-candidate` branch is `cut`
-from the latest `origin/develop` commit.
+from the latest `origin/stable` commit and `origin/develop` is merged into the
+`release-candidate`, unless the release is a hotfix in which case nothing is
+merged into the branch by default.
 
     release cut
 

--- a/scripts/release
+++ b/scripts/release
@@ -133,12 +133,12 @@ cut_release() {
     exit 1
   fi
 
+  git checkout -b release-candidate origin/stable
+
   if $isHotFix; then
-    echo "This is a hotfix... branching off origin/stable and awaiting cherry-picks."
-    git checkout -b release-candidate origin/stable
+    echo "This is a hotfix... we've branched off origin/stable and are now awaiting cherry-picks."
   else
-    echo "This is a normal release... branching off origin/stable and merging origin/develop"
-    git checkout -b release-candidate origin/stable
+    echo "This is a normal release... we've branched off origin/stable and are now merging origin/develop..."
     git merge --no-ff origin/develop --no-edit
   fi
 

--- a/scripts/release
+++ b/scripts/release
@@ -130,7 +130,7 @@ cut_release() {
     echo "    Your local develop branch is ahead of origin/develop."
     echo "    Refusing to continue until you've landed your local changes into origin/develop."
     echo
-    exit 1
+    exit 1 # TODO: Revert this line so we bail out.
   fi
 
   git checkout -b release-candidate origin/stable

--- a/scripts/release
+++ b/scripts/release
@@ -130,18 +130,18 @@ cut_release() {
     echo "    Your local develop branch is ahead of origin/develop."
     echo "    Refusing to continue until you've landed your local changes into origin/develop."
     echo
-    exit 1 # TODO: Revert this line so we bail out.
+    exit 1
   fi
 
   if $isHotFix; then
-    branch=origin/stable
-    branch_message="This is a hotfix... branching off $branch"
+    echo "This is a hotfix... branching off origin/stable and awaiting cherry-picks."
+    git checkout -b release-candidate origin/stable
   else
-    branch=origin/develop
-    branch_message="This is a normal release... branching off $branch"
+    echo "This is a normal release... branching off origin/stable and merging origin/develop"
+    git checkout -b release-candidate origin/stable
+    git merge --no-ff origin/develop --no-edit
   fi
-  echo $branch_message
-  git checkout -b release-candidate $branch
+
   git checkout origin/stable -- .gitattributes
 
   touch "$rootdir/CHANGELOG.md"


### PR DESCRIPTION
Prior to this change, our release process was merging `develop` directly into `stable` without first branching off of `stable`.

The result of this process was that `stable` shares no common ancestor with `develop`, making it difficult to calculate differences between a commit on `develop` and a commit on `stable`.

One example of where this becomes problematic is in generating internal CLs for our PRs and for `develop`. It is not possible to compute the delta between the most recent `stable` commit that was mirrored internally and a given `develop` commit, making it difficult for tooling to apply deltas to the internal codebase without simply blowing away the internal directory and checking out the desired `develop` commit.

To fix this problem, we need to create a common ancestor between `develop` and `stable`. To do so, when cutting a release we need to cut the `release-candidate` from `stable` rather than `develop`, and then immediately merge `develop` into the release-candidate. This creates a common ancestor between `develop` and `stable`.

Note that this change causes us to deviate from the pure git flow model we have historically been following, as shown in the before/after of the model below (note the new red lines connecting stable to develop).

| Before | After |
|:--|:--|
| ![git-model@2x](https://user-images.githubusercontent.com/45670/71178792-ebf05600-223c-11ea-9f16-df72bd13a067.png) | ![git-model@2x copy 2](https://user-images.githubusercontent.com/45670/71179290-dd566e80-223d-11ea-8eab-2487490985f6.png) |

