### PR TITLE
[Dialogs] Adding accessory view vertical inset to private header

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -56,6 +56,15 @@
 @property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
 /**
+ If YES, a new layout calculation that is customizable by the insets in this header file is used
+ to layout the dialog. If NO, we fall back to the legaccy layout calculation, ignoring all
+ customized inset values.
+
+ Default value is @c NO.
+ */
+@property(nonatomic, assign) BOOL enableAdjustableInsets;
+
+/**
  The margins around the title icon or the title icon view against the dialog
  edges (top, leading, trailing) and the title (bottom). Note that the actual
  bottom space is the smallest between titleImageInsets.bottom and
@@ -113,12 +122,10 @@
 @property(nonatomic, assign) CGFloat actionsVerticalMargin;
 
 /**
- If YES, a new layout calculation that is customizable by the insets in this header file is used
- to layout the dialog. If NO, we fall back to the legaccy layout calculation, ignoring all
- customized inset values.
+ The vertical inset between the accessory view and the message, if both are present.
 
- Default value is @c NO.
+ Default value is 20.
  */
-@property(nonatomic, assign) BOOL enableAdjustableInsets;
+@property(nonatomic, assign) CGFloat accessoryViewVerticalInset;
 
 @end

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -68,6 +68,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.actionsInsets = UIEdgeInsetsMake(8.f, 8.f, 8.f, 8.f);
     self.actionsHorizontalMargin = 8.f;
     self.actionsVerticalMargin = 12.f;
+    self.accessoryViewVerticalInset = 20.f;
 
     self.titleScrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];
     [self addSubview:self.titleScrollView];


### PR DESCRIPTION
# Description

Adding accessory view vertical inset to private header, with a default value of 20.0, which is a backward compatible value.

Moving the feature flag to the top of the insets list, and adding the new inset value last on the list.

# Issue
Issues: b/132948073, 294022719