### PR TITLE
[BottomNavigation] Fix bug in delegate method call

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -321,7 +321,8 @@ Pod::Spec.new do |mdc|
         "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
       ]
       unit_tests.exclude_files = [
-        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerTests.m"
+        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerTests.m",
+        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m"
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
     end

--- a/MaterialComponentsBeta.podspec
+++ b/MaterialComponentsBeta.podspec
@@ -64,7 +64,8 @@ Pod::Spec.new do |mdc|
 
     component.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [
-        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerTests.m"
+        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerTests.m",
+        "components/#{component.base_name}/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m"
       ]
     end
   end

--- a/components/BottomNavigation/BUILD
+++ b/components/BottomNavigation/BUILD
@@ -156,7 +156,10 @@ mdc_objc_library(
             "tests/unit/*.h",
             "tests/unit/Theming/*.m",
         ],
-        exclude = ["tests/unit/MDCBottomNavigationBarControllerTests.m"],
+        exclude =  [
+            "tests/unit/MDCBottomNavigationBarControllerTests.m",
+            "tests/unit/MDCBottomNavigationBarControllerDelegateTests.m",
+        ],
     ),
     sdk_frameworks = [
         "CoreGraphics",
@@ -174,7 +177,10 @@ mdc_objc_library(
 mdc_objc_library(
     name = "unit_test_beta_sources",
     testonly = 1,
-    srcs = ["tests/unit/MDCBottomNavigationBarControllerTests.m"],
+    srcs = [
+        "tests/unit/MDCBottomNavigationBarControllerTests.m",
+        "tests/unit/MDCBottomNavigationBarControllerDelegateTests.m",
+    ],
     sdk_frameworks = [
         "CoreGraphics",
         "XCTest",

--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.m
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.m
@@ -266,7 +266,7 @@ static UIViewController *_Nullable DecodeViewController(NSCoder *coder, NSString
 
   // Pass the response to the delegate if they want to handle this request.
   if ([self.delegate respondsToSelector:@selector(bottomNavigationBarController:
-                                                        didSelectViewController:)]) {
+                                                     shouldSelectViewController:)]) {
     UIViewController *viewControllerToSelect = [self.viewControllers objectAtIndex:index];
     return [self.delegate bottomNavigationBarController:self
                              shouldSelectViewController:viewControllerToSelect];

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m
@@ -1,0 +1,205 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialBottomNavigationBeta.h"
+
+/** Category to expose private views for simulating taps. */
+@interface MDCBottomNavigationBar (DelegateTesting)
+- (UIView *)viewForItem:(UITabBarItem *)item;
+@end
+
+/** Delegate that implements no optional APIs. */
+@interface MDCBottomNavigationBarControllerDelegateWithNoOptionals
+    : NSObject <MDCBottomNavigationBarControllerDelegate>
+@end
+
+@implementation MDCBottomNavigationBarControllerDelegateWithNoOptionals
+@end
+
+/** Delegate that only implements @c bottomNavigationBarController:shouldSelectViewController:. */
+@interface MDCBottomNavigationBarControllerDelegateWithOnlyShouldSelect
+    : NSObject <MDCBottomNavigationBarControllerDelegate>
+
+/** @c YES if @c bottomNavigationBarController:shouldSelectViewController: was called. */
+@property(nonatomic, assign, readonly) BOOL shouldSelectViewControllerWasCalled;
+
+@end
+
+@implementation MDCBottomNavigationBarControllerDelegateWithOnlyShouldSelect
+
+- (BOOL)bottomNavigationBarController:
+            (MDCBottomNavigationBarController *)bottomNavigationBarController
+           shouldSelectViewController:(UIViewController *)viewController {
+  _shouldSelectViewControllerWasCalled = YES;
+  return YES;
+}
+
+@end
+
+/** Delegate that only implements @c bottomNavigationBarController:didSelectViewController:. */
+@interface MDCBottomNavigationBarControllerDelegateWithOnlyDidSelect
+    : NSObject <MDCBottomNavigationBarControllerDelegate>
+
+/** @c YES if @c bottomNavigationBarController:didSelectViewController: was called. */
+@property(nonatomic, assign, readonly) BOOL didSelectViewControllerWasCalled;
+
+@end
+
+@implementation MDCBottomNavigationBarControllerDelegateWithOnlyDidSelect
+
+- (void)bottomNavigationBarController:
+            (MDCBottomNavigationBarController *)bottomNavigationBarController
+              didSelectViewController:(UIViewController *)viewController {
+  _didSelectViewControllerWasCalled = YES;
+}
+
+@end
+
+/** Delegate that implements all optional APIs. */
+@interface MDCBottomNavigationBarControllerDelegateWithAllOptionals
+    : NSObject <MDCBottomNavigationBarControllerDelegate>
+
+/** @c YES if @c bottomNavigationBarController:shouldSelectViewController: was called. */
+@property(nonatomic, assign, readonly) BOOL shouldSelectViewControllerWasCalled;
+
+/** @c YES if @c bottomNavigationBarController:didSelectViewController: was called. */
+@property(nonatomic, assign, readonly) BOOL didSelectViewControllerWasCalled;
+
+@end
+
+@implementation MDCBottomNavigationBarControllerDelegateWithAllOptionals
+
+- (BOOL)bottomNavigationBarController:
+            (MDCBottomNavigationBarController *)bottomNavigationBarController
+           shouldSelectViewController:(UIViewController *)viewController {
+  _shouldSelectViewControllerWasCalled = YES;
+  return YES;
+}
+
+- (void)bottomNavigationBarController:
+            (MDCBottomNavigationBarController *)bottomNavigationBarController
+              didSelectViewController:(UIViewController *)viewController {
+  _didSelectViewControllerWasCalled = YES;
+}
+
+@end
+
+/** Unit tests to ensure the different implementations of delegates function correctly. */
+@interface MDCBottomNavigationBarControllerDelegateTests : XCTestCase
+
+/** Controller for testing. */
+@property(nonatomic, strong) MDCBottomNavigationBarController *controller;
+
+@end
+
+@implementation MDCBottomNavigationBarControllerDelegateTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.controller = [[MDCBottomNavigationBarController alloc] init];
+  NSMutableArray<UIViewController *> *viewControllers = [NSMutableArray array];
+  [viewControllers addObject:[[UIViewController alloc] init]];
+  [viewControllers addObject:[[UIViewController alloc] init]];
+  [viewControllers addObject:[[UIViewController alloc] init]];
+  [viewControllers addObject:[[UIViewController alloc] init]];
+  self.controller.viewControllers = [viewControllers copy];
+
+  self.controller.view.bounds = CGRectMake(0, 0, 320, 72);
+  [self.controller.view layoutIfNeeded];
+}
+
+- (void)tearDown {
+  self.controller = nil;
+
+  [super tearDown];
+}
+
+- (void)testNoOptionalsDelegate {
+  // Given
+  MDCBottomNavigationBarControllerDelegateWithNoOptionals *delegate =
+      [[MDCBottomNavigationBarControllerDelegateWithNoOptionals alloc] init];
+  self.controller.selectedIndex = 0;
+
+  // When
+  self.controller.delegate = delegate;
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+         shouldSelectItem:self.controller.navigationBar.items.lastObject]);
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+            didSelectItem:self.controller.navigationBar.items.lastObject]);
+}
+
+- (void)testOnlyDidSelectDelegate {
+  // Given
+  MDCBottomNavigationBarControllerDelegateWithOnlyDidSelect *delegate =
+      [[MDCBottomNavigationBarControllerDelegateWithOnlyDidSelect alloc] init];
+  self.controller.selectedIndex = 0;
+
+  // When
+  self.controller.delegate = delegate;
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+         shouldSelectItem:self.controller.navigationBar.items.lastObject]);
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+            didSelectItem:self.controller.navigationBar.items.lastObject]);
+
+  // Then
+  XCTAssertTrue(delegate.didSelectViewControllerWasCalled);
+}
+
+- (void)testOnlyShouldSelectDelegate {
+  // Given
+  MDCBottomNavigationBarControllerDelegateWithOnlyShouldSelect *delegate =
+      [[MDCBottomNavigationBarControllerDelegateWithOnlyShouldSelect alloc] init];
+  self.controller.selectedIndex = 0;
+
+  // When
+  self.controller.delegate = delegate;
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+         shouldSelectItem:self.controller.navigationBar.items.lastObject]);
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+            didSelectItem:self.controller.navigationBar.items.lastObject]);
+
+  // Then
+  XCTAssertTrue(delegate.shouldSelectViewControllerWasCalled);
+}
+
+- (void)testAllOptionalsDelegate {
+  // Given
+  MDCBottomNavigationBarControllerDelegateWithAllOptionals *delegate =
+      [[MDCBottomNavigationBarControllerDelegateWithAllOptionals alloc] init];
+  self.controller.selectedIndex = 0;
+
+  // When
+  self.controller.delegate = delegate;
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+         shouldSelectItem:self.controller.navigationBar.items.lastObject]);
+  XCTAssertNoThrow([self.controller.navigationBar.delegate
+      bottomNavigationBar:self.controller.navigationBar
+            didSelectItem:self.controller.navigationBar.items.lastObject]);
+
+  // Then
+  XCTAssertTrue(delegate.shouldSelectViewControllerWasCalled);
+  XCTAssertTrue(delegate.didSelectViewControllerWasCalled);
+}
+
+@end

--- a/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m
+++ b/components/BottomNavigation/tests/unit/MDCBottomNavigationBarControllerDelegateTests.m
@@ -16,11 +16,6 @@
 
 #import "MaterialBottomNavigationBeta.h"
 
-/** Category to expose private views for simulating taps. */
-@interface MDCBottomNavigationBar (DelegateTesting)
-- (UIView *)viewForItem:(UITabBarItem *)item;
-@end
-
 /** Delegate that implements no optional APIs. */
 @interface MDCBottomNavigationBarControllerDelegateWithNoOptionals
     : NSObject <MDCBottomNavigationBarControllerDelegate>


### PR DESCRIPTION
[BottomNavigation] Fix bug in delegate method call

The MDCBottomNavigationBarController checks the wrong delegate method before calling `-bottomNavigationBarController:shouldSelectViewController:`. This can lead to crashes in clients that do not implement this method, but implement `-bottomNavigationBarController:didSelectViewController:`.

Fixes #9483
