### PR TITLE
[NavigationDrawer] Fix #9410

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.m
@@ -59,7 +59,9 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 
 @end
 
-@implementation MDCBottomDrawerPresentationController
+@implementation MDCBottomDrawerPresentationController {
+  UIColor *_scrimColor;
+}
 
 @synthesize delegate;
 
@@ -123,8 +125,7 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
   self.bottomDrawerContainerViewController.delegate = self;
 
   self.scrimView = [[MDCBottomDrawerScrimView alloc] initWithFrame:self.containerView.bounds];
-  self.scrimView.backgroundColor =
-      self.scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
+  self.scrimView.backgroundColor = self.scrimColor;
   self.scrimView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   self.scrimView.accessibilityIdentifier = @"Close drawer";
@@ -295,6 +296,10 @@ static CGFloat kTopHandleTopMargin = (CGFloat)5.0;
 - (void)setScrimColor:(UIColor *)scrimColor {
   _scrimColor = scrimColor;
   self.scrimView.backgroundColor = scrimColor;
+}
+
+- (UIColor *)scrimColor {
+  return _scrimColor ?: [UIColor colorWithWhite:0 alpha:(CGFloat)0.32];
 }
 
 - (void)setTopHandleHidden:(BOOL)topHandleHidden {


### PR DESCRIPTION
Fix bug where scrim color is set to `nil` by the presentation controller if it has not been explicitly set on the `MDCBottomDrawerViewController`.

Testing steps:
1) Present a `MDCBottomDrawerViewController` that has not had it's `scrimColor` explicitly set.
2) Drag `MDCBottomDrawerViewController` fully open or past full screen.
3) Drag `MDCBottomDrawerViewController` back down to partial-screen.
4) Observe that `scrimColor` is preserved at default `[UIColor colorWithWhite:0 alpha:(CGFloat)0.32]`