### PR TITLE
[ColorScheme] deprecate init method and update documentation to reflect its purpose.

### DIFF
--- a/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarThemingSnapshotTests.m
+++ b/components/BottomNavigation/tests/snapshot/MDCBottomNavigationBarThemingSnapshotTests.m
@@ -105,7 +105,9 @@ static const CGFloat kFakeHeight = 75;
 }
 
 - (MDCSemanticColorScheme *)customColorScheme {
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  ;
   colorScheme.primaryColor = UIColor.blueColor;
   colorScheme.primaryColorVariant = UIColor.greenColor;
   colorScheme.secondaryColor = UIColor.redColor;

--- a/components/BottomNavigation/tests/unit/Theming/MDCBottomNavigationThemingTests.m
+++ b/components/BottomNavigation/tests/unit/Theming/MDCBottomNavigationThemingTests.m
@@ -171,7 +171,9 @@ static UIImage *fakeImage(void) {
 }
 
 - (MDCSemanticColorScheme *)customColorScheme {
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  ;
   colorScheme.primaryColor = UIColor.blueColor;
   colorScheme.primaryColorVariant = UIColor.greenColor;
   colorScheme.secondaryColor = UIColor.redColor;

--- a/components/Tabs/tests/unit/Theming/TabsThemingTests.m
+++ b/components/Tabs/tests/unit/Theming/TabsThemingTests.m
@@ -101,7 +101,9 @@ static const CGFloat kSurfaceThemeUnselectedOpacity = (CGFloat)0.6;
 #pragma mark - Test helpers
 
 - (MDCSemanticColorScheme *)customColorScheme {
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  ;
 
   colorScheme.primaryColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:0];
   colorScheme.primaryColorVariant = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.1];

--- a/components/TextControls/examples/supplemental/MDCTextControlContentViewController.m
+++ b/components/TextControls/examples/supplemental/MDCTextControlContentViewController.m
@@ -315,7 +315,8 @@ This button allows the user to signal that they want to toggle the layout direct
 - (void)applyThemesToButtons {
   [self.allButtons enumerateObjectsUsingBlock:^(MDCButton *button, NSUInteger idx, BOOL *stop) {
     if (self.isErrored) {
-      MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+      MDCSemanticColorScheme *colorScheme =
+          [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
       colorScheme.primaryColor = colorScheme.errorColor;
       MDCContainerScheme *containerScheme = [[MDCContainerScheme alloc] init];
       containerScheme.colorScheme = colorScheme;

--- a/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCFilledTextFieldThemingTests.m
@@ -107,7 +107,9 @@ static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
 #pragma mark - Test helpers
 
 - (MDCSemanticColorScheme *)customColorScheme {
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  ;
 
   colorScheme.primaryColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:0];
   colorScheme.primaryColorVariant = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.1];

--- a/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
+++ b/components/TextControls/tests/unit/Theming/MDCOutlinedTextFieldThemingTests.m
@@ -106,7 +106,9 @@ static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
 #pragma mark - Test helpers
 
 - (MDCSemanticColorScheme *)customColorScheme {
-  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+  MDCSemanticColorScheme *colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201804];
+  ;
 
   colorScheme.primaryColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:0];
   colorScheme.primaryColorVariant = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.1];

--- a/components/schemes/Color/src/MDCSemanticColorScheme.h
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.h
@@ -127,9 +127,10 @@ typedef NS_ENUM(NSInteger, MDCColorSchemeDefaults) {
 @property(readwrite, assign, nonatomic) BOOL elevationOverlayEnabledForDarkMode;
 
 /**
- Initializes the color scheme with the latest material defaults.
+ Initializes the color scheme with the MDCColorSchemeDefaultsMaterial201804 default scheme.
  */
-- (nonnull instancetype)init;
+- (nonnull instancetype)init __deprecated_msg("Use initWithDefaults: with a "
+                                              "specific scheme default.");
 
 /**
  Initializes the color scheme with the colors associated with the given defaults.

--- a/components/schemes/Color/src/MDCSemanticColorScheme.m
+++ b/components/schemes/Color/src/MDCSemanticColorScheme.m
@@ -122,7 +122,10 @@ static CGFloat blendColorChannel(CGFloat value, CGFloat bValue, CGFloat alpha, C
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   MDCSemanticColorScheme *copy = [[MDCSemanticColorScheme alloc] init];
+#pragma clang diagnostic pop
   copy.primaryColor = self.primaryColor;
   copy.primaryColorVariant = self.primaryColorVariant;
   copy.secondaryColor = self.secondaryColor;

--- a/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
+++ b/components/schemes/Color/tests/unit/MDCSemanticColorSchemeTests.m
@@ -330,7 +330,10 @@ static UIColor *ColorFromRGB(uint32_t colorValue) {
 
 - (void)testColorSchemeCopy {
   // Given
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+#pragma clang diagnostic pop
 
   // When
   MDCSemanticColorScheme *colorSchemeCopy = [colorScheme copy];


### PR DESCRIPTION
closes https://github.com/material-components/material-components-ios/issues/9390