### PR TITLE
[bazel] Switch back to google/xctestrunner.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,12 +53,10 @@ git_repository(
     tag = "v3.0.0",
 )
 
-# TODO: https://github.com/material-components/material-components-ios/issues/8182
-# Restore this back to google/xctestrunner repository once Xcode 11's fix is in their new release
 http_file(
     name = "xctestrunner",
     executable = 1,
-    urls = ["https://github.com/material-foundation/xctestrunner/releases/download/0.2.9/ios_test_runner.par"],
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.10/ios_test_runner.par"],
 )
 
 git_repository(


### PR DESCRIPTION
Closes https://github.com/material-components/material-components-ios/issues/8182