### PR TITLE
[AppBar] Annotate MDCAppBarNavigationControllerDelegate's appBarNavigationController:willAddAppBar:asChildOfViewController: as to be deprecated.

### DIFF
--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -52,10 +52,9 @@
 /**
  Defines the events that an MDCAppBarNavigationController may send to a delegate.
  */
-@protocol MDCAppBarNavigationControllerDelegate <
-    UINavigationControllerDelegate,
-    MDCAppBarNavigationControllerToBeDeprecatedDelegate
->
+@protocol
+    MDCAppBarNavigationControllerDelegate <UINavigationControllerDelegate,
+                                           MDCAppBarNavigationControllerToBeDeprecatedDelegate>
 @optional
 
 /**

--- a/components/AppBar/src/MDCAppBarNavigationController.h
+++ b/components/AppBar/src/MDCAppBarNavigationController.h
@@ -20,9 +20,42 @@
 @class MDCFlexibleHeaderViewController;
 
 /**
+ Defines delegate methods that will be deprecated.
+ */
+@protocol MDCAppBarNavigationControllerToBeDeprecatedDelegate <NSObject>
+@optional
+
+/**
+ Informs the receiver that the given App Bar will be added as a child of the given view controller.
+
+ This event is primarily intended to allow any configuration or theming of the App Bar to occur
+ before it becomes part of the view controller hierarchy.
+
+ By the time this event has fired, the navigation controller will already have attempted to infer
+ the tracking scroll view from the provided view controller.
+
+ @note This method will only be invoked if a new App Bar instance is about to be added to the view
+ controller. If a flexible header is already present in the view controller, this method will not
+ be invoked.
+
+ @warning This method will soon be deprecated. Please use
+ -appBarNavigationController:willAddAppBarViewController:asChildOfViewController: instead. Learn
+ more at
+ https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
+ */
+- (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
+                     willAddAppBar:(nonnull MDCAppBar *)appBar
+           asChildOfViewController:(nonnull UIViewController *)viewController;
+
+@end
+
+/**
  Defines the events that an MDCAppBarNavigationController may send to a delegate.
  */
-@protocol MDCAppBarNavigationControllerDelegate <UINavigationControllerDelegate>
+@protocol MDCAppBarNavigationControllerDelegate <
+    UINavigationControllerDelegate,
+    MDCAppBarNavigationControllerToBeDeprecatedDelegate
+>
 @optional
 
 /**
@@ -72,30 +105,6 @@
                                (nonnull MDCAppBarNavigationController *)navigationController
                   trackingScrollViewForViewController:(nonnull UIViewController *)viewController
                           suggestedTrackingScrollView:(nullable UIScrollView *)scrollView;
-
-#pragma mark - Will be deprecated
-
-/**
- Informs the receiver that the given App Bar will be added as a child of the given view controller.
-
- This event is primarily intended to allow any configuration or theming of the App Bar to occur
- before it becomes part of the view controller hierarchy.
-
- By the time this event has fired, the navigation controller will already have attempted to infer
- the tracking scroll view from the provided view controller.
-
- @note This method will only be invoked if a new App Bar instance is about to be added to the view
- controller. If a flexible header is already present in the view controller, this method will not
- be invoked.
-
- @warning This method will soon be deprecated. Please use
- -appBarNavigationController:willAddAppBarViewController:asChildOfViewController: instead. Learn
- more at
- https://github.com/material-components/material-components-ios/blob/develop/components/AppBar/docs/migration-guide-appbar-appbarviewcontroller.md
- */
-- (void)appBarNavigationController:(nonnull MDCAppBarNavigationController *)navigationController
-                     willAddAppBar:(nonnull MDCAppBar *)appBar
-           asChildOfViewController:(nonnull UIViewController *)viewController;
 
 @end
 


### PR DESCRIPTION
Part of https://github.com/material-components/material-components-ios/issues/9392