### PR TITLE
[Snackbar] Accessibility focus change to include the accessibilityHint being announced

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -246,7 +246,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
             completion:^{
               if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
                   ![self isSnackbarTransient:snackbarView]) {
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification,
                                                 snackbarView);
               } else {
                 snackbarView.accessibilityElementsHidden = YES;


### PR DESCRIPTION
Currently the accessibilityHint exists for the Snackbar and is there throughout its lifecycle, but when the focus changes with VoiceOver, it is not read out.

The current way we focus on the Snackbar for VoiceOver when it is presented is by issuing a UIAccessibilityPostNotification of UIAccessibilityLayoutChangedNotification to the MDCSnackbarMessageView. 
What this does is it focuses correctly on the Snackbar view and announces the accessibilityLabel text (the UILabel text) and the accessibilityTrait (Button), but it doesn't however read out the accessibilityHint (double-tap to dismiss).

This seems undocumented by Apple, but when focusing on an element using a UIAccessibilityLayoutChangedNotification, the hint isn't announced. 
The solution is to change the notification to UIAccessibilityScreenChangedNotification and then the hint is announced correctly.

I have tested and verified this with an actual iPhone device.
Manual steps taken for testing:
1. Launch catalog
2. Go to Snackbar Simple example
3. Turn on VoiceOver
4. Tap Snackbar with Action cell
5. Verify that for Voiceover it announces the label, trait, and then hint.

Closes #9319 