### PR TITLE
[FlexibleHeader] Delete deprecated contentView property

### DIFF
--- a/components/FlexibleHeader/README.md
+++ b/components/FlexibleHeader/README.md
@@ -770,7 +770,7 @@ override var childViewControllerForStatusBarStyle: UIViewController? {
 
 This example shows how to add a custom background image view to a flexible header.
 
-You can create and add a UIImageView subview to the flexible header view's content view:
+You can create and add a UIImageView subview to the flexible header view:
 
 <!--<div class="material-code-render" markdown="1">-->
 #### Swift
@@ -780,7 +780,7 @@ let headerView = headerViewController.headerView
 let imageView = ...
 imageView.frame = headerView.bounds
 imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-headerView.contentView.insertSubview(imageView, at: 0)
+headerView.insertSubview(imageView, at: 0)
 
 imageView.contentMode = .scaleAspectFill
 imageView.clipsToBounds = true
@@ -791,7 +791,7 @@ imageView.clipsToBounds = true
 UIImageView *imageView = ...;
 imageView.frame = self.headerViewController.headerView.bounds;
 imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-[self.headerViewController.headerView.contentView insertSubview:imageView atIndex:0];
+[self.headerViewController.headerView insertSubview:imageView atIndex:0];
 
 imageView.contentMode = UIViewContentModeScaleAspectFill;
 imageView.clipsToBounds = YES;
@@ -800,7 +800,6 @@ imageView.clipsToBounds = YES;
 
 Notes:
 
-- Add the image view to the header view's `contentView`, not the header view itself.
 - Set the `contentMode` to "ScaleAspectFill" to ensure that the image always fills the available
   header space, even if the image is too small. This is usually preferred, but consider changing
   the contentMode if you want a different behavior.

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.h
@@ -483,15 +483,3 @@ IB_DESIGNABLE
     (nonnull MDCFlexibleHeaderView *)flexibleHeaderView;
 
 @end
-
-// clang-format off
-@interface MDCFlexibleHeaderView ()
-
-#pragma mark Accessing the header's views
-
-/** Deprecated. Please register views directly to the flexible header. */
-@property(nonatomic, strong, nonnull) UIView *contentView
-__deprecated_msg("Please register views directly to the flexible header.");
-
-@end
-// clang-format on

--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -304,11 +304,6 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   _topSafeAreaGuide.frame = CGRectMake(0, 0, 0, [_topSafeArea topSafeAreaInset]);
   [self addSubview:_topSafeAreaGuide];
 
-  _contentView = [[UIView alloc] initWithFrame:self.bounds];
-  _contentView.autoresizingMask =
-      (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-  [super addSubview:_contentView];
-
   if (![MDCFlexibleHeaderView appearance].backgroundColor) {
     self.backgroundColor = [UIColor lightGrayColor];
   }
@@ -423,8 +418,7 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   UIView *hitView = [super hitTest:point withEvent:event];
 
   // Forwards taps to the scroll view.
-  if (hitView == self || (_contentView != nil && hitView == _contentView) ||
-      [_forwardingViews containsObject:hitView]) {
+  if (hitView == self || [_forwardingViews containsObject:hitView]) {
     hitView = _trackingScrollView;
   }
 


### PR DESCRIPTION
Deletes the deprecated `contentView` property from MDCFlexibleHeaderView.

Fixes #9357.