### PR TITLE
[bazel] Remove all unused mdc_objc_library loads.

### DIFF
--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -17,7 +17,6 @@ load(
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/AnimationTiming/BUILD
+++ b/components/AnimationTiming/BUILD
@@ -16,7 +16,6 @@ load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/Banner/BUILD
+++ b/components/Banner/BUILD
@@ -17,7 +17,6 @@ load(
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/Cards/BUILD
+++ b/components/Cards/BUILD
@@ -18,7 +18,6 @@ load(
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/CollectionCells/BUILD
+++ b/components/CollectionCells/BUILD
@@ -16,7 +16,6 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/CollectionLayoutAttributes/BUILD
+++ b/components/CollectionLayoutAttributes/BUILD
@@ -16,7 +16,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/Elevation/BUILD
+++ b/components/Elevation/BUILD
@@ -16,7 +16,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/HeaderStackView/BUILD
+++ b/components/HeaderStackView/BUILD
@@ -16,7 +16,6 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/LibraryInfo/BUILD
+++ b/components/LibraryInfo/BUILD
@@ -15,7 +15,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/List/BUILD
+++ b/components/List/BUILD
@@ -17,7 +17,6 @@ load(
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/NavigationBar/BUILD
+++ b/components/NavigationBar/BUILD
@@ -18,7 +18,6 @@ load(
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
     "mdc_extension_objc_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/OverlayWindow/BUILD
+++ b/components/OverlayWindow/BUILD
@@ -15,7 +15,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/Palettes/BUILD
+++ b/components/Palettes/BUILD
@@ -15,7 +15,6 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_swift_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/ShadowElevations/BUILD
+++ b/components/ShadowElevations/BUILD
@@ -16,7 +16,6 @@ load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/ShadowLayer/BUILD
+++ b/components/ShadowLayer/BUILD
@@ -16,7 +16,6 @@ load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
     "mdc_examples_swift_library",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/ShapeLibrary/BUILD
+++ b/components/ShapeLibrary/BUILD
@@ -15,7 +15,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/Shapes/BUILD
+++ b/components/Shapes/BUILD
@@ -15,7 +15,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_snapshot_objc_library",
     "mdc_snapshot_test",

--- a/components/Themes/BUILD
+++ b/components/Themes/BUILD
@@ -16,7 +16,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/private/Application/BUILD
+++ b/components/private/Application/BUILD
@@ -14,7 +14,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/private/Color/BUILD
+++ b/components/private/Color/BUILD
@@ -14,7 +14,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/private/Icons/BUILD
+++ b/components/private/Icons/BUILD
@@ -15,7 +15,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",

--- a/components/private/KeyboardWatcher/BUILD
+++ b/components/private/KeyboardWatcher/BUILD
@@ -14,7 +14,6 @@
 
 load(
     "//:material_components_ios.bzl",
-    "mdc_objc_library",
     "mdc_public_objc_library",
     "mdc_unit_test_objc_library",
     "mdc_unit_test_suite",


### PR DESCRIPTION
Found by searching for all references to `\bmdc_objc_library` and removing load statements from files that only returned one result.

Clean up as part of https://github.com/material-components/material-components-ios/issues/9363
