### PR TITLE
[Dialogs] Refactor content frame calculations to accommodate adjustable insets 

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -566,9 +566,13 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 // @param boundingWidth should not include any internal margins or padding
 - (CGSize)calculateContentSizeThatFitsWidth:(CGFloat)boundingWidth {
   CGFloat leftInset =
-      MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left);
+      self.enableAdjustableInsets
+          ? MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left)
+          : MDCDialogContentInsets.left;
   CGFloat rightInset =
-      MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right);
+      self.enableAdjustableInsets
+          ? MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right)
+          : MDCDialogContentInsets.right;
 
   CGSize boundsSize = CGRectInfinite.size;
   boundsSize.width = boundingWidth - leftInset - rightInset;
@@ -577,30 +581,18 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   CGSize messageSize = [self.messageLabel sizeThatFits:boundsSize];
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
 
-  CGFloat contentTotalWidth =
-      MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) + leftInset +
-      rightInset;
+  CGFloat contentWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
+                         leftInset + rightInset;
   CGFloat totalElementsHeight = messageSize.height + accessoryViewSize.height;
 
-  // Adjustable insets layout
-  CGFloat contentTotalHeight =
-      totalElementsHeight + [self accessoryVerticalInset] + self.contentInsets.bottom;
-
-  CGSize contentSize;
-  contentSize.width = (CGFloat)ceil(contentTotalWidth);
-  contentSize.height = (CGFloat)ceil(contentTotalHeight);
-
-  // Fixed insets layout
-  CGFloat contentAccessoryVerticalPadding =
-      [self fixedInsetsContentAccessoryVerticalPaddingWithFittingSize:boundsSize];
-  CGFloat fixedInsetsHeight =
-      totalElementsHeight + contentAccessoryVerticalPadding + MDCDialogContentInsets.bottom;
-  CGFloat fixedInsetsWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
-                             MDCDialogContentInsets.left + MDCDialogContentInsets.right;
-  CGSize fixedInsetsContentSize =
-      CGSizeMake((CGFloat)ceil(fixedInsetsWidth), (CGFloat)ceil(fixedInsetsHeight));
-
-  return self.enableAdjustableInsets ? contentSize : fixedInsetsContentSize;
+  CGFloat contentHeight;
+  if (self.enableAdjustableInsets) {
+    contentHeight = totalElementsHeight + [self accessoryVerticalInset] + self.contentInsets.bottom;
+  } else {
+    contentHeight = totalElementsHeight + MDCDialogContentInsets.bottom +
+                    [self fixedInsetsContentAccessoryVerticalPaddingWithFittingSize:boundsSize];
+  }
+  return CGSizeMake((CGFloat)ceil(contentWidth), (CGFloat)ceil(contentHeight));
 }
 
 /**

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -466,7 +466,19 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   }
 }
 
+- (CGFloat)accessoryVerticalInset {
+  return [self hasMessage] && [self hasAccessoryView] ? self.accessoryViewVerticalInset : 0.f;
+}
+
 - (CGFloat)contentInternalVerticalPadding {
+  if (self.enableAdjustableInsets) {
+    return [self titleInsetBottom];
+  } else {
+    return [self fixedInsetsContentInternalVerticalPadding];
+  }
+}
+
+- (CGFloat)fixedInsetsContentInternalVerticalPadding {
   return (([self hasTitle] || [self hasTitleIcon]) && [self hasMessage])
              ? MDCDialogContentVerticalPadding
              : 0.0f;
@@ -476,7 +488,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return ([self hasTitle] && [self hasTitleIcon]) ? MDCDialogTitleIconVerticalPadding : 0.0f;
 }
 
-- (CGFloat)contentAccessoryVerticalPaddingWithFittingSize:(CGSize)boundsSize {
+- (CGFloat)fixedInsetsContentAccessoryVerticalPaddingWithFittingSize:(CGSize)boundsSize {
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
   return (([self hasTitle] || [self hasTitleIcon] || [self hasMessage]) &&
           (0.0 < accessoryViewSize.height))
@@ -509,16 +521,17 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 }
 
 - (CGRect)messageFrameWithSize:(CGSize)messageSize {
-  CGRect messageFrame =
-      CGRectMake(MDCDialogContentInsets.left, 0, messageSize.width, messageSize.height);
-  return messageFrame;
+  CGFloat leftInset =
+      self.enableAdjustableInsets ? self.contentInsets.left : MDCDialogContentInsets.left;
+  return CGRectMake(leftInset, 0, messageSize.width, messageSize.height);
 }
 
 - (CGRect)titleIconFrameWithTitleSize:(CGSize)titleSize {
   CGSize titleIconViewSize = [self titleIconViewSize];
   CGRect titleFrame = [self titleFrameWithTitleSize:titleSize];
   // match the titleIcon alignment to the title alignment
-  CGFloat titleIconLeftPadding = MDCDialogContentInsets.left;
+  CGFloat titleIconLeftPadding =
+      self.enableAdjustableInsets ? self.titleInsets.left : MDCDialogContentInsets.left;
   if (self.titleAlignment == NSTextAlignmentCenter) {
     titleIconLeftPadding =
         CGRectGetMinX(titleFrame) + (CGRectGetWidth(titleFrame) - titleIconViewSize.width) / 2.0f;
@@ -552,26 +565,42 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 // @param boundingWidth should not include any internal margins or padding
 - (CGSize)calculateContentSizeThatFitsWidth:(CGFloat)boundingWidth {
+  CGFloat leftInset =
+      MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left);
+  CGFloat rightInset =
+      MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right);
+
   CGSize boundsSize = CGRectInfinite.size;
-  boundsSize.width = boundingWidth - MDCDialogContentInsets.left - MDCDialogContentInsets.right;
+  boundsSize.width = boundingWidth - leftInset - rightInset;
 
   CGSize titleSize = [self.titleLabel sizeThatFits:boundsSize];
   CGSize messageSize = [self.messageLabel sizeThatFits:boundsSize];
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
 
-  CGFloat contentWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
-                         MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  CGFloat contentTotalWidth =
+      MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) + leftInset +
+      rightInset;
+  CGFloat totalElementsHeight = messageSize.height + accessoryViewSize.height;
 
-  CGFloat contentAccessoryVerticalPadding =
-      [self contentAccessoryVerticalPaddingWithFittingSize:boundsSize];
-  CGFloat contentHeight = messageSize.height + contentAccessoryVerticalPadding +
-                          accessoryViewSize.height + MDCDialogContentInsets.bottom;
+  // Adjustable insets layout
+  CGFloat contentTotalHeight =
+      totalElementsHeight + [self accessoryVerticalInset] + self.contentInsets.bottom;
 
   CGSize contentSize;
-  contentSize.width = (CGFloat)ceil(contentWidth);
-  contentSize.height = (CGFloat)ceil(contentHeight);
+  contentSize.width = (CGFloat)ceil(contentTotalWidth);
+  contentSize.height = (CGFloat)ceil(contentTotalHeight);
 
-  return contentSize;
+  // Fixed insets layout
+  CGFloat contentAccessoryVerticalPadding =
+      [self fixedInsetsContentAccessoryVerticalPaddingWithFittingSize:boundsSize];
+  CGFloat fixedInsetsHeight =
+      totalElementsHeight + contentAccessoryVerticalPadding + MDCDialogContentInsets.bottom;
+  CGFloat fixedInsetsWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
+                             MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  CGSize fixedInsetsContentSize =
+      CGSizeMake((CGFloat)ceil(fixedInsetsWidth), (CGFloat)ceil(fixedInsetsHeight));
+
+  return self.enableAdjustableInsets ? contentSize : fixedInsetsContentSize;
 }
 
 /**
@@ -683,7 +712,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   self.contentScrollView.contentSize = contentRect.size;
 
   // Place Content in contentScrollView
-  boundsSize.width = boundsSize.width - MDCDialogContentInsets.left - MDCDialogContentInsets.right;
+  CGFloat horizontalContentInsets =
+      self.enableAdjustableInsets ? self.contentInsets.left + self.contentInsets.right
+                                  : MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  boundsSize.width = boundsSize.width - horizontalContentInsets;
   CGSize titleSize = [self.titleLabel sizeThatFits:boundsSize];
   titleSize.width = boundsSize.width;
 
@@ -696,15 +728,20 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
                               verticalFittingPriority:UILayoutPriorityFittingSizeLevel];
   accessoryViewSize.width = boundsSize.width;
 
-  boundsSize.width = boundsSize.width + MDCDialogContentInsets.left + MDCDialogContentInsets.right;
+  boundsSize.width = boundsSize.width + horizontalContentInsets;
 
-  CGFloat contentAccessoryVerticalPadding =
-      [self contentAccessoryVerticalPaddingWithFittingSize:boundsSize];
+  CGFloat accessoryVerticalInset =
+      self.enableAdjustableInsets
+          ? [self accessoryVerticalInset]
+          : [self fixedInsetsContentAccessoryVerticalPaddingWithFittingSize:boundsSize];
+  CGFloat leftInset =
+      self.enableAdjustableInsets ? self.contentInsets.left : MDCDialogContentInsets.left;
+
   CGRect titleFrame = [self titleFrameWithTitleSize:titleSize];
   CGRect messageFrame = [self messageFrameWithSize:messageSize];
-  CGRect accessoryViewFrame = CGRectMake(
-      MDCDialogContentInsets.left, CGRectGetMaxY(messageFrame) + contentAccessoryVerticalPadding,
-      accessoryViewSize.width, accessoryViewSize.height);
+  CGRect accessoryViewFrame =
+      CGRectMake(leftInset, CGRectGetMaxY(messageFrame) + accessoryVerticalInset,
+                 accessoryViewSize.width, accessoryViewSize.height);
 
   CGRect titleIconImageViewRect = [self titleIconFrameWithTitleSize:titleSize];
   if (self.titleIconImageView != nil) {


### PR DESCRIPTION
# Description
Refactoring Content frame calculations to enable both fixed and adjustable insets layout.

# Note
The enableAdjustableInsets flag toggles between the fixed (old calculations) 
   and adjustable (new calculations) layouts. 

Additionally, starting to rename method that are used only in fixed layout calculations, and do not
      participate in the  adjustable layout calculations, and prefix them with 
      fixedLayout<name of method>.  They will be removed once the feature flag is 
      Deprecated.

# Issue
b/148802180, cl/293909793