### PR TITLE
[NavigationDrawer] Implemented opt-in default empty header.

### DIFF
--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -156,6 +156,15 @@
 - (void)setTopCornersRadius:(CGFloat)radius forDrawerState:(MDCBottomDrawerState)drawerState;
 
 /**
+ Called to instruct the bottom drawer to generate a default empty header. This can be used to
+ prevent bottom drawer content from conflicting with status bar when a header has not been provided
+ by the client (see Github issue #6434).
+
+ @param backgroundColor The desired backgroundColor of the header.
+ */
+- (void)setEmptyHeaderWithBackgroundColor:(nullable UIColor *)backgroundColor;
+
+/**
  Returns the top corners radius for an MDCBottomDrawerState drawerState.
 
  If no radius has been set for a state, the value 0 is returned.

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.m
@@ -17,6 +17,7 @@
 #import "MDCBottomDrawerTransitionController.h"
 #import "MaterialMath.h"
 #import "MaterialUIMetrics.h"
+#import "private/MDCBottomDrawerEmptyHeader.h"
 #import "private/MDCBottomDrawerHeaderMask.h"
 
 @interface MDCBottomDrawerViewController () <MDCBottomDrawerPresentationControllerDelegate>
@@ -120,6 +121,7 @@
 
   if (drawerState == MDCBottomDrawerStateCollapsed) {
     _maskLayer.maximumCornerRadius = radius;
+    [self updateEmptyHeaderHeightIfApplicable:radius];
   } else {
     _maskLayer.minimumCornerRadius = [self minimumCornerRadius];
   }
@@ -137,6 +139,25 @@
     return (CGFloat)[topCornersRadius doubleValue];
   }
   return 0;
+}
+
+- (void)setEmptyHeaderWithBackgroundColor:(nullable UIColor *)backgroundColor {
+  MDCBottomDrawerEmptyHeader *emptyHeader = [[MDCBottomDrawerEmptyHeader alloc] init];
+  emptyHeader.backgroundColor = backgroundColor;
+  // The height of the empty header should track the collapsed state corner radius.
+  NSNumber* collapsedCornerRadius = _topCornersRadius[@(MDCBottomDrawerStateCollapsed)];
+  if (collapsedCornerRadius) {
+    emptyHeader.headerHeight = [collapsedCornerRadius doubleValue];
+  }
+  [self setHeaderViewController:emptyHeader];
+}
+
+- (void)updateEmptyHeaderHeightIfApplicable:(CGFloat)headerHeight {
+  if ([self.headerViewController isKindOfClass:[MDCBottomDrawerEmptyHeader class]]) {
+    MDCBottomDrawerEmptyHeader *emptyHeader =
+        (MDCBottomDrawerEmptyHeader *)self.headerViewController;
+    emptyHeader.headerHeight = headerHeight;
+  }
 }
 
 - (void)setHeaderViewController:(UIViewController<MDCBottomDrawerHeader> *)headerViewController {

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerEmptyHeader.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerEmptyHeader.h
@@ -1,0 +1,37 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@protocol MDCBottomDrawerHeader;
+
+/**
+ Empty header for the MDCBottomDrawerViewController, to be used to prevent bottom drawer content
+ from conflicting with status bar when a header has not been provided by the client (see Github
+ issue #6434).
+ */
+@interface MDCBottomDrawerEmptyHeader : UIViewController <MDCBottomDrawerHeader>
+
+/**
+ The color applied to the background of the header, this likely should match the background of the
+ drawer content.
+ */
+@property(nonatomic, nullable) UIColor *backgroundColor;
+
+/**
+ The height of the header, this should match the collapsed bottom drawer corner radius, if any.
+ */
+@property(nonatomic) CGFloat headerHeight;
+
+@end

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerEmptyHeader.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerEmptyHeader.m
@@ -1,0 +1,32 @@
+// Copyright 2018-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBottomDrawerEmptyHeader.h"
+
+@implementation MDCBottomDrawerEmptyHeader
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.view.backgroundColor = self.backgroundColor;
+}
+
+- (CGSize)preferredContentSize {
+  return CGSizeMake(CGFLOAT_MIN, self.headerHeight);
+}
+
+- (void)updateDrawerHeaderTransitionRatio:(CGFloat)transitionToTopRatio {
+  // No-op.
+}
+
+@end


### PR DESCRIPTION
This PR adds to the MDCBottomDrawerViewController the ability to specify that a default header be used, which prevents the bottom drawer content from conflicting with status bar when a header has not been provided, closing #6434.

This behavior is entirely opt-in as currently implemented, and saves clients from having to each create their own implementation of a similar empty `headerViewController` (which is what we are currently having to do to work around b/123186711).

I wanted to verify whether or not this is fix is something that may be an acceptable fix for #6434 before adding tests, but if it is, I was planning to adding the following tests (and am open to adding additional suggested tests if it seems necessary):

1. Test that verifies `preferredContentSize` height of the `headerViewController` matches that of the collapsed state corner radius, regardless of the order in which `setEmptyHeaderWithBackgroundColor:` and `setCornerRadius:` are called.
2. Test that verifies that the backgroundColor specified when calling `setEmptyHeaderWithBackgroundColor:` matches the backgroundColor of the header both once it is presented and also before presentation if its view is accessed (causing `viewDidLoad:` to fire).

I've also already manually verified that this fix works as a drop-in replacement for our team's existing workaround, and have added a screencast on the internal issue for this ticket [b/123186711](http://b/123186711).

Look forward to hearing what you think about all this @yarneo 😄 