### PR TITLE
[ActionSheet] Add delegate to support dismissal notification

### DIFF
--- a/components/ActionSheet/README.md
+++ b/components/ActionSheet/README.md
@@ -25,6 +25,7 @@ the screen and displays actions a user can take.
   <li class="icon-list-item icon-list-item--spec"><a href="https://material.io/go/design-action-sheet">Material Design guidelines: ActionSheet</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/action-sheet/api-docs/Classes/MDCActionSheetAction.html">MDCActionSheetAction</a></li>
   <li class="icon-list-item icon-list-item--link">Class: <a href="https://material.io/components/ios/catalog/action-sheet/api-docs/Classes/MDCActionSheetController.html">MDCActionSheetController</a></li>
+  <li class="icon-list-item icon-list-item--link">Protocol: <a href="https://material.io/components/ios/catalog/action-sheet/api-docs/Protocols/MDCActionSheetControllerDelegate.html">MDCActionSheetControllerDelegate</a></li>
 </ul>
 
 ## Table of contents

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExample.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExample.m
@@ -22,7 +22,8 @@
 #import "MaterialContainerScheme.h"
 #import "MaterialTypographyScheme.h"
 
-@interface ActionSheetTypicalUseExampleViewController : UIViewController
+@interface ActionSheetTypicalUseExampleViewController
+    : UIViewController <MDCActionSheetControllerDelegate>
 
 @property(nonatomic, strong) MDCButton *showButton;
 @property(nonatomic, strong) id<MDCContainerScheming> containerScheme;
@@ -88,7 +89,13 @@
   [actionSheet addAction:favoriteAction];
   [actionSheet addAction:emailAction];
   [actionSheet applyThemeWithScheme:self.containerScheme];
+  actionSheet.delegate = self;
   [self presentViewController:actionSheet animated:YES completion:nil];
+}
+
+#pragma mark - MDCActionSheetControllerDelegate
+- (void)actionSheetControllerDidDismiss:(MDCActionSheetController *)actionSheetController {
+  NSLog(@"Did dismiss");
 }
 
 @end

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -18,6 +18,21 @@
 #import "MaterialElevation.h"
 
 @class MDCActionSheetAction;
+@class MDCActionSheetController;
+
+/**
+ MDCActionSheetControllerDelegate provides a method that allows a delegate of an
+ MDCActionSheetController to respond to its dismissals.
+ */
+@protocol MDCActionSheetControllerDelegate <NSObject>
+@optional
+
+/**
+ This method allows a delegate conforming to MDCActionSheetControllerDelegate to respond to
+ MDCActionSheetController dismissals.
+ */
+- (void)actionSheetControllerDidDismiss:(nonnull MDCActionSheetController *)actionSheetController;
+@end
 
 /**
  MDCActionSheetController displays an alert message to the user, similar to
@@ -89,6 +104,13 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
  @param action Will be added to the end of MDCActionSheetController.actions.
  */
 - (void)addAction:(nonnull MDCActionSheetAction *)action;
+
+/**
+ An object conforming to MDCActionSheetControllerDelegate. When non-nil, the
+ MDCActionSheetController will call the appropriate MDCActionSheetControllerDelegate methods on this
+ object.
+ */
+@property(nonatomic, weak, nullable) id<MDCActionSheetControllerDelegate> delegate;
 
 /**
  The actions that the user can take in response to the action sheet.

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -21,15 +21,14 @@
 @class MDCActionSheetController;
 
 /**
- MDCActionSheetControllerDelegate provides a method that allows a delegate of an
- MDCActionSheetController to respond to its dismissals.
+ Defines methods that allows the adopting delegate to respond to messages from an
+ @c MDCActionSheetController.
  */
 @protocol MDCActionSheetControllerDelegate <NSObject>
 @optional
 
 /**
- This method allows a delegate conforming to MDCActionSheetControllerDelegate to respond to
- MDCActionSheetController dismissals.
+ Tells the delegate that the action sheet was dismissed.
  */
 - (void)actionSheetControllerDidDismiss:(nonnull MDCActionSheetController *)actionSheetController;
 @end
