### PR TITLE
[Buttons] Add tvOS support to MDCButton.

### DIFF
--- a/components/Buttons/src/MDCButton.m
+++ b/components/Buttons/src/MDCButton.m
@@ -169,7 +169,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
 
   // Disable default highlight state.
   self.adjustsImageWhenHighlighted = NO;
+
+#ifndef TARGET_OS_TV
   self.showsTouchWhenHighlighted = NO;
+#endif
 
   self.layer.cornerRadius = MDCButtonDefaultCornerRadius;
   if (!self.layer.shapeGenerator) {
@@ -195,8 +198,10 @@ static NSAttributedString *uppercaseAttributedString(NSAttributedString *string)
                 action:@selector(touchDragExit:forEvent:)
       forControlEvents:UIControlEventTouchDragExit];
 
+#ifndef TARGET_OS_TV
   // Block users from activating multiple buttons simultaneously by default.
   self.exclusiveTouch = YES;
+#endif
 
   _inkView.inkColor = [UIColor colorWithWhite:1 alpha:(CGFloat)0.2];
 


### PR DESCRIPTION
[Buttons] Add tvOS support to MDCButton.

We are trying to use Snackbar on tvOS, it uses MDCButton, and showsTouchWhenHighlighted, exclusiveTouch in MDCButton are not supported on tvOS. Without modifying, the tvOS build fail.
