### PR TITLE
[scripts/release] Connect stable to develop's ancestry.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -291,8 +291,18 @@ merge_release() {
   fi
 
   echo "Merging release-candidate into stable and develop..."
+  
+  # Legend of commits.
+  # Each numbered commit corresponds to a set of commands below, with all `o` symbols having been
+  # committed by earlier steps in the release process.
+  #
+  #           develop o-o----------3
+  #                      \        /
+  # release-candidate     o--o---2
+  #                           \ /
+  #            stable o--------1
 
-  # Create the releasable merge commit in stable.
+  # Create the releasable merge commit in stable (commit #1).
   git fetch
   if [ ! $(git rev-parse --verify stable 2> /dev/null) ]; then
     git checkout -b stable origin/stable
@@ -302,12 +312,10 @@ merge_release() {
   git rebase origin/stable
   git merge --no-ff release-candidate --no-edit
 
-  # Connect stable to develop's ancestry by merging stable back into the release-candidate...
+  # Connect stable to develop's ancestry by merging stable back into the release-candidate.
+  # (commit #2)
   git checkout release-candidate
   git merge --no-ff stable --no-edit
-  # ...and then prepare the release-candidate to be merged into develop.
-  git checkout origin/develop -- .gitattributes
-  git commit -m "Automatic reset of .gitattributes in preparation for merge to develop."
 
   if [ ! $(git rev-parse --verify develop 2> /dev/null) ]; then
     git checkout -b develop origin/develop
@@ -316,6 +324,7 @@ merge_release() {
   fi
   git rebase origin/develop
   # The following lines will only create one commit thanks to the --no-commit argument here.
+  # (commit #3)
   git merge --no-ff --no-commit release-candidate --no-edit
   git reset HEAD .gitattributes
   git checkout -- .gitattributes

--- a/scripts/release
+++ b/scripts/release
@@ -292,7 +292,7 @@ merge_release() {
 
   echo "Merging release-candidate into stable and develop..."
 
-  # Merge in to stable.
+  # Create the releasable merge commit in stable.
   git fetch
   if [ ! $(git rev-parse --verify stable 2> /dev/null) ]; then
     git checkout -b stable origin/stable
@@ -300,8 +300,6 @@ merge_release() {
     git checkout stable
   fi
   git rebase origin/stable
-
-  # Create the releasable merge commit.
   git merge --no-ff release-candidate --no-edit
 
   # Connect stable to develop's ancestry by merging stable back into the release-candidate...

--- a/scripts/release
+++ b/scripts/release
@@ -300,7 +300,16 @@ merge_release() {
     git checkout stable
   fi
   git rebase origin/stable
+
+  # Create the releasable merge commit.
   git merge --no-ff release-candidate --no-edit
+
+  # Connect stable to develop's ancestry by merging stable back into the release-candidate...
+  git checkout release-candidate
+  git merge --no-ff stable --no-edit
+  # ...and then prepare the release-candidate to be merged into develop.
+  git checkout origin/develop -- .gitattributes
+  git commit -m "Automatic reset of .gitattributes in preparation for merge to develop."
 
   if [ ! $(git rev-parse --verify develop 2> /dev/null) ]; then
     git checkout -b develop origin/develop

--- a/scripts/release
+++ b/scripts/release
@@ -302,7 +302,7 @@ merge_release() {
   #                           \ /
   #            stable o--------1
 
-  # Create the releasable merge commit in stable (commit #1).
+  # Commit #1: Create the releasable merge commit in stable.
   git fetch
   if [ ! $(git rev-parse --verify stable 2> /dev/null) ]; then
     git checkout -b stable origin/stable
@@ -312,11 +312,12 @@ merge_release() {
   git rebase origin/stable
   git merge --no-ff release-candidate --no-edit
 
-  # Connect stable to develop's ancestry by merging stable back into the release-candidate.
-  # (commit #2)
+  # Commit #2: Connect stable to develop's ancestry by merging stable back into the
+  # release-candidate.
   git checkout release-candidate
   git merge --no-ff stable --no-edit
 
+  # Commit #3: Merge the release-candidate into develop.
   if [ ! $(git rev-parse --verify develop 2> /dev/null) ]; then
     git checkout -b develop origin/develop
   else
@@ -324,7 +325,6 @@ merge_release() {
   fi
   git rebase origin/develop
   # The following lines will only create one commit thanks to the --no-commit argument here.
-  # (commit #3)
   git merge --no-ff --no-commit release-candidate --no-edit
   git reset HEAD .gitattributes
   git checkout -- .gitattributes


### PR DESCRIPTION
Prior to this change, merging the release-candidate would create a new merge commit in `stable` that was never accessible from `develop`'s direct history.

![Untitled Diagram (3)](https://user-images.githubusercontent.com/45670/71490777-af06ff00-27fa-11ea-8737-e24d7b6e69d0.png)

After this change, the release `merge` command will merge `stable` back into `release-candidate` prior to merging `release-candidate` into `develop`. This ensures that there is a direct lineage from `develop` to the most recent `stable` release.

![Untitled Diagram (2)](https://user-images.githubusercontent.com/45670/71490627-b8439c00-27f9-11ea-9c16-7338bea54a10.png)

Part of https://github.com/material-components/material-components-ios/issues/9025
