### PR TITLE
Delete NavigationDrawer OWNERS file

### DIFF
--- a/components/NavigationDrawer/OWNERS
+++ b/components/NavigationDrawer/OWNERS
@@ -1,6 +1,0 @@
-# go/mdc-contributing
-
-# Please see the main OWNERS file under the parent folder
-# material_components_ios/ to find the core owners of this component.
-approve-only: rockland
-


### PR DESCRIPTION
This file has the PII of Googlers.

https://github.com/material-components/material-components-ios/blob/stable/CODEOWNERS is github friendly version of the same information.