### PR TITLE
[TextControls] Give MDCBaseTextField same default font as UITextField

### DIFF
--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -496,12 +496,8 @@
 }
 
 - (UIFont *)uiTextFieldDefaultFont {
-  static dispatch_once_t onceToken;
-  static UIFont *font;
-  dispatch_once(&onceToken, ^{
-    font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
-  });
-  return font;
+  // This value comes from https://developer.apple.com/documentation/uikit/uitextfield/1619604-font
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 #pragma mark Dynamic Type


### PR DESCRIPTION
According to [Apple docs](https://developer.apple.com/documentation/uikit/uitextfield/1619604-font), UITextField uses the preferred body font for its default font. We should do the same for MDCBaseTextFIeld.

Closes #9469