### PR TITLE
[TextControls] Use CGFloat consts in theming extensions

### DIFF
--- a/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
@@ -17,7 +17,15 @@
 #import <Foundation/Foundation.h>
 
 static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
 static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+
+static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = 0.60;
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
 
 @implementation MDCFilledTextField (MaterialTheming)
 
@@ -38,33 +46,36 @@ static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
 }
 
 - (void)applyDefaultColorScheme:(id<MDCColorScheming>)colorScheme {
-  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
-  UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
   UIColor *floatingLabelColorEditing =
-      [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
-  UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+      [colorScheme.primaryColor colorWithAlphaComponent:kPrimaryFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *underlineColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.42];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity];
   UIColor *underlineColorEditing = colorScheme.primaryColor;
-  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *underlineColorDisabled = [underlineColorNormal
+      colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity * kDisabledOpacity];
 
   UIColor *filledSublayerFillColorNormal =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
@@ -105,9 +116,11 @@ static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
 }
 
 - (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
-  UIColor *textColorNormal = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
@@ -120,10 +133,10 @@ static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
       [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *underlineColorNormal = colorScheme.errorColor;
   UIColor *underlineColorEditing = underlineColorNormal;

--- a/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
 
 @implementation MDCFilledTextField (MaterialTheming)
 
@@ -66,10 +67,10 @@ static const CGFloat kDisabledOpacity = (CGFloat)0.60;
   UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *filledSublayerFillColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
   UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
 
   self.tintColor = colorScheme.primaryColor;
 
@@ -129,10 +130,10 @@ static const CGFloat kDisabledOpacity = (CGFloat)0.60;
   UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *filledSublayerFillColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
   UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
 
   self.tintColor = colorScheme.errorColor;
 

--- a/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCFilledTextField+MaterialTheming.m
@@ -23,7 +23,7 @@ static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
 static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
 
 static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
-static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = 0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
 

--- a/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
+++ b/components/TextControls/src/Theming/MDCOutlinedTextField+MaterialTheming.m
@@ -17,14 +17,12 @@
 static const CGFloat kDisabledOpacity = (CGFloat)0.60;
 
 static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
-static const CGFloat kAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
-static const CGFloat kFloatingLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kFloatingLabelColorEditingOpacity = (CGFloat)0.87;
 static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kOutlineColorNormalOpacity = (CGFloat)0.38;
 
-static const CGFloat kTextColorNormalErrorOpacity = (CGFloat)0.87;
-static const CGFloat kNormalLabelColorNormalErrorOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
 
 @implementation MDCOutlinedTextField (MaterialTheming)
 
@@ -48,31 +46,33 @@ static const CGFloat kNormalLabelColorNormalErrorOpacity = (CGFloat)0.60;
   UIColor *textColorNormal =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kAssistiveLabelColorNormalOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
-  UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFloatingLabelColorNormalOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
   UIColor *floatingLabelColorEditing =
       [colorScheme.primaryColor colorWithAlphaComponent:kFloatingLabelColorEditingOpacity];
-  UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *outlineColorNormal =
       [colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlineColorNormalOpacity];
   UIColor *outlineColorEditing = colorScheme.primaryColor;
-  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *outlineColorDisabled =
+      [outlineColorNormal colorWithAlphaComponent:kOutlineColorNormalOpacity * kDisabledOpacity];
 
   UIColor *tintColor = colorScheme.primaryColor;
 
@@ -104,9 +104,10 @@ static const CGFloat kNormalLabelColorNormalErrorOpacity = (CGFloat)0.60;
 
 - (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
   UIColor *textColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalErrorOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
@@ -119,10 +120,10 @@ static const CGFloat kNormalLabelColorNormalErrorOpacity = (CGFloat)0.60;
       [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalErrorOpacity];
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *outlineColorNormal = colorScheme.errorColor;
   UIColor *outlineColorEditing = outlineColorNormal;

--- a/components/TextControls/src/private/MDCTextControlStyleFilled.m
+++ b/components/TextControls/src/private/MDCTextControlStyleFilled.m
@@ -24,7 +24,7 @@ static const CGFloat kFilledContainerStyleTopCornerRadius = (CGFloat)4.0;
 static const CGFloat kFilledContainerStyleUnderlineWidthThin = (CGFloat)1.0;
 static const CGFloat kFilledContainerStyleUnderlineWidthThick = (CGFloat)2.0;
 
-static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
+static const CGFloat kFilledFloatingLabelScaleFactor = (CGFloat)0.75;
 
 @interface MDCTextControlStyleFilled () <CAAnimationDelegate>
 

--- a/components/TextControls/src/private/MDCTextControlStyleOutlined.m
+++ b/components/TextControls/src/private/MDCTextControlStyleOutlined.m
@@ -20,7 +20,7 @@
 
 static const CGFloat kOutlinedContainerStyleCornerRadius = (CGFloat)4.0;
 static const CGFloat kFloatingLabelOutlineSidePadding = (CGFloat)5.0;
-static const CGFloat kFilledFloatingLabelScaleFactor = 0.75;
+static const CGFloat kFilledFloatingLabelScaleFactor = (CGFloat)0.75;
 
 @interface MDCTextControlStyleOutlined ()
 

--- a/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
@@ -24,7 +24,7 @@ static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
 static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
 static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
 
-static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = 0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
 static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
 static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;

--- a/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
@@ -18,6 +18,17 @@
 #import "MaterialTextControls+Theming.h"
 #import "MaterialTextControls.h"
 
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = 0.60;
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
+
 @interface MDCFilledTextFieldThemingTest : XCTestCase
 @property(nonatomic, strong) MDCFilledTextField *textField;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
@@ -134,42 +145,42 @@
 
 - (void)verifyTextFieldPrimaryTheming {
   // Color
-  CGFloat disabledOpacity = (CGFloat)0.60;
-
   UIColor *textColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
-  UIColor *assistiveLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *assistiveLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
-  UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
 
-  UIColor *floatingLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  UIColor *floatingLabelColorEditing =
-      [self.colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
-  UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *floatingLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
+  UIColor *floatingLabelColorEditing = [self.colorScheme.primaryColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *underlineColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.42];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity];
   UIColor *underlineColorEditing = self.colorScheme.primaryColor;
-  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *underlineColorDisabled = [underlineColorNormal
+      colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity * kDisabledOpacity];
 
-  UIColor *filledSublayerFillColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
+  UIColor *filledSublayerFillColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
   UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
 
   UIColor *tintColor = self.colorScheme.primaryColor;
 
@@ -231,38 +242,37 @@
 
 - (void)verifyTextFieldErrorTheming {
   // Color
-  CGFloat disabledOpacity = (CGFloat)0.60;
-
   UIColor *textColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal = self.colorScheme.errorColor;
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
   UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal = self.colorScheme.errorColor;
   UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
   UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *underlineColorNormal = self.colorScheme.errorColor;
   UIColor *underlineColorEditing = underlineColorNormal;
-  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
-  UIColor *filledSublayerFillColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.12];
+  UIColor *filledSublayerFillColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
   UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
-  UIColor *filledSublayerFillColorDisabled =
-      [filledSublayerFillColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
 
   UIColor *tintColor = self.colorScheme.errorColor;
 

--- a/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
@@ -18,6 +18,16 @@
 #import "MaterialTextControls+Theming.h"
 #import "MaterialTextControls.h"
 
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kOutlineColorNormalOpacity = (CGFloat)0.38;
+
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+
 @interface MDCOutlinedTextFieldThemingTest : XCTestCase
 @property(nonatomic, strong) MDCOutlinedTextField *textField;
 @property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
@@ -134,36 +144,36 @@
 
 - (void)verifyTextFieldPrimaryTheming {
   // Color
-  CGFloat disabledOpacity = (CGFloat)0.60;
-
   UIColor *textColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
-  UIColor *assistiveLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *assistiveLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
-  UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
 
-  UIColor *floatingLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *floatingLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
   UIColor *floatingLabelColorEditing =
-      [self.colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
-  UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+      [self.colorScheme.primaryColor colorWithAlphaComponent:kFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *outlineColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.38];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlineColorNormalOpacity];
   UIColor *outlineColorEditing = self.colorScheme.primaryColor;
-  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *outlineColorDisabled =
+      [outlineColorNormal colorWithAlphaComponent:kOutlineColorNormalOpacity * kDisabledOpacity];
 
   UIColor *tintColor = self.colorScheme.primaryColor;
 
@@ -219,32 +229,31 @@
 
 - (void)verifyTextFieldErrorTheming {
   // Color
-  CGFloat disabledOpacity = (CGFloat)0.60;
-
   UIColor *textColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
   UIColor *textColorEditing = textColorNormal;
-  UIColor *textColorDisabled = [textColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
 
   UIColor *assistiveLabelColorNormal = self.colorScheme.errorColor;
   UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
   UIColor *assistiveLabelColorDisabled =
-      [assistiveLabelColorNormal colorWithAlphaComponent:(CGFloat)0.60];
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *floatingLabelColorNormal = self.colorScheme.errorColor;
   UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
   UIColor *floatingLabelColorDisabled =
-      [floatingLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *normalLabelColorNormal =
-      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
   UIColor *normalLabelColorEditing = normalLabelColorNormal;
-  UIColor *normalLabelColorDisabled =
-      [normalLabelColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
 
   UIColor *outlineColorNormal = self.colorScheme.errorColor;
   UIColor *outlineColorEditing = outlineColorNormal;
-  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:disabledOpacity];
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
 
   UIColor *tintColor = self.colorScheme.errorColor;
 


### PR DESCRIPTION
This PR makes it so that the opacity values in the TextControls theming extensions use CGFloat consts.

c497441 also resolves an issue related to MDCTextControl textfield disabled opacity values being higher than they should be. I noticed the disabled opacity looked off while working on #9358. This gif, which demonstrates the theming extension value changes in this PR, was taken from that PR:
![example](https://user-images.githubusercontent.com/8020010/71596471-8ab66580-2b0d-11ea-81c5-e1a775d8db14.gif)

Closes #9361.

