### PR TITLE
[Snackbar] Support orientation changes that respect safe area

### DIFF
--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -989,8 +989,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
   // Figure out which of the elements is tallest, and use that for calculating our preferred height.
   // Images are forced to be no bigger than @c kMaximumImageSize.
-  height = MAX(height, [self.label sizeThatFits:CGSizeMake(CGRectGetWidth(self.frame),
-                                                           CGFLOAT_MAX)].height);
+  height = MAX(
+      height, [self.label sizeThatFits:CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX)].height);
 
   // Make sure that content margins are included in our calculation.
   height += self.safeContentMargin.top + self.safeContentMargin.bottom;

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -979,6 +979,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
                                                                       : kCornerRadius];
   self.layer.shadowPath = path.CGPath;
   self.layer.shadowColor = self.snackbarMessageViewShadowColor.CGColor;
+  [self invalidateIntrinsicContentSize];
 }
 
 #pragma mark - Sizing
@@ -988,7 +989,8 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
   // Figure out which of the elements is tallest, and use that for calculating our preferred height.
   // Images are forced to be no bigger than @c kMaximumImageSize.
-  height = MAX(height, self.label.intrinsicContentSize.height);
+  height = MAX(height, [self.label sizeThatFits:CGSizeMake(CGRectGetWidth(self.frame),
+                                                           CGFLOAT_MAX)].height);
 
   // Make sure that content margins are included in our calculation.
   height += self.safeContentMargin.top + self.safeContentMargin.bottom;

--- a/components/Snackbar/src/MDCSnackbarMessageView.m
+++ b/components/Snackbar/src/MDCSnackbarMessageView.m
@@ -989,8 +989,7 @@ static const MDCFontTextStyle kButtonTextStyle = MDCFontTextStyleButton;
 
   // Figure out which of the elements is tallest, and use that for calculating our preferred height.
   // Images are forced to be no bigger than @c kMaximumImageSize.
-  height = MAX(
-      height, [self.label sizeThatFits:CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX)].height);
+  height = MAX(height, self.label.intrinsicContentSize.height);
 
   // Make sure that content margins are included in our calculation.
   height += self.safeContentMargin.top + self.safeContentMargin.bottom;

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -118,6 +118,17 @@ static const CGFloat kMaximumHeight = 80;
  */
 @property(nonatomic) NSLayoutConstraint *snackbarOffscreenConstraint;
 
+/**
+ The constraint used to set the leading margin spacing of the Snackbar.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarLeadingMarginConstraint;
+
+/**
+ The constraint used to set the trailing margin spacing of the Snackbar.
+ */
+@property(nonatomic) NSLayoutConstraint *snackbarTrailingMarginConstraint;
+
+
 @end
 
 @implementation MDCSnackbarOverlayView
@@ -208,6 +219,36 @@ static const CGFloat kMaximumHeight = 80;
                                                       multiplier:1.0
                                                         constant:-[self dynamicBottomMargin]];
   [self addConstraint:self.bottomConstraint];
+}
+
+- (void)updateConstraints {
+  [super updateConstraints];
+
+  self.maximumHeightConstraint.constant = self.maximumHeight;
+
+  CGFloat sideMargin = [self sideMargin];
+  CGFloat leftMargin = sideMargin;
+  CGFloat rightMargin = sideMargin;
+
+  BOOL isRegularWidth =
+  self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+  BOOL isRegularHeight =
+  self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+  if (!isRegularWidth || !isRegularHeight) {
+    if (@available(iOS 11.0, *)) {
+      if (self.mdf_effectiveUserInterfaceLayoutDirection ==
+          UIUserInterfaceLayoutDirectionLeftToRight) {
+        leftMargin += self.mdc_safeAreaInsets.left;
+        rightMargin += self.mdc_safeAreaInsets.right;
+      } else {
+        leftMargin += self.mdc_safeAreaInsets.right;
+        rightMargin += self.mdc_safeAreaInsets.left;
+      }
+    }
+
+    _snackbarLeadingMarginConstraint.constant = leftMargin;
+    _snackbarTrailingMarginConstraint.constant = -1 * rightMargin;
+  }
 }
 
 - (void)dealloc {
@@ -338,21 +379,23 @@ static const CGFloat kMaximumHeight = 80;
           }
         }
 
-        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+        _snackbarLeadingMarginConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
                                                               attribute:NSLayoutAttributeLeading
                                                               relatedBy:NSLayoutRelationEqual
                                                                  toItem:container
                                                               attribute:NSLayoutAttributeLeading
                                                              multiplier:1.0
