### PR TITLE
[NavigationDrawer] Update `transitionPercentageForContentOffset:` to use `kEpsilon`

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -1007,10 +1007,10 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (CGFloat)transitionPercentageForContentOffset:(CGPoint)contentOffset
                                          offset:(CGFloat)offset
                                        distance:(CGFloat)distance {
-  // If the distance is zero or negative there is no distance for a transition to occur and therefore
-  // it is set to 1 (100%).
-  // Rather than comparing precisely against `0`, comparison is done against the almost-zero value 
-  // that is used throughout the calculations performed in this class.
+  // If the distance is zero or negative there is no distance for a transition to occur and
+  // therefore it is set to one (100%). Rather than comparing precisely against `0`, comparison is
+  // done against the almost-zero value that is used throughout the calculations performed in this
+  // class.
   if (distance <= kEpsilon) {
     return 1;
   }

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -1007,9 +1007,11 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 - (CGFloat)transitionPercentageForContentOffset:(CGPoint)contentOffset
                                          offset:(CGFloat)offset
                                        distance:(CGFloat)distance {
-  // If the distance is 0 or negative there is no distance for a transition to occur and therefore
+  // If the distance is zero or negative there is no distance for a transition to occur and therefore
   // it is set to 1 (100%).
-  if (distance <= 0) {
+  // Rather than comparing precisely against `0`, comparison is done against the almost-zero value 
+  // that is used throughout the calculations performed in this class.
+  if (distance <= kEpsilon) {
     return 1;
   }
   return 1 - MAX(0, MIN(1, (self.transitionCompleteContentOffset - contentOffset.y - offset) /


### PR DESCRIPTION
This is a partial (or perhaps somewhat temporary) fix for #8277, as it is not entirely clear to me that this fixes the issue in all cases, unless there is a different issue tracking the more underlying issue making this change sufficient to close #8277.

Either way, we're currently running into a similar problem to that documented in [b/139120589](https://b.corp.google.com/issues/139120589), where our header is not being delegated to with the proper transition ratio in `updateDrawerHeaderTransitionRatio:` (more context at [b/148122160](https://b.corp.google.com/issues/148122160) and [b/148161091](https://b.corp.google.com/issues/148161091)).

After diving into the issue, it seems the reason this issue is _not_ occurring for non-notched devices is _somewhat_ unexpected, or at least counter-intuitive 😅. From my testing/debugging, it seems to be due to there being a top inset that is applied via calls to `MDCDeviceTopSafeAreaInset()`, which always returns `20` for non-notched devices, regardless of device orientation (whereas calls to `MDCDeviceTopSafeAreaInset()` for notched devices do effectively take into account device orientation). This eventually results in the calculation-chain determining that the device is at fullscreen, and the drawer state + transition ratio of `1` being set accordingly.

This change fixes at least the major issue of the transition ratio of `0` being sent and drawer state being set to collapsed for notched devices in landscape, by comparing to the almost-zero value used throughout calculations performed in this class, which works as the calculated distance in `(CGFloat)headerAnimationDistance` _is_ almost zero but not _precisely_ zero in this situation. However, this fix is definitely only partial as I believe there are some other underlying kinks in the calculations going on here that likely need to be updated for the issue to be fully resolved. 

To clarify more concretely, for us this fix resolves the issue of `updateDrawerHeaderTransitionRatio:` always being triggered with a ratio of `0` despite fullscreen presentation on landscape notched devices; however, when dragging the drawer closed in landscape, the `updateDrawerHeaderTransitionRatio:` is not called with the expected intermediary values throughout the dragging, resulting in a lack of animation where one would expect one.

This is much smaller of an issue though than receiving the wrong drawer state, especially given that  in landscape the drawer only has the two stable states of fully opened or fully closed, so this partial fix resolves the major issue for us at this time.

I have not added any new tests for this change, but did verify that it does not break any of the existing unit or snapshot tests + verified manually that this resolves our related internal issues.

Sorry for the essay here @yarneo 😅, just wanted to give as much context into this as possible in the hopes that it is helpful in documenting what may become a more complete solution to #8277. Though hopefully we can get this partial fix in during the interim. 🙏Thanks again for taking the time to review all this. 