### PR TITLE
[Dialogs] Refactor title frame calculations to accommodate adjustable insets

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -70,7 +70,7 @@
  edges (top, leading, trailing) and the title (bottom). Note that
  `titleIconInsets.bottom` takes precedence over `titleInsets.top`.
 
- Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 20, trailing: 24).
+ Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 12, trailing: 24).
  */
 @property(nonatomic, assign) UIEdgeInsets titleIconInsets;
 
@@ -81,7 +81,7 @@
   no message, `titleInsets.bottom` is ignored.
 
 
- Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 24, trailing: 24).
+ Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 20, trailing: 24).
  */
 @property(nonatomic, assign) UIEdgeInsets titleInsets;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -62,8 +62,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.clipsToBounds = YES;
 
     self.enableAdjustableInsets = NO;
-    self.titleIconInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);
-    self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 24.f, 24.f);
+    self.titleIconInsets = UIEdgeInsetsMake(24.f, 24.f, 12.f, 24.f);
+    self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);
     self.contentInsets = UIEdgeInsetsMake(24.f, 24.f, 24.f, 24.f);
     self.actionsInsets = UIEdgeInsetsMake(8.f, 8.f, 8.f, 8.f);
     self.actionsHorizontalMargin = 8.f;
@@ -443,13 +443,36 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return self.message.length > 0;
 }
 
+- (BOOL)hasAccessoryView {
+  CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:CGRectInfinite.size];
+  return accessoryViewSize.height > 0.f;
+}
+
+- (CGFloat)titleIconInsetBottom {
+  return [self hasTitleIcon] && [self hasTitle] ? self.titleIconInsets.bottom : 0.0f;
+}
+
+- (CGFloat)titleInsetTop {
+  return [self hasTitleIcon] ? self.titleIconInsets.top : self.titleInsets.top;
+}
+
+- (CGFloat)titleInsetBottom {
+  if (![self hasMessage] && ![self hasAccessoryView]) {
+    return 0.0f;
+  } else if ([self hasTitle] || [self hasTitleIcon]) {
+    return self.titleInsets.bottom;
+  } else {
+    return 0.0f;
+  }
+}
+
 - (CGFloat)contentInternalVerticalPadding {
   return (([self hasTitle] || [self hasTitleIcon]) && [self hasMessage])
              ? MDCDialogContentVerticalPadding
              : 0.0f;
 }
 
-- (CGFloat)contentTitleIconVerticalPadding {
+- (CGFloat)fixedInsetsContentTitleIconVerticalPadding {
   return ([self hasTitle] && [self hasTitleIcon]) ? MDCDialogTitleIconVerticalPadding : 0.0f;
 }
 
@@ -471,14 +494,18 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return titleIconViewSize;
 }
 
-- (CGFloat)titleTop {
-  return MDCDialogContentInsets.top + [self contentTitleIconVerticalPadding] +
-         [self titleIconViewSize].height;
-}
-
 - (CGRect)titleFrameWithTitleSize:(CGSize)titleSize {
-  return CGRectMake(MDCDialogContentInsets.left, [self titleTop], titleSize.width,
-                    titleSize.height);
+  CGFloat titleTop = 0.0f;
+  CGFloat leftInset = 0.0f;
+  if (self.enableAdjustableInsets) {
+    leftInset = self.titleInsets.left;
+    titleTop = [self titleIconViewSize].height + [self titleInsetTop] + [self titleIconInsetBottom];
+  } else {
+    leftInset = MDCDialogContentInsets.left;
+    titleTop = MDCDialogContentInsets.top + [self fixedInsetsContentTitleIconVerticalPadding] +
+               [self titleIconViewSize].height;
+  }
+  return CGRectMake(leftInset, titleTop, titleSize.width, titleSize.height);
 }
 
 - (CGRect)messageFrameWithSize:(CGSize)messageSize {
@@ -547,26 +574,42 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return contentSize;
 }
 
-// @param boundingWidth should not include any internal margins or padding
+/**
+ Calculate the size of the title frame, which includes an optional title, optional title icon and
+ optional icon view.
+
+ @param boundingWidth should not include any internal margins or padding
+*/
 - (CGSize)calculateTitleViewSizeThatFitsWidth:(CGFloat)boundingWidth {
+  CGFloat leftInset =
+      self.enableAdjustableInsets
+          ? MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left)
+          : MDCDialogContentInsets.left;
+  CGFloat rightInset =
+      self.enableAdjustableInsets
+          ? MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right)
+          : MDCDialogContentInsets.right;
+
   CGSize boundsSize = CGRectInfinite.size;
-  boundsSize.width = boundingWidth - MDCDialogContentInsets.left - MDCDialogContentInsets.right;
+  boundsSize.width = boundingWidth - leftInset - rightInset;
 
   CGSize titleSize = [self.titleLabel sizeThatFits:boundsSize];
   CGSize messageSize = [self.messageLabel sizeThatFits:boundsSize];
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
-  CGFloat contentWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
-                         MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  CGFloat titleWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
+                       leftInset + rightInset;
+  CGFloat totalElementsHeight = [self titleIconViewSize].height + titleSize.height;
 
-  CGFloat contentHeight = MDCDialogContentInsets.top + [self titleIconViewSize].height +
-                          [self contentTitleIconVerticalPadding] + titleSize.height +
-                          [self contentInternalVerticalPadding];
-
-  CGSize contentSize;
-  contentSize.width = (CGFloat)ceil(contentWidth);
-  contentSize.height = (CGFloat)ceil(contentHeight);
-
-  return contentSize;
+  CGFloat titleHeight = 0.f;
+  if (self.enableAdjustableInsets) {
+    titleHeight = totalElementsHeight + [self titleInsetTop] + [self titleIconInsetBottom] +
+                  [self titleInsetBottom];
+  } else {
+    titleHeight = totalElementsHeight + MDCDialogContentInsets.top +
+                  [self fixedInsetsContentTitleIconVerticalPadding] +
+                  [self contentInternalVerticalPadding];
+  }
+  return CGSizeMake((CGFloat)ceil(titleWidth), (CGFloat)ceil(titleHeight));
 }
 
 // @param boundingWidth should not include any internal margins or padding


### PR DESCRIPTION
# Description
Compute adjustable insets for the title frame. Both adjustable and fixed insets mode are supported. The adjustable insets logic is hidden behind a feature flag - enableAdjustableInsets, so this PR should not result in any visual changes.

## Issue
b/148802180, 293706369