### PR TITLE
[Shadows] Experiment with UIKit shadows

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1316,9 +1316,9 @@ Pod::Spec.new do |mdc|
     end
   end
 
-  # ShadowMetrics
+  # ShadowStandards
 
-  mdc.subspec "ShadowMetrics" do |component|
+  mdc.subspec "ShadowStandards" do |component|
     component.ios.deployment_target = '9.0'
     component.public_header_files = "components/#{component.base_name}/src/*.h"
     component.source_files = "components/#{component.base_name}/src/*.{h,m}"

--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1316,6 +1316,20 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  # ShadowMetrics
+
+  mdc.subspec "ShadowMetrics" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name}/src/*.h"
+    component.source_files = "components/#{component.base_name}/src/*.{h,m}"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+        "components/#{component.base_name}/tests/unit/*.{h,m,swift}",
+      ]
+    end
+  end
+
   # ShapeLibrary
 
   mdc.subspec "ShapeLibrary" do |component|

--- a/components/ShadowStandards/examples/MDCShadowStandardsExampleViewController.swift
+++ b/components/ShadowStandards/examples/MDCShadowStandardsExampleViewController.swift
@@ -1,0 +1,142 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import MaterialComponents.MaterialContainerScheme
+import MaterialComponents.MaterialShadowStandards
+import UIKit
+
+class MDCShadowStandardsExampleViewController: UIViewController {
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+
+  private let slider = UISlider()
+
+  private let label = UILabel()
+
+  private let exampleView = MDCExampleShadowView()
+
+  private let exampleLegacyView = MDCLegacyExampleShadowView()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
+    exampleView.backgroundColor = containerScheme.colorScheme.primaryColor
+    view.addSubview(exampleView)
+    exampleLegacyView.backgroundColor = containerScheme.colorScheme.primaryColor
+    view.addSubview(exampleLegacyView)
+    slider.minimumValue = 0
+    slider.maximumValue = 24
+    view.addSubview(slider)
+    slider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
+    label.text = "Elevation: \(Int(slider.value))"
+    label.textAlignment = .center
+    view.addSubview(label)
+  }
+
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    var safeArea: UIEdgeInsets = .zero
+    if #available(iOS 11.0, *) {
+      safeArea = view.safeAreaInsets
+    }
+    exampleView.frame = CGRect(
+      x: (view.bounds.width / 2) - 50,
+      y: 100 + safeArea.top,
+      width: 100,
+      height: 100
+    )
+    exampleLegacyView.frame = CGRect(
+      x: (view.bounds.width / 2) - 50,
+      y: 250 + safeArea.top,
+      width: 100,
+      height: 100
+    )
+    slider.frame = CGRect(
+      x: 20 + safeArea.left,
+      y: 20 + safeArea.top,
+      width: view.bounds.width - (40 + safeArea.left + safeArea.right),
+      height: 48
+    )
+    label.frame = CGRect(
+      x: 20 + safeArea.left,
+      y: 68 + safeArea.top,
+      width: view.bounds.width - (40 + safeArea.left + safeArea.right),
+      height: 24
+    )
+  }
+
+  @objc func sliderValueChanged() {
+    exampleView.elevation = CGFloat(Int(slider.value))
+    exampleLegacyView.elevation = CGFloat(Int(slider.value))
+    label.text = "Elevation: \(Int(slider.value))"
+  }
+}
+
+class MDCLegacyExampleShadowView: UIView {
+  override class var layerClass: AnyClass {
+    return MDCShadowLayer.self
+  }
+
+  func shadowLayer() -> MDCShadowLayer {
+    return self.layer as! MDCShadowLayer
+  }
+
+  var elevation: CGFloat {
+    didSet {
+      (self.layer as! MDCShadowLayer).elevation = ShadowElevation(rawValue: elevation)
+    }
+  }
+
+  override init(frame: CGRect) {
+    elevation = 8
+    super.init(frame: frame)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+class MDCExampleShadowView: UIView {
+  var elevation: CGFloat {
+    didSet {
+      let shadowStandards = MDCShadowStandards(elevation: elevation)
+      layer.shadowOpacity = shadowStandards.shadowOpacity
+      layer.shadowOffset = shadowStandards.shadowOffset
+      layer.shadowRadius = shadowStandards.shadowRadius
+    }
+  }
+
+  override init(frame: CGRect) {
+    elevation = 8
+    super.init(frame: frame)
+    layer.shadowColor = UIColor.black.cgColor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Catalog by conventions
+extension MDCShadowStandardsExampleViewController {
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Shadow Standards", "Shadow Standards"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}

--- a/components/ShadowStandards/src/MDCShadowStandards.h
+++ b/components/ShadowStandards/src/MDCShadowStandards.h
@@ -1,0 +1,19 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <CoreGraphics/CoreGraphics.h>
+
+@interface MDCShadowStandards : NSObject
+
+@end

--- a/components/ShadowStandards/src/MDCShadowStandards.h
+++ b/components/ShadowStandards/src/MDCShadowStandards.h
@@ -14,6 +14,36 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 
+/**
+ The standard shadow values applied to a UIView's @c layer when creating Material components.
+ */
 @interface MDCShadowStandards : NSObject
