### PR TITLE
[TextFields] Add theming extension for underline controller

### DIFF
--- a/components/TextFields/examples/TextFieldControllerStylesExample.m
+++ b/components/TextFields/examples/TextFieldControllerStylesExample.m
@@ -14,8 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import "MaterialTextFields.h"
 #import "MaterialTextFields+Theming.h"
+#import "MaterialTextFields.h"
 
 #import "supplemental/TextFieldControllerStylesExampleSupplemental.h"
 

--- a/components/TextFields/examples/TextFieldControllerStylesExample.m
+++ b/components/TextFields/examples/TextFieldControllerStylesExample.m
@@ -15,6 +15,7 @@
 #import <UIKit/UIKit.h>
 
 #import "MaterialTextFields.h"
+#import "MaterialTextFields+Theming.h"
 
 #import "supplemental/TextFieldControllerStylesExampleSupplemental.h"
 
@@ -35,7 +36,10 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.view.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.97 alpha:1];
+  if (self.containerScheme == nil) {
+    self.containerScheme = [[MDCContainerScheme alloc] init];
+  }
+  self.view.backgroundColor = self.containerScheme.colorScheme.backgroundColor;
   self.title = @"Material Text Fields";
 
   [self setupExampleViews];
@@ -156,6 +160,7 @@
   self.textFieldControllerUnderline.characterCountMax = characterCountMax;
 
   [self.textFieldControllerUnderline mdc_setAdjustsFontForContentSizeCategory:YES];
+  [self.textFieldControllerUnderline applyThemeWithScheme:self.containerScheme];
 
   [NSLayoutConstraint constraintWithItem:textFieldUnderline
                                attribute:NSLayoutAttributeTop

--- a/components/TextFields/examples/supplemental/TextFieldControllerStylesExampleSupplemental.h
+++ b/components/TextFields/examples/supplemental/TextFieldControllerStylesExampleSupplemental.h
@@ -14,9 +14,13 @@
 
 #import <UIKit/UIKit.h>
 
+#import "MaterialContainerScheme.h"
+
 @interface TextFieldControllerStylesExample : UIViewController <UITextFieldDelegate>
 
 @property(nonatomic, strong) UIScrollView *scrollView;
+
+@property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
 
 @end
 

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.h
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.h
@@ -1,0 +1,33 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialContainerScheme.h"
+#import "MaterialTextFields.h"
+
+/**
+ This category is used to style MDCTextInputControllerUnderline instances to a specific Material style
+ which can be found within the
+ [Material Guidelines](https://material.io/design/components/text-fields.html).
+ */
+@interface MDCTextInputControllerUnderline (MaterialTheming)
+
+/**
+ Applies the Material theme to this instance.
+
+ @param scheme A container scheme instance containing any desired customizations to the theming
+ system.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.h
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.h
@@ -16,9 +16,9 @@
 #import "MaterialTextFields.h"
 
 /**
- This category is used to style MDCTextInputControllerUnderline instances to a specific Material style
- which can be found within the
- [Material Guidelines](https://material.io/design/components/text-fields.html).
+ This category is used to style MDCTextInputControllerUnderline instances to a specific Material
+ style which can be found within the [Material
+ Guidelines](https://material.io/design/components/text-fields.html).
  */
 @interface MDCTextInputControllerUnderline (MaterialTheming)
 

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -25,11 +25,21 @@
 }
 
 - (void)applyColorThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
+
   self.activeColor = colorScheme.primaryColor;
