### PR TITLE
[Dialogs] Expose MDCAlertController presentation animation properties

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -157,6 +157,28 @@
  */
 - (void)setAccessoryViewNeedsLayout;
 
+/**
+ Duration of the dialog fade-in or fade-out presentation animation.
+
+ Defaults to 0.27 seconds.
+ */
+@property(nonatomic, assign) NSTimeInterval presentationOpacityAnimationDuration;
+
+/**
+ Duration of dialog scale-up or scale-down presentation animation.
+
+ Defaults to 0 seconds (no animation is performed).
+ */
+@property(nonatomic, assign) NSTimeInterval presentationScaleAnimationDuration;
+
+/**
+ The starting scale factor of the dialog during the presentation animation, between 0 and 1. The
+ "animate in" transition scales the dialog from this value to 1.0.
+
+ Defaults to 1.0 (no scaling is performed).
+ */
+@property(nonatomic, assign) CGFloat presentationInitialScaleFactor;
+
 /*
  Indicates whether the alert contents should automatically update their font when the device’s
  UIContentSizeCategory changes.

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -212,32 +212,33 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
       [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
 }
 
+- (MDCDialogTransitionController *)dialogTransitionController {
+  return (MDCDialogTransitionController *)self.transitioningDelegate;
+}
+
 - (NSTimeInterval)presentationOpacityAnimationDuration {
-  return ((MDCDialogTransitionController *)self.transitioningDelegate).opacityAnimationDuration;
+  return [self dialogTransitionController].opacityAnimationDuration;
 }
 
 - (void)setPresentationOpacityAnimationDuration:
     (NSTimeInterval)presentationOpacityAnimationDuration {
-  ((MDCDialogTransitionController *)self.transitioningDelegate).opacityAnimationDuration =
-      presentationOpacityAnimationDuration;
+  [self dialogTransitionController].opacityAnimationDuration = presentationOpacityAnimationDuration;
 }
 
 - (NSTimeInterval)presentationScaleAnimationDuration {
-  return ((MDCDialogTransitionController *)self.transitioningDelegate).scaleAnimationDuration;
+  return [self dialogTransitionController].scaleAnimationDuration;
 }
 
 - (void)setPresentationScaleAnimationDuration:(NSTimeInterval)presentationScaleAnimationDuration {
-  ((MDCDialogTransitionController *)self.transitioningDelegate).scaleAnimationDuration =
-      presentationScaleAnimationDuration;
+  [self dialogTransitionController].scaleAnimationDuration = presentationScaleAnimationDuration;
 }
 
 - (CGFloat)presentationInitialScaleFactor {
-  return ((MDCDialogTransitionController *)self.transitioningDelegate).dialogInitialScaleFactor;
+  return [self dialogTransitionController].dialogInitialScaleFactor;
 }
 
 - (void)setPresentationInitialScaleFactor:(CGFloat)presentationInitialScaleFactor {
-  ((MDCDialogTransitionController *)self.transitioningDelegate).dialogInitialScaleFactor =
-      presentationInitialScaleFactor;
+  [self dialogTransitionController].dialogInitialScaleFactor = presentationInitialScaleFactor;
 }
 
 - (NSArray<MDCAlertAction *> *)actions {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -212,6 +212,34 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
       [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
 }
 
+- (NSTimeInterval)presentationOpacityAnimationDuration {
+  return ((MDCDialogTransitionController *)self.transitioningDelegate).opacityAnimationDuration;
+}
+
+- (void)setPresentationOpacityAnimationDuration:
+    (NSTimeInterval)presentationOpacityAnimationDuration {
+  ((MDCDialogTransitionController *)self.transitioningDelegate).opacityAnimationDuration =
+      presentationOpacityAnimationDuration;
+}
+
+- (NSTimeInterval)presentationScaleAnimationDuration {
+  return ((MDCDialogTransitionController *)self.transitioningDelegate).scaleAnimationDuration;
+}
+
+- (void)setPresentationScaleAnimationDuration:(NSTimeInterval)presentationScaleAnimationDuration {
+  ((MDCDialogTransitionController *)self.transitioningDelegate).scaleAnimationDuration =
+      presentationScaleAnimationDuration;
+}
+
+- (CGFloat)presentationInitialScaleFactor {
+  return ((MDCDialogTransitionController *)self.transitioningDelegate).dialogInitialScaleFactor;
+}
+
+- (void)setPresentationInitialScaleFactor:(CGFloat)presentationInitialScaleFactor {
+  ((MDCDialogTransitionController *)self.transitioningDelegate).dialogInitialScaleFactor =
+      presentationInitialScaleFactor;
+}
+
 - (NSArray<MDCAlertAction *> *)actions {
   return self.actionManager.actions;
 }

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -838,6 +838,23 @@ than @c UIContentSizeCategoryLarge.
   XCTAssertEqual(passedAlertController, alertController);
 }
 
+- (void)testForwardsAnimationPropertiesToTransitionDelegate {
+  // Given
+  MDCAlertController *alertController = [[MDCAlertController alloc] init];
+  MDCDialogTransitionController *transitionController =
+      (MDCDialogTransitionController *)alertController.transitioningDelegate;
+
+  // When
+  alertController.presentationInitialScaleFactor = 7.0;
+  alertController.presentationScaleAnimationDuration = 8.0;
+  alertController.presentationOpacityAnimationDuration = 9.0;
+
+  // Then
+  XCTAssertEqualWithAccuracy(7.0, transitionController.dialogInitialScaleFactor, 0.0001);
+  XCTAssertEqualWithAccuracy(8.0, transitionController.scaleAnimationDuration, 0.0001);
+  XCTAssertEqualWithAccuracy(9.0, transitionController.opacityAnimationDuration, 0.0001);
+}
+
 #pragma mark - MaterialElevation
 
 - (void)testDefaultBaseElevationOverrideIsNegative {


### PR DESCRIPTION
Exposes MDCDialogTransitionController scaleAnimationDuration, opacityAnimationDuration, and dialogInitialScaleFactor presentation configuration properties through MDCAlertController. 

Fixes #9313