### PR TITLE
[Typography] Remove unused import in //components/Typography:SwiftExamples.

### DIFF
--- a/components/Typography/BUILD
+++ b/components/Typography/BUILD
@@ -56,7 +56,6 @@ mdc_examples_swift_library(
     name = "SwiftExamples",
     deps = [
         ":Typography",
-        "//components/schemes/Typography",
     ],
 )
 


### PR DESCRIPTION
Prep work for https://github.com/material-components/material-components-ios/issues/5491
