### PR TITLE
[Snackbar] Update dismiss animation duration

### DIFF
--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -29,7 +29,7 @@ NSString *const MDCSnackbarOverlayIdentifier = @"MDCSnackbar";
 
 // The time it takes to show or hide the Snackbar.
 NSTimeInterval const MDCSnackbarEnterTransitionDuration = 0.15;
-NSTimeInterval const MDCSnackbarExitTransitionDuration = 0.075;
+NSTimeInterval const MDCSnackbarExitTransitionDuration = 0.125;
 NSTimeInterval const MDCSnackbarLegacyTransitionDuration = 0.5;
 
 // The scaling starting point for presenting the new Snackbar.


### PR DESCRIPTION
As part of an ongoing thread with design (b/147753186) we looked into the duration of the animation during dismissal and found that with 75ms the Snackbar dismisses too instantaneously and the animation is barely seen. By updating to 125ms, the animation becomes more inline with the guidelines as seen in https://material.io/components/snackbars/#behavior

Videos:

|Before|After|
|---|---|
|![beforeanimation](https://user-images.githubusercontent.com/4066863/72997473-1cf81380-3e05-11ea-8983-b4620a7aba6f.gif)|![afteranimation](https://user-images.githubusercontent.com/4066863/72997482-21bcc780-3e05-11ea-918f-658fa30da980.gif)|

Closes #9467 