### PR TITLE
Revert "[scripts/release] Always branch off of stable. (#9310)"

### DIFF
--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -6,9 +6,8 @@ These instructions describe how to cut a new release.
 
 MDC follows the ["git flow"](http://nvie.com/posts/a-successful-git-branching-model/) style of 
 development, where the default branch is called `develop`. `stable` (instead of the traditional
-`master`) is reserved for releases. The `develop` branch is periodically merged into a release
-candidate that is cut from `stable`. The release candidate is then tested and release notes are
-added. Once validated, the release-candidate is merged into `stable`, which serves as the stable "vetted" branch, and into `develop`.
+`master`) is reserved for releases. The `develop` branch is periodically copied to a release candidate,
+tested, and then merged into `stable`, which serves as the stable "vetted" branch.
 
 ## A note on the role of the release engineer
 

--- a/scripts/README-release.md
+++ b/scripts/README-release.md
@@ -20,9 +20,7 @@ version tag.
 ## Cut the release
 
 When a stable release is ready to be cut, a `release-candidate` branch is `cut`
-from the latest `origin/stable` commit and `origin/develop` is merged into the
-`release-candidate` branch in preparation for cherry picks, unless the release
-is a hotfix in which case nothing is merged into the branch by default.
+from the latest `origin/develop` commit.
 
     release cut
 

--- a/scripts/release
+++ b/scripts/release
@@ -133,15 +133,15 @@ cut_release() {
     exit 1 # TODO: Revert this line so we bail out.
   fi
 
-  git checkout -b release-candidate origin/stable
-
   if $isHotFix; then
-    echo "This is a hotfix... we've branched off origin/stable and are now awaiting cherry-picks."
+    branch=origin/stable
+    branch_message="This is a hotfix... branching off $branch"
   else
-    echo "This is a normal release... we've branched off origin/stable and are now merging origin/develop..."
-    git merge --no-ff origin/develop --no-edit
+    branch=origin/develop
+    branch_message="This is a normal release... branching off $branch"
   fi
-
+  echo $branch_message
+  git checkout -b release-candidate $branch
   git checkout origin/stable -- .gitattributes
 
   touch "$rootdir/CHANGELOG.md"


### PR DESCRIPTION
This reverts commit ca81e6e42826956e1912665a8e8077ab0d9705be.

The reverted commit does not actually fix the ancestry problem for a given release and the change was adding an unnecessary merge operation as a result. Simply branching off of `develop` is sufficient to create history from `stable` to `develop`.

In a follow-up change, I will address the actual root problem of `develop` not having an ancestral relations to the `stable` release commits.