### PR TITLE
[NavigationDrawer] Added ability to account for bottom safe area in presentation of initial drawer height

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -197,6 +197,14 @@
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
 
 /**
+ A flag allowing clients to opt-in to adding additional height to the initial presentation of the
+ drawer to include the bottom safe area inset. This will remove the need for clients to calculate
+ their desired maximum height with the bottom safe area when setting the maximumInitialDrawerHeight.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInInitialDrawerHeight;
+
+/**
  A boolean value that indicates whether the drawer is currently the full height of the window.
  */
 @property(nonatomic, readonly) BOOL contentReachesFullscreen;

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -98,6 +98,8 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   }
   bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight =
       self.shouldIncludeSafeAreaInContentHeight;
+  bottomDrawerContainerViewController.shouldIncludeSafeAreaInInitialDrawerHeight =
+      self.shouldIncludeSafeAreaInInitialDrawerHeight;
   bottomDrawerContainerViewController.shouldAlwaysExpandHeader = self.shouldAlwaysExpandHeader;
   bottomDrawerContainerViewController.elevation = self.elevation;
   bottomDrawerContainerViewController.drawerShadowColor = self.drawerShadowColor;

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -117,6 +117,14 @@
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
 
 /**
+ A flag allowing clients to opt-in to adding additional height to the initial presentation of the
+ drawer to include the bottom safe area inset. This will remove the need for clients to calculate
+ their desired maximum height with the bottom safe area when setting the maximumInitialDrawerHeight.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInInitialDrawerHeight;
+
+/**
  The drawer's top shadow color. Defaults to black with 20% opacity.
  */
 @property(nonatomic, strong, nonnull) UIColor *drawerShadowColor;

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -287,6 +287,17 @@
   }
 }
 
