### PR TITLE
[TextControls] Add swift storyboard example

### DIFF
--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -15,6 +15,7 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
+    "mdc_examples_swift_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -68,6 +69,14 @@ mdc_examples_objc_library(
         ":Theming",
         "//components/Buttons",
         "//components/schemes/Container",
+    ],
+)
+
+mdc_examples_swift_library(
+    name = "SwiftExamples",
+    deps = [
+        ":TextControls",
+        ":Theming",
     ],
 )
 

--- a/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
+++ b/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UIKit
 import MaterialComponents.MaterialTextControls
 import MaterialComponents.MaterialTextControls_Theming
 
+import UIKit
+
+/// This example showcases how to use an MDCTextControl with a storyboard.
 final class MDCTextControlTextFieldsStoryboardExample: UIViewController {
+
+  //MARK: Properties
 
   @IBOutlet weak var filledTextField: MDCFilledTextField!
   @IBOutlet weak var outlinedTextField: MDCOutlinedTextField!
 
   @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+
+  //MARK: Object Lifecycle
 
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
@@ -31,10 +37,14 @@ final class MDCTextControlTextFieldsStoryboardExample: UIViewController {
     NotificationCenter.default.removeObserver(self)
   }
 
+  //MARK: View Lifecycle
+
   override func viewDidLoad() {
     super.viewDidLoad()
     setUpTextFields()
   }
+
+  //MARK: Setup
 
   func setUpTextFields() {
     filledTextField.label.text = "label text"
@@ -47,8 +57,7 @@ final class MDCTextControlTextFieldsStoryboardExample: UIViewController {
   }
 }
 
-// MARK: - CatalogByConvention
-
+/// This extension implements a CatalogByConvention method
 extension MDCTextControlTextFieldsStoryboardExample {
   @objc class func catalogMetadata() -> [String: Any] {
     return [

--- a/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
+++ b/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import UIKit
+import MaterialComponents.MaterialTextControls
+import MaterialComponents.MaterialTextControls_Theming
 
 final class MDCTextControlTextFieldsStoryboardExample: UIViewController {
 

--- a/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
+++ b/components/TextControls/examples/MDCTextControlTextFieldsStoryboardExample.swift
@@ -1,0 +1,59 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+final class MDCTextControlTextFieldsStoryboardExample: UIViewController {
+
+  @IBOutlet weak var filledTextField: MDCFilledTextField!
+  @IBOutlet weak var outlinedTextField: MDCOutlinedTextField!
+
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+
+  required init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setUpTextFields()
+  }
+
+  func setUpTextFields() {
+    filledTextField.label.text = "label text"
+    filledTextField.placeholder = "placeholder text"
+    filledTextField.applyTheme(withScheme: containerScheme)
+
+    outlinedTextField.label.text = "label text"
+    outlinedTextField.placeholder = "placeholder text"
+    outlinedTextField.applyTheme(withScheme: containerScheme)
+  }
+}
+
+// MARK: - CatalogByConvention
+
+extension MDCTextControlTextFieldsStoryboardExample {
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Text Controls", "MDCTextControl TextFields (Storyboard)"],
+      "primaryDemo": false,
+      "presentable": false,
+      "storyboardName": "MDCTextControlTextFieldsStoryboardExample"
+    ]
+  }
+}

--- a/components/TextControls/examples/resources/MDCTextControlTextFieldsStoryboardExample.storyboard
+++ b/components/TextControls/examples/resources/MDCTextControlTextFieldsStoryboardExample.storyboard
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tne-qL-tVg">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Text Control Text Fields Storyboard Example-->
+        <scene sceneID="AI2-Cq-eFA">
+            <objects>
+                <viewController id="Tne-qL-tVg" customClass="MDCTextControlTextFieldsStoryboardExample" customModule="MaterialComponentsExamples" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="sQd-I4-ipH"/>
+                        <viewControllerLayoutGuide type="bottom" id="9CB-iU-8AN"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="4Ps-Zj-S5d">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YJM-Hq-LRT" customClass="MDCFilledTextField">
+                                <rect key="frame" x="50" y="94" width="314" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GpT-rE-WFy" customClass="MDCOutlinedTextField">
+                                <rect key="frame" x="50" y="161" width="314" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="GpT-rE-WFy" firstAttribute="leading" secondItem="4Ps-Zj-S5d" secondAttribute="leading" constant="50" id="3a1-pC-434"/>
+                            <constraint firstItem="GpT-rE-WFy" firstAttribute="top" secondItem="YJM-Hq-LRT" secondAttribute="bottom" constant="50" id="C3m-09-wP8"/>
+                            <constraint firstAttribute="trailing" secondItem="GpT-rE-WFy" secondAttribute="trailing" constant="50" id="HZA-uU-Vwf"/>
+                            <constraint firstAttribute="trailing" secondItem="YJM-Hq-LRT" secondAttribute="trailing" constant="50" id="fXa-Qa-tZJ"/>
+                            <constraint firstItem="YJM-Hq-LRT" firstAttribute="leading" secondItem="4Ps-Zj-S5d" secondAttribute="leading" constant="50" id="q5G-qP-GNN"/>
+                            <constraint firstItem="YJM-Hq-LRT" firstAttribute="top" secondItem="sQd-I4-ipH" secondAttribute="bottom" constant="50" id="rnG-Zr-Wld"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Mmq-hZ-DQb"/>
+                    </view>
+                    <connections>
+                        <outlet property="filledTextField" destination="YJM-Hq-LRT" id="OBb-Fl-tvM"/>
+                        <outlet property="outlinedTextField" destination="GpT-rE-WFy" id="g4u-ZA-xtF"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="63B-YX-U94" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-201" y="-60"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
This PR adds a Swift storyboard example for TextControls.

Here is a screenshot:

![Simulator Screen Shot - iPhone 7 - 2019-12-20 at 15 15 17](https://user-images.githubusercontent.com/8020010/71290693-7b316280-233e-11ea-9029-4097a4d12c46.png)

Closes #9329.
