### PR TITLE
[AppBar] Fix swipe to go back gesture for MDCAppBarNavigationController.

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -44,12 +44,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
     let rootNodeViewController = MDCCatalogComponentsController(node: tree)
     navigationController.pushViewController(rootNodeViewController, animated: false)
 
-    // In the event that an example view controller hides the navigation bar we generally want to
-    // ensure that the edge-swipe pop gesture can still take effect. This may be overly-assumptive
-    // but we'll explore other alternatives when we have a concrete example of this approach causing
-    // problems.
-    navigationController.interactivePopGestureRecognizer?.delegate = navigationController
-
     self.window?.rootViewController = navigationController
     self.window?.makeKeyAndVisible()
 

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -29,6 +29,9 @@
 
 @end
 
+@interface MDCAppBarNavigationController () <UIGestureRecognizerDelegate>
+@end
+
 @implementation MDCAppBarNavigationControllerInfo
 
 - (void)dealloc {
@@ -44,6 +47,10 @@
 // We're overriding UINavigationController's delegate solely to change its type (we don't provide
 // a getter or setter implementation), thus the @dynamic.
 @dynamic delegate;
+
+- (void)dealloc {
+  self.interactivePopGestureRecognizer.delegate = nil;
+}
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
@@ -67,6 +74,12 @@
   // We always want the UIKit navigation bar to be hidden; to do so we must invoke the super
   // implementation.
   [super setNavigationBarHidden:YES animated:NO];
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  self.interactivePopGestureRecognizer.delegate = self;
 }
 
 #pragma mark - UINavigationController overrides

--- a/components/AppBar/src/MDCAppBarNavigationController.m
+++ b/components/AppBar/src/MDCAppBarNavigationController.m
@@ -29,6 +29,8 @@
 
 @end
 
+// This is intentionally a private protocol conformance in order to avoid public reliance on our
+// conformance to this protocol.
 @interface MDCAppBarNavigationController () <UIGestureRecognizerDelegate>
 @end
 

--- a/components/AppBar/tests/unit/AppBarNavigationControllerInteractivePopGestureTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerInteractivePopGestureTests.m
@@ -1,0 +1,52 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialAppBar.h"
+
+@interface AppBarNavigationControllerInteractivePopGestureTests : XCTestCase
+@property(nonatomic, strong) MDCAppBarNavigationController *appBarNavigationController;
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
+@end
+
+@implementation AppBarNavigationControllerInteractivePopGestureTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.appBarNavigationController = [[MDCAppBarNavigationController alloc] init];
+}
+
+- (void)tearDown {
+  self.appBarNavigationController = nil;
+
+  [super tearDown];
+}
+
+- (void)testIsNilByDefault {
+  // Then
+  XCTAssertNil(self.appBarNavigationController.interactivePopGestureRecognizer.delegate);
+}
+
+- (void)testIsSelfAfterViewDidLoad {
+  // When
+  [self.appBarNavigationController loadViewIfNeeded];
+
+  // Then
+  XCTAssertEqualObjects(self.appBarNavigationController.interactivePopGestureRecognizer.delegate,
+                        self.appBarNavigationController);
+}
+
+@end

--- a/components/AppBar/tests/unit/AppBarNavigationControllerInteractivePopGestureTests.m
+++ b/components/AppBar/tests/unit/AppBarNavigationControllerInteractivePopGestureTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Originally authored by anthonylai in cl/290091107.

https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/gestures/

"But users can also navigate back by swiping from the side of the screen."

Closes https://github.com/material-components/material-components-ios/issues/9447

Tested manually on:

- iPhone 7, 11.2
- iPhone X, 12.2
- iPhone 8 Plus, 13.2.2

## Testing Steps
1. Set MDCAppBarNavigationController as the root view controller
2. Push a view controller.
3. Swipe from the trailing edge toward the leading edge.

Tested by running the MDCCatalog and verifying that I can swipe to dismiss pushed view controllers on the root navigation controller.