### PR TITLE
[ShadowElevations] extern-ize static variables in MDCShadowElevations.h

### DIFF
--- a/components/ShadowElevations/src/MDCShadowElevations.h
+++ b/components/ShadowElevations/src/MDCShadowElevations.h
@@ -31,76 +31,76 @@ NS_SWIFT_NAME(ShadowElevation)
 typedef CGFloat MDCShadowElevation MDC_SHADOW_ELEVATION_TYPED_EXTENSIBLE_ENUM;
 
 /** The shadow elevation of the app bar. */
-static const MDCShadowElevation MDCShadowElevationAppBar = (CGFloat)4.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationAppBar;
 
 /** The shadow elevation of the Bottom App Bar. */
-static const MDCShadowElevation MDCShadowElevationBottomAppBar = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationBottomAppBar;
 
 /** The shadow elevation of the Bottom App Bar. */
-static const MDCShadowElevation MDCShadowElevationBottomNavigationBar = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationBottomNavigationBar;
 
 /** The shadow elevation of a card in its picked up state. */
-static const MDCShadowElevation MDCShadowElevationCardPickedUp = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationCardPickedUp;
 
 /** The shadow elevation of a card in its resting state. */
-static const MDCShadowElevation MDCShadowElevationCardResting = (CGFloat)2.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationCardResting;
 
 /** The shadow elevation of dialogs. */
-static const MDCShadowElevation MDCShadowElevationDialog = (CGFloat)24.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationDialog;
 
 /** The shadow elevation of the floating action button in its pressed state. */
-static const MDCShadowElevation MDCShadowElevationFABPressed = (CGFloat)12.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationFABPressed;
 
 /** The shadow elevation of the floating action button in its resting state. */
-static const MDCShadowElevation MDCShadowElevationFABResting = (CGFloat)6.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationFABResting;
 
 /** The shadow elevation of a menu. */
-static const MDCShadowElevation MDCShadowElevationMenu = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationMenu;
 
 /** The shadow elevation of a modal bottom sheet. */
-static const MDCShadowElevation MDCShadowElevationModalActionSheet = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationModalActionSheet;
 
 /** The shadow elevation of a modal bottom sheet. */
-static const MDCShadowElevation MDCShadowElevationModalBottomSheet = (CGFloat)16.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationModalBottomSheet;
 
 /** The shadow elevation of the navigation drawer. */
-static const MDCShadowElevation MDCShadowElevationNavDrawer = (CGFloat)16.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationNavDrawer;
 
 /** No shadow elevation at all. */
-static const MDCShadowElevation MDCShadowElevationNone = (CGFloat)0.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationNone;
 
 /** The shadow elevation of a picker. */
-static const MDCShadowElevation MDCShadowElevationPicker = (CGFloat)24.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationPicker;
 
 /** The shadow elevation of the quick entry in the scrolled state. */
-static const MDCShadowElevation MDCShadowElevationQuickEntry = (CGFloat)3.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationQuickEntry;
 
 /** The shadow elevation of the quick entry in the resting state. */
-static const MDCShadowElevation MDCShadowElevationQuickEntryResting = (CGFloat)2.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationQuickEntryResting;
 
 /** The shadow elevation of a raised button in the pressed state. */
-static const MDCShadowElevation MDCShadowElevationRaisedButtonPressed = (CGFloat)8.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationRaisedButtonPressed;
 
 /** The shadow elevation of a raised button in the resting state. */
-static const MDCShadowElevation MDCShadowElevationRaisedButtonResting = (CGFloat)2.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationRaisedButtonResting;
 
 /** The shadow elevation of a refresh indicator. */
-static const MDCShadowElevation MDCShadowElevationRefresh = (CGFloat)3.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationRefresh;
 
 /** The shadow elevation of the right drawer. */
-static const MDCShadowElevation MDCShadowElevationRightDrawer = (CGFloat)16.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationRightDrawer;
 
 /** The shadow elevation of the search bar in the resting state. */
-static const MDCShadowElevation MDCShadowElevationSearchBarResting = (CGFloat)2.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationSearchBarResting;
 
 /** The shadow elevation of the search bar in the scrolled state. */
-static const MDCShadowElevation MDCShadowElevationSearchBarScrolled = (CGFloat)3.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationSearchBarScrolled;
 
 /** The shadow elevation of the snackbar. */
-static const MDCShadowElevation MDCShadowElevationSnackbar = (CGFloat)6.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationSnackbar;
 
 /** The shadow elevation of a sub menu (+1 for each additional sub menu). */
-static const MDCShadowElevation MDCShadowElevationSubMenu = (CGFloat)9.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationSubMenu;
 
 /** The shadow elevation of a switch. */
