### PR TITLE
[bazel] Add a .bazelrc file.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # Common flags for all builds
-build --verbose_failures
-build --test_output=errors
+build --verbose_failures  # Print the full command line for commands that failed.
+build --test_output=errors  # Prints log file output to the console on failure.
 
 # Platform-specific flags
-build --apple_platform_type=ios
+build --apple_platform_type=ios  # Build for iOS by default.
 
 # Swift-specific features: https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/features.bzl
-build --features=swift.enable_batch_mode
-build --features=swift.use_global_module_cache
+build --features=swift.enable_batch_mode  # Intended to speed up non-incremental non-WMO builds.
+build --features=swift.use_global_module_cache  # Use the same global Clang module as ObjC targets.

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,24 @@
+# Copyright 2020-present The Material Foundation Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common flags for all builds
+build --verbose_failures
+build --test_output=errors
+
+# Platform-specific flags
+build --apple_platform_type=ios
+
+# Swift-specific features: https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/features.bzl
+build --features=swift.enable_batch_mode
+build --features=swift.use_global_module_cache


### PR DESCRIPTION
This file standardizes the flags passed to bazel when building our repo. This removes the need to specify these flags on every bazel invocation.

This initial set of flags was chosen to optimize our workflow for iOS development via the `-apple_platform_type=ios` flag. `test_output=error` is currently enabled by .kokoro and enables us to see test failure logs on CI machines. `verbose_failures` is a new flag.

The Swift options are documented in https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/features.bzl and are intended to improve build times.

Part of https://github.com/material-components/material-components-ios/issues/9363
