### PR TITLE
[Chips] Tests to evaluate `padding` APIs.

### DIFF
--- a/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
@@ -1,0 +1,485 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import "MaterialChips.h"
+
+/**
+ An MDCChipView subclass that allows the user to override the @c traitCollection property.
+ */
+@interface MDCChipViewLayoutCustomTraitCollectionFake : MDCChipView
+@property(nonatomic, strong) UITraitCollection *traitCollectionOverride;
+@end
+
+@implementation MDCChipViewLayoutCustomTraitCollectionFake
+- (UITraitCollection *)traitCollection {
+  return self.traitCollectionOverride ?: [super traitCollection];
+}
+@end
+
+/** Snapshot tests exercising the layout APIs for MDCChipView. */
+@interface MDCChipViewLayoutSnapshotTests : MDCSnapshotTestCase
+
+/** The chip being tested. */
+@property(nonatomic, strong) MDCChipViewLayoutCustomTraitCollectionFake *chipView;
+@end
+
+@implementation MDCChipViewLayoutSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+  //  self.recordMode = YES;
+
+  self.chipView = [[MDCChipViewLayoutCustomTraitCollectionFake alloc] init];
+  self.chipView.titleLabel.text = @"Chip";
+  self.chipView.imageView.image = [UIImage mdc_testImageOfSize:CGSizeMake(24, 24)];
+  UIImageView *accessoryView = [[UIImageView alloc] init];
+  accessoryView.image = [UIImage mdc_testImageOfSize:CGSizeMake(18, 18)
+                                           withStyle:MDCSnapshotTestImageStyleFramedX];
+  self.chipView.accessoryView = accessoryView;
+
+  self.chipView.titleLabel.layer.borderColor = UIColor.blueColor.CGColor;
+  self.chipView.titleLabel.layer.borderWidth = 1;
+  self.chipView.imageView.layer.borderColor = UIColor.orangeColor.CGColor;
+  self.chipView.imageView.layer.borderWidth = 1;
+  self.chipView.accessoryView.layer.borderColor = UIColor.greenColor.CGColor;
+  self.chipView.accessoryView.layer.borderWidth = 1;
+
+  self.chipView.contentPadding = UIEdgeInsetsZero;
+  self.chipView.titlePadding = UIEdgeInsetsZero;
+  self.chipView.imagePadding = UIEdgeInsetsZero;
+  self.chipView.accessoryPadding = UIEdgeInsetsZero;
+}
+
+- (void)tearDown {
+  self.chipView = nil;
+  [super tearDown];
+}
+
+- (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  CGSize aSize = [view sizeThatFits:CGSizeMake(300, INFINITY)];
+  view.bounds = CGRectMake(0, 0, aSize.width, aSize.height);
+  [view layoutIfNeeded];
+
+  UIView *snapshotView = [view mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(50, 50, 50, 50)];
+  [self snapshotVerifyView:snapshotView];
+}
+
+#pragma mark - Tests
+
+- (void)testChipWithAllZeroPadding {
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)changeToRTL:(MDCChipViewLayoutCustomTraitCollectionFake *)chip {
+  if (@available(iOS 10.0, *)) {
+    chip.traitCollectionOverride = [UITraitCollection
+                                    traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+  }
+}
+
+#pragma mark - ContentPadding
+
+- (void)testChipContentPaddingAllPositiveValuesLTR {
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingAllPositiveValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingAllNegativeValuesLTR {
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingAllNegativeValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftToLeadingEdgeLTR {
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftToLeadingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftToTrailingEdgeLTR {
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftToTrailingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftDown {
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(20, 0, -20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipContentPaddingShiftUp {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.contentPadding = UIEdgeInsetsMake(-20, 0, 20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+#pragma mark - ImagePadding
+
+- (void)testChipImagePaddingAllPositiveValuesLTR {
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingAllPositiveValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingAllNegativeValuesLTR {
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingAllNegativeValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftToLeadingEdgeLTR {
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftToLeadingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftToTrailingEdgeLTR {
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftToTrailingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftDown {
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(20, 0, -20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipImagePaddingShiftUp {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(-20, 0, 20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+#pragma mark - TitlePadding
+
+- (void)testChipTitlePaddingAllPositiveValuesLTR {
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingAllPositiveValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingAllNegativeValuesLTR {
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingAllNegativeValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftToLeadingEdgeLTR {
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftToLeadingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftToTrailingEdgeLTR {
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftToTrailingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftDown {
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(20, 0, -20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipTitlePaddingShiftUp {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.titlePadding = UIEdgeInsetsMake(-20, 0, 20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+#pragma mark - AccessoryPadding
+
+- (void)testChipAccessoryPaddingAllPositiveValuesLTR {
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingAllPositiveValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingAllNegativeValuesLTR {
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingAllNegativeValuesRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(-2, -4, -6, -8);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftToLeadingEdgeLTR {
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftToLeadingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(0, -20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftToTrailingEdgeLTR {
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftToTrailingEdgeRTL {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(0, 20, 0, -20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftDown {
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(20, 0, -20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testChipAccessoryPaddingShiftUp {
+  // Given
+  [self changeToRTL:self.chipView];
+
+  // When
+  self.chipView.accessoryPadding = UIEdgeInsetsMake(-20, 0, 20, 0);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+@end

--- a/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
@@ -90,7 +90,7 @@
 - (void)changeToRTL:(MDCChipViewLayoutCustomTraitCollectionFake *)chip {
   if (@available(iOS 10.0, *)) {
     chip.traitCollectionOverride = [UITraitCollection
-                                    traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
+        traitCollectionWithLayoutDirection:UITraitEnvironmentLayoutDirectionRightToLeft];
   }
 }
 

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllNegativeValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllNegativeValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34ebb0ba4e84daf5aff5522e8492fc1bde3b2f73bfffb84970552ffc1e3ba800
+size 5871

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllNegativeValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllNegativeValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cddbc4d25f0701c3420f53740ecdfc01f30de932b9a2a4b67429e6b541e8bee
+size 5854

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllPositiveValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllPositiveValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecdbc02802d28aaf39058f71f9e813dfce8fc9eb4d3bb3307fab19782238b435
+size 8563

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllPositiveValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingAllPositiveValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e730d381b5212aae083409a866f40eae465690429c8cc4c1bb31222c3c1ffcbb
+size 8668

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftDown_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftDown_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96a89b233e3fbb98247c658998655f71f37bbd5492c0e0ea25de3869cd913a51
+size 6258

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToLeadingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToLeadingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95071c262b97400016ce10456c2645fbcdda776efe7b00f54bda7263d9658c69
+size 5986

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToLeadingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToLeadingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85d8095702d33d024f43eb87a0604385794a59bea251a95baac560f94e8cc4d0
+size 6083

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToTrailingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToTrailingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:923479398e2d8e3d094c1ac936697710395c984f39bc26205ceefba5d005a22d
+size 6325

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToTrailingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftToTrailingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50655e0a6718a1e5d75fe65dbd9ccf49aa9bbde4078fe2c98fe9d0de358760f1
+size 6411

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftUp_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipAccessoryPaddingShiftUp_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13a9135db2adcd322c328c3288eb531972aafc7bfccde1256a3f48b20eacfaf5
+size 6552

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7896af5dae1c0492e03b20e5e6f6e09d8ff817e18bcf0d644db0431a010a8f73
+size 5997

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllNegativeValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:136e36a494f4595a75901aa666386b3d623991613a2de5d77960d1ee5dd98a70
+size 5871

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f99ab685678acaf0eda999a86c486050ebca6d4b3e3852a5d6d498b52ed4f3e
+size 8795

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingAllPositiveValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f71bf46c1ef41a83ef2944b3f5a887bbc37b829cd10f266164e1376ba9d11956
+size 8926

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftDown_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftDown_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07fae752bdb3974f04476b74fe9edb4fa4d7f51e04192683156f59b8876361c7
+size 6087

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToLeadingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToLeadingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6d7d7d351a9564ec0e5bab697333d8bd29c0581add402b70307ba81916244a1
+size 6127

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToLeadingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToLeadingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c57868f378fe4e97116940118eb2e099308ad6a5ae80f3534be200f5fabf96a7
+size 6376

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToTrailingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToTrailingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c53bbc819d1d39d1d46fd637be84ba8001329473a649c305371a322804a6982e
+size 6104

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToTrailingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftToTrailingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ccf57b23d3f815fa8d574cb518c63f809fa507b2be92abf71b432c2b57d477a
+size 6172

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftUp_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipContentPaddingShiftUp_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:029e5f8b0c87251d84a12db039b0105faa4bd4e4dc29e78d020a0c043c8b09ab
+size 6064

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllNegativeValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllNegativeValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbf66c18249f1d8de80d9cfddcb5dd9b015236db2cd49550a011f9f24750f678
+size 4507

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllNegativeValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllNegativeValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f2bcef5bade497a0b0d06f2567075aa95cfaa6dcf586c7160c7a20877684314
+size 4741

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllPositiveValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllPositiveValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91fa84afcba24db32489ba231e2831242cd97f59fff81bd1196a20b0638b9d64
+size 9330

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllPositiveValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingAllPositiveValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8934d24a090b3e2318f2cca5ea7373e7e072dc6bfdd814120ede1590f2a1428d
+size 9288

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftDown_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftDown_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fc36e319cb93e8744cd9e2117e792b325a1c0331983eafccf9f6ee3f6e38129
+size 6337

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToLeadingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToLeadingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed5c08b930636dba9bf43c18d4aaeee61e6781be340cb5cbb9e5b78acc8ba53d
+size 6166

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToLeadingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToLeadingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2ac514304ee6482f93bee13602910a83c17e39e624a7a676baa55ba5d322f90
+size 6246

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToTrailingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToTrailingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2099c086772f4406383947e52d90123bbd626221b508e76d3467f068c58a2c48
+size 5537

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToTrailingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftToTrailingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b8e1849239345866d2defb6e60059b66fe8a4857eef4546d9add6b36b23a63f
+size 5123

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftUp_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingShiftUp_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf6afd943d88de8457893ccdce876b9a1c707a2219306f82d9819caa5e6f2612
+size 6622

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllNegativeValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllNegativeValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2270bc3dcb81bd45e707d3aaed6534b092472ae8c590a6b0e7c64a1787212ab
+size 5412

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllNegativeValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllNegativeValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6693e6d042f03d6d93500d5d8b6062d51dc409e64b6ac724214babd7e1cb0ad2
+size 5450

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllPositiveValuesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllPositiveValuesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61a11305736b5d91edc5f38de094f4920acbc0ea265215ee817a220d7f8be36f
+size 8255

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllPositiveValuesRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingAllPositiveValuesRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37b9caa218d7acfd052532e612f66b18c5cb3ec007a2b8803daa76621b7fa52a
+size 8393

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftDown_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftDown_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08542bcc7b974ba68929532f00f51d9354e1eb02a34b8b1d134b9514fd08961a
+size 6012

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToLeadingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToLeadingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75dd231f367e963b636d95e27606a1af339b82b62da83f4f180469bfd7302fbd
+size 5654

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToLeadingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToLeadingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc7c9da7c04770432540298dd3ace204f892fb261e181098d8ce458ab1234eea
+size 5787

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToTrailingEdgeLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToTrailingEdgeLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e54cb639ae7e276caa03a95216cec7d92befe23dbf97c965bda596b1c3050e71
+size 5988

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToTrailingEdgeRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftToTrailingEdgeRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4efe366787c399ea2a3fdb51b5e4ddd6462c3c395a44875a7f528a45deea3290
+size 5980

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftUp_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipTitlePaddingShiftUp_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0799d76fb02ff6a6b99b6bdc495f0cfff2f60de5b31e77a519823f5b62574745
+size 6196

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipWithAllZeroPadding_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipWithAllZeroPadding_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07fae752bdb3974f04476b74fe9edb4fa4d7f51e04192683156f59b8876361c7
+size 6087


### PR DESCRIPTION
Adds several new snapshot tests intended to evaluate the following APIs:
*  `- contentPadding`
*  `- titlePadding`
*  `- imagePadding`
*  `- accessoryPadding`

Confirms bugs found as part of #7940

This is a roll-forward of #9252