### PR TITLE
Add UITextView subclass used by text area

### DIFF
--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,15 @@
 #import <UIKit/UIKit.h>
 
 @class MDCBaseTextAreaTextView;
+
+/**
+ This protocol allows the MDCBaseTextAreaTextView to inform the text area of important responder events.
+ */
 @protocol MDCBaseTextAreaTextViewDelegate <NSObject>
-- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
-- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
 @end
 
 @interface MDCBaseTextAreaTextView : UITextView
-@property(nonatomic, weak) id<MDCBaseTextAreaTextViewDelegate> textAreaTextViewDelegate;
+@property(nonatomic, weak, nullable) id<MDCBaseTextAreaTextViewDelegate> textAreaTextViewDelegate;
 @end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -16,8 +16,8 @@
 
 @class MDCBaseTextAreaTextView;
 @protocol MDCBaseTextAreaTextViewDelegate <NSObject>
-- (void)textAreaTextViewWillBecomeFirstResponder:(BOOL)didBecome;
-- (void)textAreaTextViewWillResignFirstResponder:(BOOL)didResign;
+- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
+- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
 @end
 
 @interface MDCBaseTextAreaTextView : UITextView

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -20,10 +20,25 @@
  This protocol allows the MDCBaseTextAreaTextView to inform the text area of important responder events.
  */
 @protocol MDCBaseTextAreaTextViewDelegate <NSObject>
+
+/**
+This method is called when the text view is about to become the first responder.
+ */
 - (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
+
+/**
+This method is called when the text view is about to resign the first responder.
+ */
 - (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
 @end
 
+/**
+This private UITextView subclass is used by the MDCBaseTextArea to handle multi-line text
+ */
 @interface MDCBaseTextAreaTextView : UITextView
+
+/**
+ A delegate conforming to MDCBaseTextAreaTextViewDelegate
+ */
 @property(nonatomic, weak, nullable) id<MDCBaseTextAreaTextViewDelegate> textAreaTextViewDelegate;
 @end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -1,0 +1,25 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@class MDCBaseTextAreaTextView;
+@protocol MDCBaseTextAreaTextViewDelegate <NSObject>
+- (void)textAreaTextViewWillBecomeFirstResponder:(BOOL)didBecome;
+- (void)textAreaTextViewWillResignFirstResponder:(BOOL)didResign;
+@end
+
+@interface MDCBaseTextAreaTextView : UITextView
+@property(nonatomic, weak) id<MDCBaseTextAreaTextViewDelegate> textAreaTextViewDelegate;
+@end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -1,0 +1,71 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBaseTextAreaTextView.h"
+#import "MDCTextControl.h"
+
+@implementation MDCBaseTextAreaTextView
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self commonMDCBaseTextAreaTextViewInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCBaseTextAreaTextViewInit];
+  }
+  return self;
+}
+
+- (void)commonMDCBaseTextAreaTextViewInit {
+  self.backgroundColor = [UIColor clearColor];
+  self.textContainerInset = UIEdgeInsetsZero;
+  self.layoutMargins = UIEdgeInsetsZero;
+  self.textContainer.lineFragmentPadding = 0;
+  self.font = MDCTextControlDefaultUITextFieldFont();
+  self.clipsToBounds = NO;
+}
+
+- (void)setFont:(UIFont *)font {
+  [super setFont:font ?: MDCTextControlDefaultUITextFieldFont()];
+}
+
+- (UIFont *)font {
+  return [super font] ?: MDCTextControlDefaultUITextFieldFont();
+}
+
+- (BOOL)resignFirstResponder {
+  BOOL superclassDidResignFirstResponder = [super resignFirstResponder];
+  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillResignFirstResponder:)]) {
+    [self.textAreaTextViewDelegate
+     textAreaTextViewWillResignFirstResponder:superclassDidResignFirstResponder];
+  }
+  return superclassDidResignFirstResponder;
+}
+
+- (BOOL)becomeFirstResponder {
+  BOOL superclassDidBecomeFirstResponder = [super becomeFirstResponder];
+  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillBecomeFirstResponder:)]) {
+    [self.textAreaTextViewDelegate
+     textAreaTextViewWillBecomeFirstResponder:superclassDidBecomeFirstResponder];
+  }
+  return superclassDidBecomeFirstResponder;
+}
+
+@end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 
 @implementation MDCBaseTextAreaTextView
 
-- (instancetype)init {
-  self = [super init];
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
   if (self) {
     [self commonMDCBaseTextAreaTextViewInit];
   }
@@ -34,7 +34,7 @@
 }
 
 - (void)commonMDCBaseTextAreaTextViewInit {
-  self.backgroundColor = [UIColor clearColor];
+  self.backgroundColor = UIColor.clearColor;
   self.textContainerInset = UIEdgeInsetsZero;
   self.layoutMargins = UIEdgeInsetsZero;
   self.textContainer.lineFragmentPadding = 0;

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -496,16 +496,11 @@
 #pragma mark Fonts
 
 - (UIFont *)normalFont {
-  return self.font ?: [self uiTextFieldDefaultFont];
+  return self.font ?: MDCTextControlDefaultUITextFieldFont();
 }
 
 - (UIFont *)floatingFont {
   return [self.containerStyle floatingFontWithNormalFont:self.normalFont];
-}
-
-- (UIFont *)uiTextFieldDefaultFont {
-  // This value comes from https://developer.apple.com/documentation/uikit/uitextfield/1619604-font
-  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 #pragma mark Dynamic Type

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
@@ -23,6 +23,10 @@
 #import "MDCTextControlState.h"
 #import "MDCTextControlVerticalPositioningReference.h"
 
+static inline UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont() {
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+}
+
 static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
 
 @protocol MDCTextControlStyle;


### PR DESCRIPTION
This PR adds the private UITextView subclass used by the TextControl text area.
Note that it is being merged into a feature branch because of our current lack of CI.
Once CI is back up and running I'll open a PR to merge the feature branch into develop.
BUILD file and podspec changes to follow.
Related to #9407.
