### PR TITLE
[Snackbar] Resolve truncation of shadow in Snackbars

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -131,7 +131,6 @@ static const CGFloat kMaximumHeight = 80;
     _watcher = watcher;
     _containingView = [[UIView alloc] initWithFrame:frame];
     _containingView.translatesAutoresizingMaskIntoConstraints = NO;
-    _containingView.clipsToBounds = YES;
     [self addSubview:_containingView];
 
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];

--- a/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c01d670be277cb300e24f96d8320b912253ff58dd48188a973c813fd607fb984
-size 31671
+oid sha256:baeecef3e233b49c38dc59dc09a4e77d78275686c15b09159c39ae8914ba0710
+size 44744


### PR DESCRIPTION
With this change we are allowing the Snackbar shadow to go beyond the layout constraints of the underlying SnackbarOverlayView that prior caused a weird truncation of shadow.

Closes #9308 

Yay snapshots!