### PR TITLE
[bazel] Remove all unused swift_library load statements.

### DIFF
--- a/components/ActionSheet/BUILD
+++ b/components/ActionSheet/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_swift_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -25,7 +25,7 @@ load(
     "mdc_unit_test_swift_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_suite",
 )
 
-
 licenses(["notice"])  # Apache 2.0
 
 mdc_public_objc_library(

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -21,7 +21,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/AppBar/BUILD
+++ b/components/AppBar/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_swift_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -24,7 +24,6 @@ load(
     "mdc_snapshot_test",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])  # Apache 2.0

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -25,7 +25,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/ButtonBar/BUILD
+++ b/components/ButtonBar/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Buttons/BUILD
+++ b/components/Buttons/BUILD
@@ -27,7 +27,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Chips/BUILD
+++ b/components/Chips/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -26,7 +26,6 @@ load(
     "mdc_unit_test_swift_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -21,7 +21,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/FlexibleHeader/BUILD
+++ b/components/FlexibleHeader/BUILD
@@ -25,7 +25,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -23,7 +23,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -25,7 +25,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/NavigationDrawer/BUILD
+++ b/components/NavigationDrawer/BUILD
@@ -24,7 +24,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Ripple/BUILD
+++ b/components/Ripple/BUILD
@@ -23,7 +23,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -23,7 +23,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -23,7 +23,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -25,7 +25,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -24,7 +24,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])
 

--- a/components/TextFields/BUILD
+++ b/components/TextFields/BUILD
@@ -25,7 +25,6 @@ load(
     "mdc_unit_test_suite",
     "mdc_unit_test_swift_library",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -19,7 +19,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/Color/BUILD
+++ b/components/private/Color/BUILD
@@ -19,7 +19,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/Dragons/BUILD
+++ b/components/private/Dragons/BUILD
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 load("//:material_components_ios.bzl", "mdc_examples_swift_library")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/components/private/UIMetrics/BUILD
+++ b/components/private/UIMetrics/BUILD
@@ -18,7 +18,6 @@ load(
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
Found by searching for all references to `\bswift_library` and removing load statements from files that only returned one result.

Clean up as part of https://github.com/material-components/material-components-ios/issues/5491