-  if ([textInputController
+  self.errorColor = colorScheme.errorColor;
+  self.normalColor = onSurface87Opacity;
+  self.inlinePlaceholderColor = onSurface60Opacity;
+  self.trailingUnderlineLabelTextColor = onSurface60Opacity;
+  self.leadingUnderlineLabelTextColor = onSurface60Opacity;
+
+  if ([self
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
-        (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
+        (id<MDCTextInputControllerFloatingPlaceholder>)self;
 
     if ([textInputControllerFloatingPlaceholder
             respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
@@ -38,23 +48,13 @@
     }
   }
 
-  if ([textInputController
+  if ([self
           conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
-        (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
-    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
+        (id<MDCTextInputControllerFloatingPlaceholder>)self;
     textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurface60Opacity;
     textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor = primary87Opacity;
   }
-
-  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
-  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  textInputController.activeColor = colorScheme.primaryColor;
-  textInputController.errorColor = colorScheme.errorColor;
-  textInputController.normalColor = onSurface87Opacity;
-  textInputController.inlinePlaceholderColor = onSurface60Opacity;
-  textInputController.trailingUnderlineLabelTextColor = onSurface60Opacity;
-  textInputController.leadingUnderlineLabelTextColor = onSurface60Opacity;
 }
 
 - (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -58,7 +58,21 @@
 }
 
 - (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {
-  
+  self.inlinePlaceholderFont = typographyScheme.subtitle1;
+  self.leadingUnderlineLabelFont = typographyScheme.caption;
+  self.trailingUnderlineLabelFont = typographyScheme.caption;
+  if ([self conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
+    id<MDCTextInputControllerFloatingPlaceholder> floatingPlaceholderController =
+        (id<MDCTextInputControllerFloatingPlaceholder>)self;
+
+    // if caption.pointSize <= 0 there is no meaningful ratio so we fallback to default.
+    if (typographyScheme.caption.pointSize <= 0) {
+      floatingPlaceholderController.floatingPlaceholderScale = nil;
+    } else {
+      double ratio = typographyScheme.caption.pointSize / typographyScheme.subtitle1.pointSize;
+      floatingPlaceholderController.floatingPlaceholderScale = [NSNumber numberWithDouble:ratio];
+    }
+  }
 }
 
 @end

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCTextInputControllerFilled+MaterialTheming.h"
-#import "MDCTextInputControllerOutlined+MaterialTheming.h"
 #import "MDCTextInputControllerUnderline+MaterialTheming.h"
+
+@implementation MDCTextInputControllerUnderline (MaterialTheming)
+
+- (void)applyThemeWithScheme:(id<MDCContainerScheming>)scheme {
+  // Color
+  [self applyColorThemeWithColorScheme:scheme.colorScheme];
+
+  // Typography
+  [self applyTypographyThemeWithScheme:scheme.typographyScheme];
+}
+
+- (void)applyColorThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+
+}
+
+- (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {
+  
+}
+
+@end

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -27,6 +27,7 @@
 - (void)applyColorThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
   UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
   UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
 
   self.activeColor = colorScheme.primaryColor;
   self.errorColor = colorScheme.errorColor;
@@ -41,8 +42,8 @@
 
     if ([textInputControllerFloatingPlaceholder
             respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
-      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor =
-          colorScheme.primaryColor;
+      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurface60Opacity;
+      textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor = primary87Opacity;
     }
   }
 }

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -61,6 +61,7 @@
   self.inlinePlaceholderFont = typographyScheme.subtitle1;
   self.leadingUnderlineLabelFont = typographyScheme.caption;
   self.trailingUnderlineLabelFont = typographyScheme.caption;
+  
   if ([self conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> floatingPlaceholderController =
         (id<MDCTextInputControllerFloatingPlaceholder>)self;

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -25,7 +25,36 @@
 }
 
 - (void)applyColorThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
+  self.activeColor = colorScheme.primaryColor;
+  if ([textInputController
+          conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
+    id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
+        (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
 
+    if ([textInputControllerFloatingPlaceholder
+            respondsToSelector:@selector(setFloatingPlaceholderNormalColor:)]) {
+      textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor =
+          colorScheme.primaryColor;
+    }
+  }
+
+  if ([textInputController
+          conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
+    id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
+        (id<MDCTextInputControllerFloatingPlaceholder>)textInputController;
+    UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
+    textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurface60Opacity;
+    textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor = primary87Opacity;
+  }
+
+  UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
+  UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
+  textInputController.activeColor = colorScheme.primaryColor;
+  textInputController.errorColor = colorScheme.errorColor;
+  textInputController.normalColor = onSurface87Opacity;
+  textInputController.inlinePlaceholderColor = onSurface60Opacity;
+  textInputController.trailingUnderlineLabelTextColor = onSurface60Opacity;
+  textInputController.leadingUnderlineLabelTextColor = onSurface60Opacity;
 }
 
 - (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -27,7 +27,6 @@
 - (void)applyColorThemeWithColorScheme:(id<MDCColorScheming>)colorScheme {
   UIColor *onSurface87Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
   UIColor *onSurface60Opacity = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  UIColor *primary87Opacity = [colorScheme.primaryColor colorWithAlphaComponent:(CGFloat)0.87];
 
   self.activeColor = colorScheme.primaryColor;
   self.errorColor = colorScheme.errorColor;
@@ -47,21 +46,13 @@
           colorScheme.primaryColor;
     }
   }
-
-  if ([self
-          conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
-    id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
-        (id<MDCTextInputControllerFloatingPlaceholder>)self;
-    textInputControllerFloatingPlaceholder.floatingPlaceholderNormalColor = onSurface60Opacity;
-    textInputControllerFloatingPlaceholder.floatingPlaceholderActiveColor = primary87Opacity;
-  }
 }
 
 - (void)applyTypographyThemeWithScheme:(id<MDCTypographyScheming>)typographyScheme {
   self.inlinePlaceholderFont = typographyScheme.subtitle1;
   self.leadingUnderlineLabelFont = typographyScheme.caption;
   self.trailingUnderlineLabelFont = typographyScheme.caption;
-  
+
   if ([self conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> floatingPlaceholderController =
         (id<MDCTextInputControllerFloatingPlaceholder>)self;

--- a/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
+++ b/components/TextFields/src/Theming/MDCTextInputControllerUnderline+MaterialTheming.m
@@ -35,8 +35,7 @@
   self.trailingUnderlineLabelTextColor = onSurface60Opacity;
   self.leadingUnderlineLabelTextColor = onSurface60Opacity;
 
-  if ([self
-          conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
+  if ([self conformsToProtocol:@protocol(MDCTextInputControllerFloatingPlaceholder)]) {
     id<MDCTextInputControllerFloatingPlaceholder> textInputControllerFloatingPlaceholder =
         (id<MDCTextInputControllerFloatingPlaceholder>)self;
 

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -31,6 +31,7 @@ class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
 
     // Then
     // Color
+    
 
     // Typography
   }

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -44,9 +44,9 @@ class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
     XCTAssertEqual(textFieldControllerUnderline.inlinePlaceholderColor, onSurface60Opacity)
     XCTAssertEqual(textFieldControllerUnderline.trailingUnderlineLabelTextColor, onSurface60Opacity)
     XCTAssertEqual(textFieldControllerUnderline.leadingUnderlineLabelTextColor, onSurface60Opacity)
-    XCTAssertEqual(
-      floatingPlaceholderController.floatingPlaceholderNormalColor,
-      scheme.colorScheme.primaryColor
+    XCTAssertEqual(floatingPlaceholderController.floatingPlaceholderNormalColor, onSurface60Opacity)
+    XCTAssertEqual(floatingPlaceholderController.floatingPlaceholderActiveColor,
+                   scheme.colorScheme.primaryColor.withAlphaComponent(0.87)
     )
     // Typography
     XCTAssertEqual(textFieldControllerUnderline.inlinePlaceholderFont, typographyScheme.subtitle1)

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -24,31 +24,42 @@ class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
     // Given
     let textFieldFilled = MDCTextField()
     let textFieldControllerUnderline = MDCTextInputControllerUnderline(textInput: textFieldFilled)
-    let scheme: MDCContainerScheme = MDCContainerScheme()
+    let scheme = MDCContainerScheme()
+    let onSurface60Opacity = scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+    let typographyScheme = scheme.typographyScheme
+    let floatingPlaceholderController: MDCTextInputControllerFloatingPlaceholder =
+      textFieldControllerUnderline
 
     // When
-    textFieldControllerFilled.applyTheme(withScheme: scheme)
+    textFieldControllerUnderline.applyTheme(withScheme: scheme)
 
     // Then
     // Color
-    XCTAssertEqual(textFieldControllerUnderline, scheme.colorScheme.primaryColor)
-    
-
+    XCTAssertEqual(textFieldControllerUnderline.activeColor, scheme.colorScheme.primaryColor)
+    XCTAssertEqual(textFieldControllerUnderline.errorColor, scheme.colorScheme.errorColor)
+    XCTAssertEqual(
+      textFieldControllerUnderline.normalColor,
+      scheme.colorScheme.onSurfaceColor.withAlphaComponent(0.87)
+    )
+    XCTAssertEqual(textFieldControllerUnderline.inlinePlaceholderColor, onSurface60Opacity)
+    XCTAssertEqual(textFieldControllerUnderline.trailingUnderlineLabelTextColor, onSurface60Opacity)
+    XCTAssertEqual(textFieldControllerUnderline.leadingUnderlineLabelTextColor, onSurface60Opacity)
+    XCTAssertEqual(
+      floatingPlaceholderController.floatingPlaceholderNormalColor,
+      scheme.colorScheme.primaryColor
+    )
     // Typography
-  }
-
-  func testWithCustomContainerSchemeStylesAppropriatly() {
-    // Given
-    let textFieldFilled = MDCTextField()
-    let textFieldControllerFilled = MDCTextInputControllerUnderline(textInput: textFieldFilled)
-    let scheme: MDCContainerScheme = MDCContainerScheme()
-
-    // When
-    textFieldControllerFilled.applyTheme(withScheme: scheme)
-
-    // Then
-    // Color
-
-    // Typography
+    XCTAssertEqual(textFieldControllerUnderline.inlinePlaceholderFont, typographyScheme.subtitle1)
+    XCTAssertEqual(textFieldControllerUnderline.leadingUnderlineLabelFont, typographyScheme.caption)
+    XCTAssertEqual(
+      textFieldControllerUnderline.trailingUnderlineLabelFont,
+      typographyScheme.caption
+    )
+    if typographyScheme.caption.pointSize <= 0 {
+      XCTAssertNil(floatingPlaceholderController.floatingPlaceholderScale)
+    } else {
+      let ratio = Double(typographyScheme.caption.pointSize / typographyScheme.subtitle1.pointSize)
+      XCTAssertEqual(floatingPlaceholderController.floatingPlaceholderScale, NSNumber(value: ratio))
+    }
   }
 }

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -23,7 +23,7 @@ class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
   func testWithDefaultContainerSchemeStylesAppropriatly() {
     // Given
     let textFieldFilled = MDCTextField()
-    let textFieldControllerFilled = MDCTextInputControllerUnderline(textInput: textFieldFilled)
+    let textFieldControllerUnderline = MDCTextInputControllerUnderline(textInput: textFieldFilled)
     let scheme: MDCContainerScheme = MDCContainerScheme()
 
     // When
@@ -31,6 +31,7 @@ class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
 
     // Then
     // Color
+    XCTAssertEqual(textFieldControllerUnderline, scheme.colorScheme.primaryColor)
     
 
     // Typography

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -20,7 +20,7 @@ import MaterialComponents.MaterialTextFields_Theming
 import XCTest
 
 class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
-  func testWithDefaultContainerSchemeStylesAppropriatly() {
+  func testWithDefaultContainerSchemeStylesAppropriately() {
     // Given
     let textFieldFilled = MDCTextField()
     let textFieldControllerUnderline = MDCTextInputControllerUnderline(textInput: textFieldFilled)

--- a/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
+++ b/components/TextFields/tests/unit/Theming/MDCTextFieldControllerUnderline_MaterialThemingTests.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import MaterialComponents.MaterialTextFields
+import MaterialComponents.MaterialColorScheme
+import MaterialComponents.MaterialContainerScheme
+import MaterialComponents.MaterialTypographyScheme
+import MaterialComponents.MaterialTextFields_Theming
+import XCTest
+
+class MDCTextFieldControllerUnderline_MaterialThemingTests: XCTestCase {
+  func testWithDefaultContainerSchemeStylesAppropriatly() {
+    // Given
+    let textFieldFilled = MDCTextField()
+    let textFieldControllerFilled = MDCTextInputControllerUnderline(textInput: textFieldFilled)
+    let scheme: MDCContainerScheme = MDCContainerScheme()
+
+    // When
+    textFieldControllerFilled.applyTheme(withScheme: scheme)
+
+    // Then
+    // Color
+
+    // Typography
+  }
+
+  func testWithCustomContainerSchemeStylesAppropriatly() {
+    // Given
+    let textFieldFilled = MDCTextField()
+    let textFieldControllerFilled = MDCTextInputControllerUnderline(textInput: textFieldFilled)
+    let scheme: MDCContainerScheme = MDCContainerScheme()
+
+    // When
+    textFieldControllerFilled.applyTheme(withScheme: scheme)
+
+    // Then
+    // Color
+
+    // Typography
+  }
+}


### PR DESCRIPTION
In #9109  we removed the color themer for the underline controller. This change closes #9371  which will allow clients to theme their underline controller text fields via a theming extension. This change will theme both color and typography.

*Note* [Material](material.io) recommends using a [filled or outlined text field](https://material.io/components/text-fields/).

| Resting | Active |
| --- | --- |
|![Simulator Screen Shot - iPhone 8 Plus - 2020-01-16 at 13 13 28](https://user-images.githubusercontent.com/7131294/72563237-1811ed80-3862-11ea-8788-816c927f03e4.png)|![Simulator Screen Shot - iPhone 8 Plus - 2020-01-16 at 13 13 26](https://user-images.githubusercontent.com/7131294/72563252-1cd6a180-3862-11ea-97c9-6d7c82f6878d.png)|

Closes #9371 
Closes #9242 