### PR TITLE
[private] Move static const to MDCTextControl.m

### DIFF
--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
@@ -27,7 +27,7 @@ static inline UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont() {
   return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
-static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
+FOUNDATION_EXTERN const CGFloat kMDCTextControlDefaultAnimationDuration;
 
 @protocol MDCTextControlStyle;
 

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.m
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.m
@@ -1,0 +1,17 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextControl.h"
+
+const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;


### PR DESCRIPTION
This change makes the static const in MDCTextControl.h a FOUNDATION_EXTERN const. 

Related to [b/143312111](http://b/143312111).