### PR TITLE
[WIP] [testing] Add an iPhone 4s simulator to all tests on kokoro.

### DIFF
--- a/components/testing/runners/BUILD
+++ b/components/testing/runners/BUILD
@@ -1,6 +1,13 @@
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 
 ios_test_runner(
+    name = "IPHONE_4S_IN_9_0",
+    device_type = "iPhone 4s",
+    os_version = "9.0",
+    visibility = ["//visibility:public"],
+)
+
+ios_test_runner(
     name = "IPHONE_5_IN_8_1",
     device_type = "iPhone 5",
     os_version = "8.1",

--- a/components/testing/runners/BUILD
+++ b/components/testing/runners/BUILD
@@ -2,8 +2,14 @@ load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl
 
 ios_test_runner(
     name = "IPHONE_4S_IN_9_0",
-    device_type = "iPhone 4s",
-    os_version = "9.0",
+    device_type = select({
+        ":xcode_10_1": "iPhone 4s",
+        "//conditions:default": "iPhone 5",
+    }),
+    os_version = select({
+        ":xcode_10_1": "9.0",
+        "//conditions:default": "10.0",
+    }),
     visibility = ["//visibility:public"],
 )
 
@@ -55,4 +61,9 @@ ios_test_runner(
 native.config_setting(
     name = "xcode_9_0",
     values = {"xcode_version": "9.0"},
+)
+
+native.config_setting(
+    name = "xcode_10_1",
+    values = {"xcode_version": "10.1"},
 )

--- a/material_components_ios.bzl
+++ b/material_components_ios.bzl
@@ -10,6 +10,7 @@ SNAPSHOT_IOS_MINIMUM_OS = "10.0"
 SWIFT_VERSION = "4.2"
 
 DEFAULT_IOS_RUNNER_TARGETS = [
+    "//components/testing/runners:IPHONE_4S_IN_9_0",
     "//components/testing/runners:IPAD_PRO_12_9_IN_9_3",
     "//components/testing/runners:IPHONE_7_PLUS_IN_10_3",
 ]


### PR DESCRIPTION
This is in service to https://github.com/material-components/material-components-ios/pull/9438.

This simulator will increase our test coverage to include 32 bit devices.