### PR TITLE
[Snackbar] Add example to show snackbar with keyboard

### DIFF
--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -100,6 +100,7 @@ mdc_examples_swift_library(
     deps = [
         ":Snackbar",
         "//components/Buttons",
+        "//components/Buttons:ButtonThemer",
         "//components/schemes/Container",
     ],
 )

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -100,6 +100,7 @@ mdc_examples_swift_library(
     deps = [
         ":Snackbar",
         "//components/Buttons",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -94,6 +94,15 @@ mdc_examples_objc_library(
     ],
 )
 
+mdc_examples_swift_library(
+    name = "SwiftExamples",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":Snackbar",
+        "//components/Buttons",
+    ],
+)
+
 mdc_objc_library(
     name = "private",
     hdrs = native.glob(["src/private/*.h"]),

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -16,6 +16,7 @@
 load(
     "//:material_components_ios.bzl",
     "mdc_examples_objc_library",
+    "mdc_examples_swift_library",
     "mdc_extension_objc_library",
     "mdc_objc_library",
     "mdc_public_objc_library",
@@ -96,7 +97,6 @@ mdc_examples_objc_library(
 
 mdc_examples_swift_library(
     name = "SwiftExamples",
-    visibility = ["//visibility:private"],
     deps = [
         ":Snackbar",
         "//components/Buttons",

--- a/components/Snackbar/BUILD
+++ b/components/Snackbar/BUILD
@@ -100,7 +100,7 @@ mdc_examples_swift_library(
     deps = [
         ":Snackbar",
         "//components/Buttons",
-        "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/schemes/Container",
     ],
 )

--- a/components/Snackbar/examples/SnackbarKeyboardExample.swift
+++ b/components/Snackbar/examples/SnackbarKeyboardExample.swift
@@ -1,0 +1,86 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+import MaterialComponents.MaterialSnackbar
+
+class SnackbarKeyboardExample: UIViewController {
+
+  @objc var containerScheme = MDCContainerScheme()
+
+  let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 10
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  lazy var textField: UITextField = {
+    let textField = UITextField()
+    textField.borderStyle = .roundedRect
+    textField.returnKeyType = .done;
+    textField.delegate = self
+    return textField
+  }()
+
+  lazy var showSnackbarButton: MDCButton = {
+    let button = MDCButton()
+    button.setTitle("Show snackbar", for: .normal)
+    button.addTarget(self, action: #selector(showSnackbarButtonTapped), for: .touchUpInside)
+    return button
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .white
+    showSnackbarButton.applyTextTheme(withScheme: containerScheme)
+
+    contentStackView.addArrangedSubview(textField)
+    contentStackView.addArrangedSubview(showSnackbarButton)
+    view.addSubview(contentStackView)
+
+    contentStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    if #available(iOSApplicationExtension 11.0, *) {
+      contentStackView.topAnchor
+        .constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20).isActive = true
+    } else {
+      contentStackView.topAnchor
+        .constraint(equalTo: topLayoutGuide.bottomAnchor, constant: 20).isActive = true
+    }
+  }
+
+  @objc func showSnackbarButtonTapped() {
+    MDCSnackbarManager.show(MDCSnackbarMessage(text: "Hello!"))
+  }
+}
+
+extension SnackbarKeyboardExample: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    textField.resignFirstResponder()
+    return false
+  }
+}
+
+extension SnackbarKeyboardExample {
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Snackbar", "Snackbar Keyboard"],
+      "primaryDemo": false,
+      "presentable": true,
+    ]
+  }
+}

--- a/components/Snackbar/examples/SnackbarKeyboardExample.swift
+++ b/components/Snackbar/examples/SnackbarKeyboardExample.swift
@@ -14,6 +14,8 @@
 
 import UIKit
 
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialSnackbar
 
 class SnackbarKeyboardExample: UIViewController {

--- a/components/Snackbar/examples/SnackbarKeyboardExample.swift
+++ b/components/Snackbar/examples/SnackbarKeyboardExample.swift
@@ -54,7 +54,7 @@ class SnackbarKeyboardExample: UIViewController {
     view.addSubview(contentStackView)
 
     contentStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-    if #available(iOSApplicationExtension 11.0, *) {
+    if #available(iOS 11.0, *) {
       contentStackView.topAnchor
         .constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20).isActive = true
     } else {


### PR DESCRIPTION
Adds a Dragons example to demonstrate how `MDCSnackbar` interacts with the on-screen keyboard. 
 
![snackbar-keyboard](https://user-images.githubusercontent.com/581764/73021209-25e0e900-3df5-11ea-83af-755176caf559.gif)

Related to #9456 