-                                                               constant:leftMargin]];
+                                                               constant:leftMargin];
+        [container addConstraint:_snackbarLeadingMarginConstraint];
 
-        [container addConstraint:[NSLayoutConstraint constraintWithItem:snackbarView
+        _snackbarTrailingMarginConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
                                                               attribute:NSLayoutAttributeTrailing
                                                               relatedBy:NSLayoutRelationEqual
                                                                  toItem:container
                                                               attribute:NSLayoutAttributeTrailing
                                                              multiplier:1.0
-                                                               constant:-1 * rightMargin]];
+                                                               constant:-1 * rightMargin];
+        [container addConstraint:_snackbarTrailingMarginConstraint];
       }
 
       _snackbarOnscreenConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
@@ -449,7 +492,7 @@ static const CGFloat kMaximumHeight = 80;
 #pragma mark - Safe Area Insets
 
 - (void)safeAreaInsetsDidChange {
-  self.maximumHeightConstraint.constant = self.maximumHeight;
+  [self setNeedsUpdateConstraints];
   [self triggerSnackbarLayoutChange];
 }
 

--- a/components/Snackbar/src/private/MDCSnackbarOverlayView.m
+++ b/components/Snackbar/src/private/MDCSnackbarOverlayView.m
@@ -128,7 +128,6 @@ static const CGFloat kMaximumHeight = 80;
  */
 @property(nonatomic) NSLayoutConstraint *snackbarTrailingMarginConstraint;
 
-
 @end
 
 @implementation MDCSnackbarOverlayView
@@ -230,10 +229,8 @@ static const CGFloat kMaximumHeight = 80;
   CGFloat leftMargin = sideMargin;
   CGFloat rightMargin = sideMargin;
 
-  BOOL isRegularWidth =
-  self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
-  BOOL isRegularHeight =
-  self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
+  BOOL isRegularWidth = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+  BOOL isRegularHeight = self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassRegular;
   if (!isRegularWidth || !isRegularHeight) {
     if (@available(iOS 11.0, *)) {
       if (self.mdf_effectiveUserInterfaceLayoutDirection ==
@@ -379,22 +376,24 @@ static const CGFloat kMaximumHeight = 80;
           }
         }
 
-        _snackbarLeadingMarginConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                              attribute:NSLayoutAttributeLeading
-                                                              relatedBy:NSLayoutRelationEqual
-                                                                 toItem:container
-                                                              attribute:NSLayoutAttributeLeading
-                                                             multiplier:1.0
-                                                               constant:leftMargin];
+        _snackbarLeadingMarginConstraint =
+            [NSLayoutConstraint constraintWithItem:snackbarView
+                                         attribute:NSLayoutAttributeLeading
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:container
+                                         attribute:NSLayoutAttributeLeading
+                                        multiplier:1.0
+                                          constant:leftMargin];
         [container addConstraint:_snackbarLeadingMarginConstraint];
 
-        _snackbarTrailingMarginConstraint = [NSLayoutConstraint constraintWithItem:snackbarView
-                                                              attribute:NSLayoutAttributeTrailing
-                                                              relatedBy:NSLayoutRelationEqual
-                                                                 toItem:container
-                                                              attribute:NSLayoutAttributeTrailing
-                                                             multiplier:1.0
-                                                               constant:-1 * rightMargin];
+        _snackbarTrailingMarginConstraint =
+            [NSLayoutConstraint constraintWithItem:snackbarView
+                                         attribute:NSLayoutAttributeTrailing
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:container
+                                         attribute:NSLayoutAttributeTrailing
+                                        multiplier:1.0
+                                          constant:-1 * rightMargin];
         [container addConstraint:_snackbarTrailingMarginConstraint];
       }
 


### PR DESCRIPTION
Snackbar prior to this change didn't respect safe area in orientation changes.

We are now updating the constants for the trailing and leading insets of the Snackbar when the safe area insets change.

Furthermore, the intrinsicContentSize of the SnackbarMessageView which called the label's intrinsicContentSize did not get called after an orientation change and only before, causing the height of the snackbar view be bigger than needed to be after 2 orientation changes while it is still showing.

Tested manually on: iPhone 7, iPhone X, and iPad 3rd gen. All with portrait and landscape changes.

Videos:
Before:
![beforeorientationsnackbar](https://user-images.githubusercontent.com/4066863/72996547-9989f280-3e03-11ea-8a35-60fcae61faf5.gif)

After:
![afterorientationsnackbar](https://user-images.githubusercontent.com/4066863/72996572-a0186a00-3e03-11ea-9fd1-e1b29671b6d1.gif)

Closes #9473 