+- (void)setShouldIncludeSafeAreaInInitialDrawerHeight:
+    (BOOL)shouldIncludeSafeAreaInInitialDrawerHeight {
+  _shouldIncludeSafeAreaInInitialDrawerHeight = shouldIncludeSafeAreaInInitialDrawerHeight;
+  if ([self.presentationController isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *bottomDrawerPresentationController =
+        (MDCBottomDrawerPresentationController *)self.presentationController;
+    bottomDrawerPresentationController.shouldIncludeSafeAreaInInitialDrawerHeight =
+        shouldIncludeSafeAreaInInitialDrawerHeight;
+  }
+}
+
 #pragma mark UIAccessibilityAction
 
 // Adds the Z gesture for dismissal.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -180,6 +180,14 @@ the backgroundColor of the trackingScrollView.
 @property(nonatomic, assign) BOOL shouldIncludeSafeAreaInContentHeight;
 
 /**
+ A flag allowing clients to opt-in to adding additional height to the initial presentation of the
+ drawer to include the bottom safe area inset. This will remove the need for clients to calculate
+ their desired maximum height with the bottom safe area when setting the maximumInitialDrawerHeight.
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldIncludeSafeAreaInInitialDrawerHeight;
+
+/**
  Determines if the header should always expand as it approaches the top of the screen.
  If the content height is smaller than the screen height then the header will not expand unless this
  flag is enabled.

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -360,7 +360,7 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
   if ([self shouldPresentFullScreen]) {
     return self.presentingViewBounds.size.height;
   }
-  return _maximumInitialDrawerHeight;
+  return _maximumInitialDrawerHeight + [self bottomSafeAreaInsetsToAdjustInitialDrawerHeight];
 }
 
 - (void)addScrollViewObserver {
@@ -630,6 +630,15 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (CGFloat)bottomSafeAreaInsetsToAdjustContainerHeight {
   if (@available(iOS 11.0, *)) {
     if (self.shouldIncludeSafeAreaInContentHeight) {
+      return self.view.safeAreaInsets.bottom;
+    }
+  }
+  return 0;
+}
+
+- (CGFloat)bottomSafeAreaInsetsToAdjustInitialDrawerHeight {
+  if (@available(iOS 11.0, *)) {
+    if (self.shouldIncludeSafeAreaInInitialDrawerHeight) {
       return self.view.safeAreaInsets.bottom;
     }
   }

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerPresentationControllerTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerPresentationControllerTests.m
@@ -132,8 +132,8 @@
   [presentationController presentationTransitionWillBegin];
 
   // Then
-  XCTAssertTrue(
-      presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight);
+  XCTAssertTrue(presentationController.bottomDrawerContainerViewController
+                    .shouldIncludeSafeAreaInContentHeight);
 }
 
 - (void)testShouldIncludeSafeAreaInInitialDrawerHeight {
@@ -152,8 +152,8 @@
   [presentationController presentationTransitionWillBegin];
 
   // Then
-  XCTAssertTrue(
-      presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInInitialDrawerHeight);
+  XCTAssertTrue(presentationController.bottomDrawerContainerViewController
+                    .shouldIncludeSafeAreaInInitialDrawerHeight);
 }
 
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerPresentationControllerTests.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerPresentationControllerTests.m
@@ -115,4 +115,45 @@
   XCTAssertTrue(
       presentationController.bottomDrawerContainerViewController.shouldAlwaysExpandHeader);
 }
+
+- (void)testShouldIncludeSafeAreaInContentHeight {
+  // Given
+  UIViewController *fakeContentViewController = [[UIViewController alloc] init];
+  MDCBottomDrawerViewController *fakeBottomDrawer = [[MDCBottomDrawerViewController alloc] init];
+  fakeBottomDrawer.contentViewController = fakeContentViewController;
+  UIViewController *fakePresentingViewController = [[UIViewController alloc] init];
+  MDCBottomDrawerPresentationController *presentationController =
+      [[MDCBottomDrawerPresentationController alloc]
+          initWithPresentedViewController:fakeBottomDrawer
+                 presentingViewController:fakePresentingViewController];
+
+  // When
+  presentationController.shouldIncludeSafeAreaInContentHeight = YES;
+  [presentationController presentationTransitionWillBegin];
+
+  // Then
+  XCTAssertTrue(
+      presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInContentHeight);
+}
+
+- (void)testShouldIncludeSafeAreaInInitialDrawerHeight {
+  // Given
+  UIViewController *fakeContentViewController = [[UIViewController alloc] init];
+  MDCBottomDrawerViewController *fakeBottomDrawer = [[MDCBottomDrawerViewController alloc] init];
+  fakeBottomDrawer.contentViewController = fakeContentViewController;
+  UIViewController *fakePresentingViewController = [[UIViewController alloc] init];
+  MDCBottomDrawerPresentationController *presentationController =
+      [[MDCBottomDrawerPresentationController alloc]
+          initWithPresentedViewController:fakeBottomDrawer
+                 presentingViewController:fakePresentingViewController];
+
+  // When
+  presentationController.shouldIncludeSafeAreaInInitialDrawerHeight = YES;
+  [presentationController presentationTransitionWillBegin];
+
+  // Then
+  XCTAssertTrue(
+      presentationController.bottomDrawerContainerViewController.shouldIncludeSafeAreaInInitialDrawerHeight);
+}
+
 @end

--- a/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
+++ b/components/NavigationDrawer/tests/unit/MDCNavigationDrawerTest.m
@@ -171,6 +171,42 @@
   }
 }
 
+- (void)testShouldIncludeSafeAreaInContentHeight {
+  // When
+  self.navigationDrawer.shouldIncludeSafeAreaInContentHeight = YES;
+
+  // Then
+  XCTAssertTrue(self.navigationDrawer.shouldIncludeSafeAreaInContentHeight);
+  if ([self.navigationDrawer.presentationController
+          isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *presentationController =
+        (MDCBottomDrawerPresentationController *)self.navigationDrawer.presentationController;
+    XCTAssertTrue(presentationController.shouldIncludeSafeAreaInContentHeight);
+  } else {
+    XCTFail(@"The presentation controller should be class of kind "
+            @"MDCBottomDrawerPresentationController but is %@",
+            self.navigationDrawer.presentationController.class);
+  }
+}
+
+- (void)testShouldIncludeSafeAreaInInitialDrawerHeight {
+  // When
+  self.navigationDrawer.shouldIncludeSafeAreaInInitialDrawerHeight = YES;
+
+  // Then
+  XCTAssertTrue(self.navigationDrawer.shouldIncludeSafeAreaInInitialDrawerHeight);
+  if ([self.navigationDrawer.presentationController
+          isKindOfClass:[MDCBottomDrawerPresentationController class]]) {
+    MDCBottomDrawerPresentationController *presentationController =
+        (MDCBottomDrawerPresentationController *)self.navigationDrawer.presentationController;
+    XCTAssertTrue(presentationController.shouldIncludeSafeAreaInInitialDrawerHeight);
+  } else {
+    XCTFail(@"The presentation controller should be class of kind "
+            @"MDCBottomDrawerPresentationController but is %@",
+            self.navigationDrawer.presentationController.class);
+  }
+}
+
 - (void)testHeaderHeightWhenShouldAlwaysExpandEnabledAndScrollOccured {
   // Given
   self.navigationDrawer.shouldAlwaysExpandHeader = YES;


### PR DESCRIPTION
Added ability to account for bottom safe area in presentation of initial drawer height, parameterized by default-off flag.

Fixes #9322.

I tried adding unit tests on this, per our conversation @yarneo, but ran into some issues with writing tests around this as: 
1) unit testing for this is difficult as one cannot manually set the `safeAreaInsets` 
2) snapshot testing this requires that the test suite is done on an iPhone X or similar device with bottom insets, which is not the current test device for snapshots as far as I can tell 

I'm happy to add tests but need a bit of guidance regarding how to best test this given the above constraints. I didn't see a test testing the related `shouldIncludeSafeAreaInContentHeight` behavior, which I was looking to use as a test reference, but perhaps could do something similar to: https://github.com/material-components/material-components-ios/blob/b8090cb6382910cc4190c7030739e145f3856929/components/FlexibleHeader/tests/unit/supplemental/FlexibleHeaderTopSafeAreaTestsFakeViewController.m#L90-L94.

Wanted to get your thoughts on this before diving further @yarneo.