-static const MDCShadowElevation MDCShadowElevationSwitch = (CGFloat)1.0;
+FOUNDATION_EXTERN const MDCShadowElevation MDCShadowElevationSwitch;

--- a/components/ShadowElevations/src/MDCShadowElevations.m
+++ b/components/ShadowElevations/src/MDCShadowElevations.m
@@ -1,4 +1,4 @@
-// Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/ShadowElevations/src/MDCShadowElevations.m
+++ b/components/ShadowElevations/src/MDCShadowElevations.m
@@ -1,0 +1,90 @@
+// Copyright 2015-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCShadowElevations.h"
+
+/** The shadow elevation of the app bar. */
+const MDCShadowElevation MDCShadowElevationAppBar = (CGFloat)4.0;
+
+/** The shadow elevation of the Bottom App Bar. */
+const MDCShadowElevation MDCShadowElevationBottomAppBar = (CGFloat)8.0;
+
+/** The shadow elevation of the Bottom App Bar. */
+const MDCShadowElevation MDCShadowElevationBottomNavigationBar = (CGFloat)8.0;
+
+/** The shadow elevation of a card in its picked up state. */
+const MDCShadowElevation MDCShadowElevationCardPickedUp = (CGFloat)8.0;
+
+/** The shadow elevation of a card in its resting state. */
+const MDCShadowElevation MDCShadowElevationCardResting = (CGFloat)2.0;
+
+/** The shadow elevation of dialogs. */
+const MDCShadowElevation MDCShadowElevationDialog = (CGFloat)24.0;
+
+/** The shadow elevation of the floating action button in its pressed state. */
+const MDCShadowElevation MDCShadowElevationFABPressed = (CGFloat)12.0;
+
+/** The shadow elevation of the floating action button in its resting state. */
+const MDCShadowElevation MDCShadowElevationFABResting = (CGFloat)6.0;
+
+/** The shadow elevation of a menu. */
+const MDCShadowElevation MDCShadowElevationMenu = (CGFloat)8.0;
+
+/** The shadow elevation of a modal bottom sheet. */
+const MDCShadowElevation MDCShadowElevationModalActionSheet = (CGFloat)8.0;
+
+/** The shadow elevation of a modal bottom sheet. */
+const MDCShadowElevation MDCShadowElevationModalBottomSheet = (CGFloat)16.0;
+
+/** The shadow elevation of the navigation drawer. */
+const MDCShadowElevation MDCShadowElevationNavDrawer = (CGFloat)16.0;
+
+/** No shadow elevation at all. */
+const MDCShadowElevation MDCShadowElevationNone = (CGFloat)0.0;
+
+/** The shadow elevation of a picker. */
+const MDCShadowElevation MDCShadowElevationPicker = (CGFloat)24.0;
+
+/** The shadow elevation of the quick entry in the scrolled state. */
+const MDCShadowElevation MDCShadowElevationQuickEntry = (CGFloat)3.0;
+
+/** The shadow elevation of the quick entry in the resting state. */
+const MDCShadowElevation MDCShadowElevationQuickEntryResting = (CGFloat)2.0;
+
+/** The shadow elevation of a raised button in the pressed state. */
+const MDCShadowElevation MDCShadowElevationRaisedButtonPressed = (CGFloat)8.0;
+
+/** The shadow elevation of a raised button in the resting state. */
+const MDCShadowElevation MDCShadowElevationRaisedButtonResting = (CGFloat)2.0;
+
+/** The shadow elevation of a refresh indicator. */
+const MDCShadowElevation MDCShadowElevationRefresh = (CGFloat)3.0;
+
+/** The shadow elevation of the right drawer. */
+const MDCShadowElevation MDCShadowElevationRightDrawer = (CGFloat)16.0;
+
+/** The shadow elevation of the search bar in the resting state. */
+const MDCShadowElevation MDCShadowElevationSearchBarResting = (CGFloat)2.0;
+
+/** The shadow elevation of the search bar in the scrolled state. */
+const MDCShadowElevation MDCShadowElevationSearchBarScrolled = (CGFloat)3.0;
+
+/** The shadow elevation of the snackbar. */
+const MDCShadowElevation MDCShadowElevationSnackbar = (CGFloat)6.0;
+
+/** The shadow elevation of a sub menu (+1 for each additional sub menu). */
+const MDCShadowElevation MDCShadowElevationSubMenu = (CGFloat)9.0;
+
+/** The shadow elevation of a switch. */
+const MDCShadowElevation MDCShadowElevationSwitch = (CGFloat)1.0;


### PR DESCRIPTION
This moves constants defined as static variables in MDCShadowElevations.h into MDCShadowElevations.m