@@ -106,10 +105,8 @@ __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
 - (void)addAction:(nonnull MDCActionSheetAction *)action;
 
 /**
- An object conforming to MDCActionSheetControllerDelegate. When non-nil, the
- MDCActionSheetController will call the appropriate MDCActionSheetControllerDelegate methods on this
- object.
- */
+ The object that acts as the delegate of the @c MDCActionSheetController
+*/
 @property(nonatomic, weak, nullable) id<MDCActionSheetControllerDelegate> delegate;
 
 /**

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -164,6 +164,11 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
   return [_actions copy];
 }
 
+- (void)loadView {
+  [super loadView];
+  self.mdc_bottomSheetPresentationController.delegate = self;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -527,6 +532,14 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 
 - (CGFloat)mdc_currentElevation {
   return self.elevation;
+}
+
+#pragma mark - MDCBottomSheetPresentationControllerDelegate
+- (void)bottomSheetPresentationControllerDidDismissBottomSheet:
+    (nonnull MDCBottomSheetController *)controller {
+  if ([self.delegate respondsToSelector:@selector(actionSheetControllerDidDismiss:)]) {
+    [self.delegate actionSheetControllerDidDismiss:self];
+  }
 }
 
 @end

--- a/components/ActionSheet/src/MDCActionSheetController.m
+++ b/components/ActionSheet/src/MDCActionSheetController.m
@@ -166,6 +166,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 
 - (void)loadView {
   [super loadView];
+
   self.mdc_bottomSheetPresentationController.delegate = self;
 }
 
@@ -535,6 +536,7 @@ static const CGFloat kDividerDefaultAlpha = (CGFloat)0.12;
 }
 
 #pragma mark - MDCBottomSheetPresentationControllerDelegate
+
 - (void)bottomSheetPresentationControllerDidDismissBottomSheet:
     (nonnull MDCBottomSheetController *)controller {
   if ([self.delegate respondsToSelector:@selector(actionSheetControllerDidDismiss:)]) {

--- a/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
@@ -1,0 +1,69 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MDCActionSheetTestHelper.h"
+
+@interface ActionSheetControllerDelegate : NSObject <MDCActionSheetControllerDelegate>
+@property(nonatomic, readonly) MDCActionSheetController *dismissedActionSheetController;
+@end
+
+@implementation ActionSheetControllerDelegate
+- (void)actionSheetControllerDidDismiss:(MDCActionSheetController *)actionSheetController {
+  _dismissedActionSheetController = actionSheetController;
+}
+@end
+
+@interface MDCActionSheetControllerDelegateTests : XCTestCase
+/** The @c MDCActionSheetController being tested. */
+@property(nonatomic, strong) MDCActionSheetController *actionSheet;
+
+/** An @c MDCActionSheetControllerDelegate to verify delegate functions are called. */
+@property(nonatomic, nullable) ActionSheetControllerDelegate *actionSheetControllerDelegate;
+@end
+
+@implementation MDCActionSheetControllerDelegateTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.actionSheet = [[MDCActionSheetController alloc] init];
+  self.actionSheetControllerDelegate = [[ActionSheetControllerDelegate alloc] init];
+  self.actionSheet.delegate = self.actionSheetControllerDelegate;
+}
+
+- (void)tearDown {
+  self.actionSheet = nil;
+
+  [super tearDown];
+}
+
+- (void)testDidDismissIsCalledWithActionSheetController {
+  // Given
+  MDCBottomSheetPresentationController *presentationController =
+      self.actionSheet.mdc_bottomSheetPresentationController;
+
+  // When
+  [self.actionSheet loadView];
+  [presentationController.delegate
+      bottomSheetPresentationControllerDidDismissBottomSheet:presentationController];
+
+  // Then
+  XCTAssertNotNil(self.actionSheetControllerDelegate.dismissedActionSheetController);
+  XCTAssertEqualObjects(self.actionSheetControllerDelegate.dismissedActionSheetController,
+                        self.actionSheet);
+}
+
+@end

--- a/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
@@ -14,7 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MDCActionSheetTestHelper.h"
+#import "MDCActionSheetController.h"
+#import "MDCBottomSheetPresentationController.h"
 
 @interface ActionSheetControllerDelegate : NSObject <MDCActionSheetControllerDelegate>
 @property(nonatomic, readonly) MDCActionSheetController *dismissedActionSheetController;

--- a/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
+++ b/components/ActionSheet/tests/unit/MDCActionSheetControllerDelegateTests.m
@@ -47,6 +47,7 @@
 
 - (void)tearDown {
   self.actionSheet = nil;
+  self.actionSheetControllerDelegate = nil;
 
   [super tearDown];
 }


### PR DESCRIPTION
Add `MDCActionSheetControllerDelegate` to `MDCActionSheetController` with `actionSheetControllerDidDismiss:` so users of the ActionSheet component can react to dismissal.

Fixes #9147