### PR TITLE
[Dialogs] Remove unused motion_transitioning_objc dependency.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,12 +90,6 @@ git_repository(
 )
 
 git_repository(
-    name = "motion_transitioning_objc",
-    remote = "https://github.com/material-motion/motion-transitioning-objc.git",
-    tag = "v6.0.0",
-)
-
-git_repository(
     name = "ios_snapshot_test_case",
     remote = "https://github.com/material-foundation/ios-snapshot-test-case",
     commit = "cd9db9129956037297ef023857e3d82c424b6880",

--- a/components/Dialogs/BUILD
+++ b/components/Dialogs/BUILD
@@ -48,7 +48,6 @@ mdc_public_objc_library(
         "//components/private/Math",
         "@material_internationalization_ios//:MDFInternationalization",
         "@motion_animator_objc//:MotionAnimator",
-        "@motion_transitioning_objc//:MotionTransitioning",
     ],
 )
 


### PR DESCRIPTION
This is clean up as part of https://github.com/material-components/material-components-ios/issues/9363