### PR TITLE
[FeatureHighlight] Allow UIAccessibility to activate the "dismiss" affordance.

### DIFF
--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -86,10 +86,6 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
   UIGestureRecognizer *tapGestureRecognizer =
       [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(acceptFeature)];
   [_displayedView addGestureRecognizer:tapGestureRecognizer];
-  //  UIGestureRecognizer *dismissTapGestureRecognizer =
-  //  [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(rejectFeature)];
-  //  [self.featureHighlightView.accessibilityDismissView
-  //   addGestureRecognizer:dismissTapGestureRecognizer];
   [self.featureHighlightView.accessibilityDismissView addTarget:self
                                                          action:@selector(rejectFeature)
                                                forControlEvents:UIControlEventTouchUpInside];

--- a/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
+++ b/components/FeatureHighlight/src/MDCFeatureHighlightViewController.m
@@ -86,7 +86,13 @@ static const CGFloat kMDCFeatureHighlightPulseAnimationInterval = (CGFloat)1.5;
   UIGestureRecognizer *tapGestureRecognizer =
       [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(acceptFeature)];
   [_displayedView addGestureRecognizer:tapGestureRecognizer];
-
+  //  UIGestureRecognizer *dismissTapGestureRecognizer =
+  //  [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(rejectFeature)];
+  //  [self.featureHighlightView.accessibilityDismissView
+  //   addGestureRecognizer:dismissTapGestureRecognizer];
+  [self.featureHighlightView.accessibilityDismissView addTarget:self
+                                                         action:@selector(rejectFeature)
+                                               forControlEvents:UIControlEventTouchUpInside];
   self.featureHighlightView.outerHighlightColor = _outerHighlightColor;
   self.featureHighlightView.innerHighlightColor = _innerHighlightColor;
   self.featureHighlightView.titleColor = _titleColor;

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
@@ -19,15 +19,16 @@
 typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 
 @interface MDCFeatureHighlightView ()
-
 @property(nonatomic, readonly) CGPoint highlightCenter;
 @property(nonatomic, readonly) CGFloat highlightRadius;
 
 @property(nonatomic, assign) CGPoint highlightPoint;
-@property(nonatomic, strong) UIView *displayedView;
-@property(nonatomic, strong) UILabel *titleLabel;
-@property(nonatomic, strong) UILabel *bodyLabel;
-@property(nonatomic, copy) MDCFeatureHighlightInteractionBlock interactionBlock;
+@property(nullable, nonatomic, strong) UIView *displayedView;
+@property(nonnull, nonatomic, strong) UILabel *titleLabel;
+@property(nonnull, nonatomic, strong) UILabel *bodyLabel;
+@property(nullable, nonatomic, copy) MDCFeatureHighlightInteractionBlock interactionBlock;
+/** A viewe used by UIAccessibility to reject the Feature Highlight. */
+@property(nonnull, readonly, nonatomic, strong) UIButton *accessibilityDismissView;
 
 @end
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.h
@@ -27,7 +27,7 @@ typedef void (^MDCFeatureHighlightInteractionBlock)(BOOL accepted);
 @property(nonnull, nonatomic, strong) UILabel *titleLabel;
 @property(nonnull, nonatomic, strong) UILabel *bodyLabel;
 @property(nullable, nonatomic, copy) MDCFeatureHighlightInteractionBlock interactionBlock;
-/** A viewe used by UIAccessibility to reject the Feature Highlight. */
+/** A view used by UIAccessibility to reject the Feature Highlight. */
 @property(nonnull, readonly, nonatomic, strong) UIButton *accessibilityDismissView;
 
 @end

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -113,6 +113,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     _accessibilityView = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     _accessibilityView.autoresizingMask = UIViewAutoresizingNone;
     _accessibilityView.accessibilityLabel = @"Dismiss";
+    // Note: The following is not strictly required, but is expected in unit tests.
+    _accessibilityView.isAccessibilityElement = YES;
     [self addSubview:_accessibilityView];
     [self sendSubviewToBack:_accessibilityView];
 

--- a/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
+++ b/components/FeatureHighlight/src/private/MDCFeatureHighlightView+Private.m
@@ -75,7 +75,7 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   MDCFeatureHighlightLayer *_pulseLayer;
   MDCFeatureHighlightLayer *_innerLayer;
   MDCFeatureHighlightLayer *_displayMaskLayer;
-  UIView *_accessibilityView;
+  UIButton *_accessibilityView;
 
   BOOL _mdc_adjustsFontForContentSizeCategory;
 
@@ -109,11 +109,9 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
     _displayMaskLayer = [[MDCFeatureHighlightLayer alloc] init];
     _displayMaskLayer.fillColor = [UIColor whiteColor].CGColor;
 
-    _accessibilityView = [[UIView alloc] initWithFrame:self.bounds];
-    _accessibilityView.autoresizingMask =
-        UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _accessibilityView.isAccessibilityElement = YES;
-    _accessibilityView.accessibilityTraits = UIAccessibilityTraitButton;
+    // Tiny frame just inside the bounds so that non-accessibility interactions aren't affected.
+    _accessibilityView = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+    _accessibilityView.autoresizingMask = UIViewAutoresizingNone;
     _accessibilityView.accessibilityLabel = @"Dismiss";
     [self addSubview:_accessibilityView];
     [self sendSubviewToBack:_accessibilityView];
@@ -436,6 +434,8 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   _pulseLayer.fillColor = _innerHighlightColor.CGColor;
   _innerLayer.fillColor = _innerHighlightColor.CGColor;
   _outerLayer.fillColor = _outerHighlightColor.CGColor;
+
+  _accessibilityView.accessibilityFrame = self.bounds;
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
@@ -660,6 +660,10 @@ static inline CGPoint CGPointAddedToPoint(CGPoint a, CGPoint b) {
   } else {
     [_outerLayer setRadius:scaledRadius animated:NO];
   }
+}
+
+- (UIButton *)accessibilityDismissView {
+  return _accessibilityView;
 }
 
 #pragma mark - Dynamic Type Support


### PR DESCRIPTION
This change connects the recently-added "dismiss" affordance to an action that
allows UIAccessibility to reject the Feature Highlight.  In #8959, a
discoverable affordance was added to Feature Highlight so UIAccessibility
would present dismiss options more easily to users. That change did not
include connecting the view to any action or gesture recognizer, so users
could discover a "dismiss" button but nothing happened when it was activated.

This change does the following:

*   Changes the dismiss view to a UIButton. There were complications when
    attempting to add another gesture recognizer to the view hierarchy and a
    UIButton was a simpler solution.
*   Sets the layout frame of the dismiss view to `{0, 0, 1, 1}`, creating a
    nearly-invisible clear view in the upper-left corner of the screen. The
    `accessibilityFrame` is set to match
    the Feature Highlight's bounds, which presents the affordance to
    UIAccessibility in a manner similar to a Scrim.  This is necessary to
    avoid introducing accidental "reject" taps if the user pressed on the
    Feature Highlight itself.

Closes #9450
