### PR TITLE
[TextFields] Add identity check in -setTextColor: in MDCTextField

### DIFF
--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -333,6 +333,9 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
 }
 
 - (void)setTextColor:(UIColor *)textColor {
+  // This identity check was added in
+  // https://github.com/material-components/material-components-ios/pull/9480 in response to
+  // b/148159587
   if (textColor != self.textColor) {
     [super setTextColor:textColor];
     _fundament.textColor = textColor;

--- a/components/TextFields/src/MDCTextField.m
+++ b/components/TextFields/src/MDCTextField.m
@@ -333,8 +333,10 @@ static const CGFloat MDCTextInputTextRectYCorrection = 1;
 }
 
 - (void)setTextColor:(UIColor *)textColor {
-  [super setTextColor:textColor];
-  _fundament.textColor = textColor;
+  if (textColor != self.textColor) {
+    [super setTextColor:textColor];
+    _fundament.textColor = textColor;
+  }
 }
 
 - (UIEdgeInsets)textInsets {


### PR DESCRIPTION
This PR adds an identity check in `-setTextColor:` in MDCTextField. This identity check short circuits an infinite loop triggered by `-setTextColor:` under certain mysterious circumstances involving the MDCTextField layout pass and MDCFlexibleHeaderView KVO stuff surrounding safeAreaInset changes. I don't fully understand what's going on tbh :)

The internal bug ([b/148159587](http://b/148159587)) has links to before and after gifs in the comments.

Closes #9470

### Update: The internal client who reported the bug was unable to reproduce it with these changes.