### PR TITLE
[Chips] Additional `imagePadding` tests.

### DIFF
--- a/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipViewLayoutSnapshotTests.m
@@ -195,6 +195,16 @@
 
 #pragma mark - ImagePadding
 
+- (void)testChipImagePaddingWithoutImagesLTR {
+  // When
+  self.chipView.imageView.image = nil;
+  self.chipView.selectedImageView.image = nil;
+  self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
 - (void)testUnselectedChipImagePaddingAllPositiveValuesLTR {
   // When
   self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
@@ -249,6 +259,33 @@
   // Given
   self.chipView.selectedImageView.image =
       [UIImage mdc_testImageOfSize:CGSizeMake(32, 32)
+                         withStyle:MDCSnapshotTestImageStyleDiagonalLines];
+  self.chipView.selected = YES;
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testUnselectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR {
+  // Given
+  self.chipView.selectedImageView.image =
+      [UIImage mdc_testImageOfSize:CGSizeMake(8, 8)
+                         withStyle:MDCSnapshotTestImageStyleDiagonalLines];
+
+  // When
+  self.chipView.imagePadding = UIEdgeInsetsMake(10, 20, 30, 40);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.chipView];
+}
+
+- (void)testSelectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR {
+  // Given
+  self.chipView.selectedImageView.image =
+      [UIImage mdc_testImageOfSize:CGSizeMake(8, 8)
                          withStyle:MDCSnapshotTestImageStyleDiagonalLines];
   self.chipView.selected = YES;
 

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingWithoutImagesLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testChipImagePaddingWithoutImagesLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4b496a7c4d42a4f1536003af79be3161cc0fa27d4663079c73c5075d961aae5
+size 5317

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testSelectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testSelectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2daab9012d4c50ee5226f0ea3b0671150c2224548f27b483140d5c972934a20
+size 8697

--- a/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testUnselectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipViewLayoutSnapshotTests/testUnselectedChipImagePaddingAllPositiveValuesForSmallSelectedImageLTR_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91fa84afcba24db32489ba231e2831242cd97f59fff81bd1196a20b0638b9d64
+size 9330


### PR DESCRIPTION
Adds extra tests for `imagePadding` focused on when no image is visible or
when only `selectedImage` is visible.

Preparation to roll-forward #9267
Part of #9250