### PR TITLE
[AppBar] Annotate MDCAppBarContainerViewController's appBar and topLayoutGuideAdjustmentEnabled as to be deprecated.

### DIFF
--- a/components/AppBar/src/MDCAppBarContainerViewController.h
+++ b/components/AppBar/src/MDCAppBarContainerViewController.h
@@ -60,7 +60,11 @@
 /** The content view controller to be displayed behind the header. */
 @property(nonatomic, strong, nonnull, readonly) UIViewController *contentViewController;
 
-#pragma mark - Enabling top layout guide adjustment behavior
+@end
+
+@interface MDCAppBarContainerViewController (ToBeDeprecated)
+
+#pragma mark - To be deprecated
 
 /**
  If enabled, the content view controller's top layout guide will be adjusted as the flexible
@@ -85,8 +89,6 @@
      frame.origin.y = self.topLayoutGuide.length + 32
  */
 @property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;
-
-#pragma mark - To be deprecated
 
 /**
  The App Bar views that will be presented in front of the contentViewController's view.

--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -17,8 +17,7 @@
 #import "MDCAppBarViewController.h"
 #import "MaterialFlexibleHeader.h"
 
-
-@interface MDCAppBarContainerViewController()
+@interface MDCAppBarContainerViewController ()
 
 // To be deprecated APIs; re-declared here in order to be auto-synthesized.
 @property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;

--- a/components/AppBar/src/MDCAppBarContainerViewController.m
+++ b/components/AppBar/src/MDCAppBarContainerViewController.m
@@ -17,9 +17,16 @@
 #import "MDCAppBarViewController.h"
 #import "MaterialFlexibleHeader.h"
 
-@implementation MDCAppBarContainerViewController {
-  MDCAppBar *_appBar;
-}
+
+@interface MDCAppBarContainerViewController()
+
+// To be deprecated APIs; re-declared here in order to be auto-synthesized.
+@property(nonatomic, getter=isTopLayoutGuideAdjustmentEnabled) BOOL topLayoutGuideAdjustmentEnabled;
+@property(nonatomic, strong, nonnull, readonly) MDCAppBar *appBar;
+
+@end
+
+@implementation MDCAppBarContainerViewController
 
 - (instancetype)initWithContentViewController:(UIViewController *)contentViewController {
   self = [super initWithNibName:nil bundle:nil];


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/9392