### PR TITLE
[Snackbar] clipToBounds for legacy Snackbar

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -131,6 +131,9 @@ static const CGFloat kMaximumHeight = 80;
     _watcher = watcher;
     _containingView = [[UIView alloc] initWithFrame:frame];
     _containingView.translatesAutoresizingMaskIntoConstraints = NO;
+    if (MDCSnackbarMessage.usesLegacySnackbar) {
+      _containingView.clipsToBounds = YES;
+    }
     [self addSubview:_containingView];
 
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];


### PR DESCRIPTION
When a bottomOffset is set and usesLegacySnackbar = YES, there is a regression created by this commit: https://github.com/material-components/material-components-ios/commit/c5f7118b13db0331ec16a596b0763130af4eb74e as reported by a client. The regression is causing weird janky animations when the legacy snackbar is dismissed. See b/147256304 for more info.

The original fix was to not truncate the shadow for the new non-legacy Snackbar, therefore this fix-forward doesn't hurt the needed improvement. By doing so we are reverting the code just for the legacy Snackbar, which doesn't have a bottom shadow and therefore would of not benefitted from this.