### PR TITLE
[Dialogs] Refactor title frame calculations to accommodate adjustable…

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -71,7 +71,7 @@
  If a message is presented, the minimum titleInsets.bottom and contentInsets.top is used.
  If there is no message, titleInsets.bottom is used.
 
- Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 20, trailing: 24).
+ Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 24, trailing: 24).
  */
 @property(nonatomic, assign) UIEdgeInsets titleInsets;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -61,9 +61,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.autoresizesSubviews = NO;
     self.clipsToBounds = YES;
 
+
     self.titleIconInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);
-    self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);
-    self.contentInsets = UIEdgeInsetsMake(24.f, 24.f, 28.f, 24.f);
+    self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 24.f, 24.f);
+    self.contentInsets = UIEdgeInsetsMake(24.f, 24.f, 24.f, 24.f);
     self.actionsInsets = UIEdgeInsetsMake(8.f, 8.f, 8.f, 8.f);
     self.actionsHorizontalMargin = 8.f;
     self.actionsVerticalMargin = 12.f;
@@ -429,8 +430,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return size;
 }
 
-- (BOOL)hasTitleIcon {
-  return (0.0f < self.titleIconImageView.image.size.height);
+- (BOOL)hasTitleIconOrImage {
+  return self.titleIconImageView.image.size.height > 0.f || self.titleIconView != nil;
+}
+
+- (BOOL)fixedLayoutHasTitleIcon {
+  return self.titleIconImageView.image.size.height > 0.f;
 }
 
 - (BOOL)hasTitle {
@@ -439,6 +444,34 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (BOOL)hasMessage {
   return self.message.length > 0;
+}
+
+- (BOOL)hasContent {
+  if ([self hasMessage]) {
+    return YES;
+  }
+  CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:CGRectInfinite.size];
+  return accessoryViewSize.height > 0.f;
+}
+
+- (CGFloat)titleIconInsetBottom {
+  return [self hasTitleIcon] && [self hasTitle]
+             ? MIN(self.titleIconInsets.bottom, self.titleInsets.top)
+             : 0.0f;
+}
+
+- (CGFloat)titleInsetTop {
+  return [self hasTitleIcon] ? self.titleIconInsets.top : self.titleInsets.top;
+}
+
+- (CGFloat)titleInsetBottom {
+  CGFloat inset = ([self hasTitle] || [self hasTitleIcon]) && [self hasMessage]
+                      ? self.titleInsets.bottom
+                      : 0.0f;
+  if (inset != 0.0f && [self hasContent]) {
+    inset = MIN(inset, self.contentInsets.top);
+  }
+  return inset;
 }
 
 - (CGFloat)contentInternalVerticalPadding {
@@ -546,26 +579,46 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return contentSize;
 }
 
-// @param boundingWidth should not include any internal margins or padding
+/**
+ Calculate the size of the title frame, which includes an optional title, optional title icon and
+ optinal icon view.
+ @param boundingWidth should not include any internal margins or padding
+*/
 - (CGSize)calculateTitleViewSizeThatFitsWidth:(CGFloat)boundingWidth {
+  CGFloat leftInset =
+      MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left);
+  CGFloat rightInset =
+      MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right);
+
   CGSize boundsSize = CGRectInfinite.size;
-  boundsSize.width = boundingWidth - MDCDialogContentInsets.left - MDCDialogContentInsets.right;
+  boundsSize.width = boundingWidth - leftInset - rightInset;
 
   CGSize titleSize = [self.titleLabel sizeThatFits:boundsSize];
   CGSize messageSize = [self.messageLabel sizeThatFits:boundsSize];
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
-  CGFloat contentWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
-                         MDCDialogContentInsets.left + MDCDialogContentInsets.right;
 
-  CGFloat contentHeight = MDCDialogContentInsets.top + [self titleIconViewSize].height +
-                          [self contentTitleIconVerticalPadding] + titleSize.height +
-                          [self contentInternalVerticalPadding];
+  CGFloat totalElementsHeight =
+      [self titleIconViewSize].height + titleSize.height;  // 0 for missing elements.
 
-  CGSize contentSize;
-  contentSize.width = (CGFloat)ceil(contentWidth);
-  contentSize.height = (CGFloat)ceil(contentHeight);
+  // Adjustable insets layout
+  CGFloat titleTotalWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
+                            leftInset + rightInset;
+  CGFloat titleTotalHeight = totalElementsHeight + [self titleInsetTop] +
+                             [self titleIconInsetBottom] + [self titleInsetBottom];
+  CGSize titleTotalSize =
+      CGSizeMake((CGFloat)ceil(titleTotalWidth), (CGFloat)ceil(titleTotalHeight));
 
-  return contentSize;
+  // Fixed insets layout
+  CGFloat originalIconPadding = [self contentTitleIconVerticalPadding];
+  CGFloat originalInernalPadding = [self contentInternalVerticalPadding];
+  CGFloat originalHeight = totalElementsHeight + MDCDialogContentInsets.top + originalIconPadding +
+                           originalInernalPadding;
+  CGFloat originalWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
+                          MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  CGSize originalTitleSize =
+      CGSizeMake((CGFloat)ceil(originalWidth), (CGFloat)ceil(originalHeight));
+
+  return self.enableAdjustableInsets ? titleTotalSize : originalTitleSize;
 }
 
 // @param boundingWidth should not include any internal margins or padding


### PR DESCRIPTION
# Description

Compute adjustable insets for the title frame in Dialogs. 
Both adjustable and fixed insets mode are supported. The adjustable insets logic is hidden behind a feature flag - enableAdjustableInsets, so this CL should not result in any visual changes.

## Issue
b/148802180, 293706369
