### PR TITLE
[Snackbar] Update reference image for testSnackbarOverlayViewWithHighElevation

### DIFF
--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -225,6 +225,7 @@ static NSString *const kItemTitleLong2Arabic =
                                                         animated:NO
                                                       completion:nil];
 
+  // This run loop drain is here to resolve Bazel flakiness.
   XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
   dispatch_async(dispatch_get_main_queue(), ^{
     [expectation fulfill];

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -225,6 +225,12 @@ static NSString *const kItemTitleLong2Arabic =
                                                         animated:NO
                                                       completion:nil];
 
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
   // Then
   [self generateSnapshotAndVerifyForView:self.testManager.internalManager.overlayView];
 }

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -213,6 +213,8 @@ static NSString *const kItemTitleLong2Arabic =
   [self generateSnapshotAndVerifyForView:messageView];
 }
 
+// TODO(https://github.com/material-components/material-components-ios/issues/9372): determine why
+// running this in Bazel produces a different-sized screenshot than what is produced by Xcode.
 - (void)testSnackbarOverlayViewWithHighElevation {
   // Given
   MDCSnackbarMessageView *messageView = [self snackbarMessageViewWithText:kItemTitleShort1Latin

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -218,7 +218,6 @@ static NSString *const kItemTitleLong2Arabic =
   MDCSnackbarMessageView *messageView = [self snackbarMessageViewWithText:kItemTitleShort1Latin
                                                               actionTitle:kItemTitleShort2Latin];
   messageView.frame = CGRectMake(0, 0, kWidth, kHeightSingleLineText);
-//  self.testManager.internalManager.overlayView.frame = CGRectMake(0, 0, 375, 667);
 
   // When
   messageView.elevation = 24;

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -218,7 +218,7 @@ static NSString *const kItemTitleLong2Arabic =
   MDCSnackbarMessageView *messageView = [self snackbarMessageViewWithText:kItemTitleShort1Latin
                                                               actionTitle:kItemTitleShort2Latin];
   messageView.frame = CGRectMake(0, 0, kWidth, kHeightSingleLineText);
-  self.testManager.internalManager.overlayView.frame = CGRectMake(0, 0, 375, 667);
+//  self.testManager.internalManager.overlayView.frame = CGRectMake(0, 0, 375, 667);
 
   // When
   messageView.elevation = 24;

--- a/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
+++ b/components/Snackbar/tests/snapshot/MDCSnackbarMessageViewSnapshotTests.m
@@ -218,6 +218,7 @@ static NSString *const kItemTitleLong2Arabic =
   MDCSnackbarMessageView *messageView = [self snackbarMessageViewWithText:kItemTitleShort1Latin
                                                               actionTitle:kItemTitleShort2Latin];
   messageView.frame = CGRectMake(0, 0, kWidth, kHeightSingleLineText);
+  self.testManager.internalManager.overlayView.frame = CGRectMake(0, 0, 375, 667);
 
   // When
   messageView.elevation = 24;

--- a/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f81e91c7830006a7aaff251d6d54f5f256b12342d1eb72a8d34af6040c8cb36d
-size 55340
+oid sha256:baeecef3e233b49c38dc59dc09a4e77d78275686c15b09159c39ae8914ba0710
+size 44744

--- a/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSnackbarMessageViewSnapshotTests/testSnackbarOverlayViewWithHighElevation_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:baeecef3e233b49c38dc59dc09a4e77d78275686c15b09159c39ae8914ba0710
-size 44744
+oid sha256:f81e91c7830006a7aaff251d6d54f5f256b12342d1eb72a8d34af6040c8cb36d
+size 55340


### PR DESCRIPTION
Adds a runloop drain to `testSnackbarOverlayViewWithHighElevation` to reduce flakiness.

Fixes #9380