+
+/**
+ The opacity of the layer’s shadow.
+ */
+@property(nonatomic, assign, readonly) float shadowOpacity;
+
+/**
+ The blur radius (in points) used to render the layer’s shadow.
+ */
+@property(nonatomic, assign, readonly) CGFloat shadowRadius;
+
+/**
+The offset (in points) of the layer’s shadow. 
+ */
+@property(nonatomic, assign, readonly) CGSize shadowOffset;
+
+/**
+ Returns a @c MDCShadowStandard with the properties set for a given elevation.
+
+ @param elevation The elevation a @c UIView should represent.
+ */
+- (nonnull instancetype)initWithElevation:(CGFloat)elevation NS_DESIGNATED_INITIALIZER;
+
+/**
+ Please use @c initWithElevation.
+ */
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/components/ShadowStandards/src/MDCShadowStandards.m
+++ b/components/ShadowStandards/src/MDCShadowStandards.m
@@ -16,6 +16,14 @@
 
 @implementation MDCShadowStandards
 
-
+- (instancetype)initWithElevation:(CGFloat)elevation {
+  self = [super init];
+  if (self) {
+    _shadowOpacity = (float)0.24;
+    _shadowRadius = elevation * (CGFloat)0.5;
+    _shadowOffset = CGSizeMake(0, (CGFloat)1.25 * elevation);
+  }
+  return self;
+}
 
 @end

--- a/components/ShadowStandards/src/MDCShadowStandards.m
+++ b/components/ShadowStandards/src/MDCShadowStandards.m
@@ -1,0 +1,21 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCShadowStandards.h"
+
+@implementation MDCShadowStandards
+
+
+
+@end

--- a/components/ShadowStandards/src/MaterialShadowStandards.h
+++ b/components/ShadowStandards/src/MaterialShadowStandards.h
@@ -1,0 +1,15 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCShadowStandards.h"


### PR DESCRIPTION
This is an experimental PR if we were to use UIKit shadows. Below are images of UIKit vs our current shadow implementation.

| 1pt | 2pt | 3pt |
| -- | -- | -- |
|![1pt](https://user-images.githubusercontent.com/7131294/71527709-6f3f2680-2891-11ea-88c5-f01aea777137.png)|![2pt](https://user-images.githubusercontent.com/7131294/71527713-749c7100-2891-11ea-9dcc-9f14d123d656.png)|![3pt](https://user-images.githubusercontent.com/7131294/71527718-782ff800-2891-11ea-8d9b-77e7a3c5dbe3.png)|

| 4pt | 5pt | 6pt |
| -- | -- | -- |
|![4pt](https://user-images.githubusercontent.com/7131294/71527737-8a119b00-2891-11ea-963b-78fd30ad24b4.png)|![5pt](https://user-images.githubusercontent.com/7131294/71527741-8ed64f00-2891-11ea-8187-88b61559f87a.png)|![6pt](https://user-images.githubusercontent.com/7131294/71527746-93026c80-2891-11ea-88bd-200ba7eeadc5.png)|

| 7pt | 8pt | 9pt |
| -- | -- | -- |
|![7pt](https://user-images.githubusercontent.com/7131294/71527761-a0b7f200-2891-11ea-9e74-c688f787eeb1.png)|![8pt](https://user-images.githubusercontent.com/7131294/71527764-a57ca600-2891-11ea-8767-598e38d69c6f.png)|![9pt](https://user-images.githubusercontent.com/7131294/71527767-a9a8c380-2891-11ea-9797-733d5a900bec.png)|

| 10pt | 11pt | 12pt |
| -- | -- | -- |
|![10pt](https://user-images.githubusercontent.com/7131294/71527787-b88f7600-2891-11ea-900a-421eab1ebe97.png)|![11pt](https://user-images.githubusercontent.com/7131294/71527792-bfb68400-2891-11ea-9029-883f969c6c67.png)|![12pt](https://user-images.githubusercontent.com/7131294/71527793-c47b3800-2891-11ea-8ed7-096e16409f9b.png)|

| 13pt | 14pt | 15pt |
| -- | -- | -- |
|![13pt](https://user-images.githubusercontent.com/7131294/71527806-d8269e80-2891-11ea-826d-1aa6492f4f0b.png)|![14pt](https://user-images.githubusercontent.com/7131294/71527811-deb51600-2891-11ea-93b0-a95d22a95c72.png)|![15pt](https://user-images.githubusercontent.com/7131294/71527818-e2e13380-2891-11ea-8c39-ee0482f6c114.png)|

| 16pt | 17pt | 18pt |
| -- | -- | -- |
|![16pt](https://user-images.githubusercontent.com/7131294/71527834-f2f91300-2891-11ea-9dc6-db97cc28b6b4.png)|![17pt](https://user-images.githubusercontent.com/7131294/71527837-f7253080-2891-11ea-96d6-adb0326b276b.png)|![18pt](https://user-images.githubusercontent.com/7131294/71527840-fb514e00-2891-11ea-906e-f73229723ea6.png)|

| 19pt | 20pt | 21pt |
| -- | -- | -- |
|![19pt](https://user-images.githubusercontent.com/7131294/71527858-099f6a00-2892-11ea-82e7-fe98bc617489.png)|![20pt](https://user-images.githubusercontent.com/7131294/71527863-0e641e00-2892-11ea-8319-f9bd38862e57.png)|![21pt](https://user-images.githubusercontent.com/7131294/71527876-17ed8600-2892-11ea-8b10-b4fc6d9c2360.png)|

| 22pt | 23pt | 24pt |
| -- | -- | -- |
|![22pt](https://user-images.githubusercontent.com/7131294/71527894-2d62b000-2892-11ea-8ecf-2c34cd17e461.png)|![23pt](https://user-images.githubusercontent.com/7131294/71527898-318ecd80-2892-11ea-9dc2-b56e33eb5e8b.png)|![24pt](https://user-images.githubusercontent.com/7131294/71527901-35baeb00-2892-11ea-89f7-e794070d765e.png)|























