### PR TITLE
[FlexibleHeader] Add new flag to allow use of inferTopSafeAreaInsetFromViewController with topLayoutGuideAdjustmentEnabled

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -486,6 +486,14 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   return _topSafeArea.topSafeAreaSourceViewController;
 }
 
+- (void)setSubtractsAdditionalSafeAreaInsets:(BOOL)subtractsAdditionalSafeAreaInsets {
+  _topSafeArea.subtractsAdditionalSafeAreaInsets = subtractsAdditionalSafeAreaInsets;
+}
+
+- (BOOL)subtractsAdditionalSafeAreaInsets {
+  return _topSafeArea.subtractsAdditionalSafeAreaInsets;
+}
+
 - (void)topSafeAreaInsetDidChange {
   [_topSafeArea safeAreaInsetsDidChange];
 }

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.h
@@ -109,8 +109,30 @@
  topLayoutGuideViewController's top layout guide, which would then be included in the
  next read of the ancestor's safe area inset, compounding the safe area inset and increasing the
  header height infinitely.
+
+ If your app only supports iOS 11+, you can instead set
+ permitInferringTopSafeAreaFromTopLayoutGuideViewController to YES.
  */
 @property(nonatomic) BOOL inferTopSafeAreaInsetFromViewController;
+
+/**
+ This runtime flag affects the way the top safe area is calculated.
+
+ When disabled, if both inferTopSafeAreaInsetFromViewController and topLayoutGuideAdjustmentEnabled
+ are set to YES, and the view controller selected to extract the safe area inset from (either
+ automatically or via the delegate) is the same as topLayoutGuideViewController, the app will
+ crash.
+
+ When enabled, the app will not crash in the situation described above. This is only supported on
+ iOS 11+.
+
+ Enable this property before setting inferTopSafeAreaInsetFromViewController or
+ topLayoutGuideViewController.
+
+ By default this is NO. In the future it will be enabled by default and eventually removed.
+ */
+@property(nonatomic)
+    BOOL permitInferringTopSafeAreaFromTopLayoutGuideViewController NS_AVAILABLE_IOS(11.0);
 
 /**
  When a WKWebView's scroll view is the tracking scroll view, this behavioral flag affects whether

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.h
@@ -38,6 +38,13 @@ __attribute__((objc_subclassing_restricted)) @interface MDCFlexibleHeaderTopSafe
  */
 @property(nonatomic, weak, nullable) UIViewController *topSafeAreaSourceViewController;
 
+/**
+ Whether to subtract additionalSafeAreaInsets from the extracted safeAreaInsets.
+
+ Ignored if topSafeAreaSourceViewController is nil.
+ */
+@property(nonatomic) BOOL subtractsAdditionalSafeAreaInsets;
+
 #pragma mark Querying the top safe area
 
 /**

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderTopSafeArea.m
@@ -41,6 +41,14 @@ static const CGFloat kNonXStatusBarHeight = 20;
   }
 }
 
+- (void)setSubtractsAdditionalSafeAreaInsets:(BOOL)subtractsAdditionalSafeAreaInsets {
+  _subtractsAdditionalSafeAreaInsets = subtractsAdditionalSafeAreaInsets;
+
+  if (self.inferTopSafeAreaInsetFromViewController) {
+    [self extractTopSafeAreaInset];
+  }
+}
+
 - (CGFloat)topSafeAreaInset {
   if (self.inferTopSafeAreaInsetFromViewController) {
     // Generally-speaking, we consider the top safe area inset to equate to the length of any
@@ -125,7 +133,11 @@ static const CGFloat kNonXStatusBarHeight = 20;
   }
 
   if (@available(iOS 11.0, *)) {
-    self.extractedTopSafeAreaInset = viewController.view.safeAreaInsets.top;
+    CGFloat safeAreaTop = viewController.view.safeAreaInsets.top;
+    if (self.subtractsAdditionalSafeAreaInsets) {
+      safeAreaTop -= viewController.additionalSafeAreaInsets.top;
+    }
+    self.extractedTopSafeAreaInset = safeAreaTop;
   } else {
     self.extractedTopSafeAreaInset = viewController.topLayoutGuide.length;
   }

--- a/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
+++ b/components/FlexibleHeader/src/private/MDCFlexibleHeaderView+Private.h
@@ -23,6 +23,13 @@
 @property(nonatomic, weak, nullable) UIViewController *topSafeAreaSourceViewController;
 
 /*
+ Whether to subtract additionalSafeAreaInsets from the extracted safeAreaInsets.
+
+ Ignored if topSafeAreaSourceViewController is nil.
+ */
+@property(nonatomic) BOOL subtractsAdditionalSafeAreaInsets;
+
+/*
  A behavioral flag affecting whether the flexible header view should extract top safe area insets
  from topSafeAreaSourceViewController or not.
  */

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -73,19 +73,18 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
 
   func testNoScrollViewInferSafeAreaTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
     // Given
-    let contentViewController = UIViewController()
-    contentViewController.addChild(fhvc)
-    contentViewController.view.addSubview(fhvc.view)
     if #available(iOS 11.0, *) {
-      fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
-    }
-    fhvc.inferTopSafeAreaInsetFromViewController = true
-    fhvc.topLayoutGuideViewController = contentViewController
-    fhvc.didMove(toParent: contentViewController)
+      let contentViewController = UIViewController()
+      contentViewController.addChild(fhvc)
+      contentViewController.view.addSubview(fhvc.view)
+        fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
+      }
+      fhvc.inferTopSafeAreaInsetFromViewController = true
+      fhvc.topLayoutGuideViewController = contentViewController
+      fhvc.didMove(toParent: contentViewController)
 
-    // Then
-    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
-    if #available(iOS 11.0, *) {
+      // Then
+      XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
       XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, fhvc.headerView.frame.maxY)
     }
   }

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -85,7 +85,9 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
 
     // Then
     XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
-    XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, fhvc.headerView.frame.maxY)
+    if #available(iOS 11.0, *) {
+      XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, fhvc.headerView.frame.maxY)
+    }
   }
 
   // MARK: Untracked table view

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -71,6 +71,22 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     }
   }
 
+  @available(iOS 11.0, *)
+  func testNoScrollViewInferSafeAreaTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
+    // Given
+    let contentViewController = UIViewController()
+    contentViewController.addChild(fhvc)
+    contentViewController.view.addSubview(fhvc.view)
+    fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
+    fhvc.inferTopSafeAreaInsetFromViewController = true
+    fhvc.topLayoutGuideViewController = contentViewController
+    fhvc.didMove(toParent: contentViewController)
+
+    // Then
+    XCTAssertEqual(contentViewController.topLayoutGuide.length, fhvc.headerView.frame.maxY)
+    XCTAssertEqual(contentViewController.additionalSafeAreaInsets.top, fhvc.headerView.frame.maxY)
+  }
+
   // MARK: Untracked table view
 
   func testUntrackedTableViewTopLayoutGuideEqualsBottomEdgeOfHeaderView() {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -77,8 +77,7 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
       let contentViewController = UIViewController()
       contentViewController.addChild(fhvc)
       contentViewController.view.addSubview(fhvc.view)
-        fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
-      }
+      fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
       fhvc.inferTopSafeAreaInsetFromViewController = true
       fhvc.topLayoutGuideViewController = contentViewController
       fhvc.didMove(toParent: contentViewController)

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderInjectionTopLayoutGuideTests.swift
@@ -71,13 +71,14 @@ class FlexibleHeaderInjectionTopLayoutGuideTests: XCTestCase {
     }
   }
 
-  @available(iOS 11.0, *)
   func testNoScrollViewInferSafeAreaTopLayoutGuideEqualsBottomEdgeOfHeaderView() {
     // Given
     let contentViewController = UIViewController()
     contentViewController.addChild(fhvc)
     contentViewController.view.addSubview(fhvc.view)
-    fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
+    if #available(iOS 11.0, *) {
+      fhvc.permitInferringTopSafeAreaFromTopLayoutGuideViewController = true
+    }
     fhvc.inferTopSafeAreaInsetFromViewController = true
     fhvc.topLayoutGuideViewController = contentViewController
     fhvc.didMove(toParent: contentViewController)


### PR DESCRIPTION
Add new flag to allow use of inferTopSafeAreaInsetFromViewController with topLayoutGuideAdjustmentEnabled

Without this change, using both of these properties will sometimes crash.
