### PR TITLE
[TextControls] Changes from text-area-feature-branch with additional podspec and BUILD file changes

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1557,7 +1557,28 @@ Pod::Spec.new do |mdc|
     component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
     component.source_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}"
   end
-  
+
+  # TextControls+BaseTextAreas
+
+  mdc.subspec "TextControls+BaseTextAreas" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
+    component.source_files = [ "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}",
+    "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/private/TextControlsPrivate+Shared"
+    component.dependency "MaterialComponents/private/TextControlsPrivate+BaseStyle"
+    component.dependency "MDFInternationalization"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
+      ]
+      unit_tests.dependency "MaterialComponents/schemes/Container"
+    end
+  end
+
   # TextControls+BaseTextFields
 
   mdc.subspec "TextControls+BaseTextFields" do |component|

--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -43,11 +43,29 @@ mdc_extension_objc_library(
 )
 
 mdc_extension_objc_library(
+    name = "BaseTextAreas",
+    deps = [
+        ":BaseTextAreasPrivate",
+        "//components/private/TextControlsPrivate:BaseStyle",
+        "//components/private/TextControlsPrivate:Shared",
+    ],
+)
+
+mdc_extension_objc_library(
     name = "BaseTextFields",
     deps = [
         "//components/private/TextControlsPrivate:BaseStyle",
         "//components/private/TextControlsPrivate:Shared",
         "@material_internationalization_ios//:MDFInternationalization",
+    ],
+)
+
+mdc_objc_library(
+    name = "BaseTextAreasPrivate",
+    hdrs = native.glob(["src/BaseTextAreas/private/*.h"]),
+    includes = ["src/BaseTextAreas/private"],
+    visibility = [
+        ":TextControlsPackageGroup",
     ],
 )
 

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.h
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.h
@@ -1,0 +1,27 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+/**
+ A UIControl subclass that leverages UITextView to provide multi-line text input
+*/
+@interface MDCBaseTextArea : UIControl
+
+/**
+ The UITextView contained within the text area.
+ */
+@property(strong, nonatomic, readonly, nonnull) UITextView *textView;
+
+@end

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -1,0 +1,100 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBaseTextArea.h"
+
+#import "private/MDCBaseTextAreaTextView.h"
+
+@interface MDCBaseTextArea ()
+
+@property(strong, nonatomic) MDCBaseTextAreaTextView *textAreaTextView;
+@end
+
+@implementation MDCBaseTextArea
+
+#pragma mark Object Lifecycle
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCBaseTextAreaInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonMDCBaseTextAreaInit];
+  }
+  return self;
+}
+
+- (void)commonMDCBaseTextAreaInit {
+  [self setUpTextAreaSpecificSubviews];
+  [self observeTextViewNotifications];
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark Setup
+
+- (void)setUpTextAreaSpecificSubviews {
+  self.textAreaTextView = [[MDCBaseTextAreaTextView alloc] init];
+  self.textAreaTextView.textAreaTextViewDelegate = self;
+  [self addSubview:self.textAreaTextView];
+}
+
+#pragma mark UIView Overrides
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  self.textAreaTextView.frame = self.bounds;
+}
+
+#pragma mark Responding to text view changes
+
+- (void)textViewChanged:(NSNotification *)notification {
+  [self setNeedsLayout];
+}
+
+#pragma mark Custom Accessors
+
+- (UITextView *)textView {
+  return self.textAreaTextView;
+}
+
+#pragma mark InputChipViewTextViewDelegate
+
+- (void)textAreaTextViewWillResignFirstResponder:(BOOL)didBecome {
+  [self setNeedsLayout];
+}
+
+- (void)textAreaTextViewWillBecomeFirstResponder:(BOOL)didBecome {
+  [self setNeedsLayout];
+}
+
+#pragma mark Notifications
+
+
+- (void)observeTextViewNotifications {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(textViewChanged:)
+                                               name:UITextViewTextDidChangeNotification
+                                             object:nil];
+}
+
+@end

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -79,16 +79,17 @@
 
 #pragma mark MDCBaseTextAreaTextViewDelegate
 
--(void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)willBecome {
+- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView
+    willBecomeFirstResponder:(BOOL)willBecome {
   [self setNeedsLayout];
 }
 
--(void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)willResign {
+- (void)textAreaTextView:(MDCBaseTextAreaTextView *)textView
+    willResignFirstResponder:(BOOL)willResign {
   [self setNeedsLayout];
 }
 
 #pragma mark Notifications
-
 
 - (void)observeTextViewNotifications {
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -16,7 +16,7 @@
 
 #import "private/MDCBaseTextAreaTextView.h"
 
-@interface MDCBaseTextArea ()
+@interface MDCBaseTextArea () <MDCBaseTextAreaTextViewDelegate>
 
 @property(strong, nonatomic) MDCBaseTextAreaTextView *textAreaTextView;
 @end
@@ -77,13 +77,13 @@
   return self.textAreaTextView;
 }
 
-#pragma mark InputChipViewTextViewDelegate
+#pragma mark MDCBaseTextAreaTextViewDelegate
 
-- (void)textAreaTextViewWillResignFirstResponder:(BOOL)didBecome {
+-(void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)willBecome {
   [self setNeedsLayout];
 }
 
-- (void)textAreaTextViewWillBecomeFirstResponder:(BOOL)didBecome {
+-(void)textAreaTextView:(MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)willResign {
   [self setNeedsLayout];
 }
 

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -17,19 +17,22 @@
 @class MDCBaseTextAreaTextView;
 
 /**
- This protocol allows the MDCBaseTextAreaTextView to inform the text area of important responder events.
+ This protocol allows the MDCBaseTextAreaTextView to inform the text area of important responder
+ events.
  */
 @protocol MDCBaseTextAreaTextViewDelegate <NSObject>
 
 /**
 This method is called when the text view is about to become the first responder.
  */
-- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)willBecome;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView
+    willBecomeFirstResponder:(BOOL)willBecome;
 
 /**
 This method is called when the text view is about to resign the first responder.
  */
-- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)willResign;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView
+    willResignFirstResponder:(BOOL)willResign;
 @end
 
 /**

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -1,0 +1,44 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@class MDCBaseTextAreaTextView;
+
+/**
+ This protocol allows the MDCBaseTextAreaTextView to inform the text area of important responder events.
+ */
+@protocol MDCBaseTextAreaTextViewDelegate <NSObject>
+
+/**
+This method is called when the text view is about to become the first responder.
+ */
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
+
+/**
+This method is called when the text view is about to resign the first responder.
+ */
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
+@end
+
+/**
+This private UITextView subclass is used by the MDCBaseTextArea to handle multi-line text
+ */
+@interface MDCBaseTextAreaTextView : UITextView
+
+/**
+ A delegate conforming to MDCBaseTextAreaTextViewDelegate
+ */
+@property(nonatomic, weak, nullable) id<MDCBaseTextAreaTextViewDelegate> textAreaTextViewDelegate;
+@end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.h
@@ -24,12 +24,12 @@
 /**
 This method is called when the text view is about to become the first responder.
  */
-- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)didBecome;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willBecomeFirstResponder:(BOOL)willBecome;
 
 /**
 This method is called when the text view is about to resign the first responder.
  */
-- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)didResign;
+- (void)textAreaTextView:(nonnull MDCBaseTextAreaTextView *)textView willResignFirstResponder:(BOOL)willResign;
 @end
 
 /**

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -56,8 +56,8 @@
   BOOL superclassDidResignFirstResponder = [super resignFirstResponder];
   SEL selector = @selector(textAreaTextView:willResignFirstResponder:);
   if ([self.textAreaTextViewDelegate respondsToSelector:selector]) {
-    [self.textAreaTextViewDelegate
-     textAreaTextView:self willResignFirstResponder:superclassDidResignFirstResponder];
+    [self.textAreaTextViewDelegate textAreaTextView:self
+                           willResignFirstResponder:superclassDidResignFirstResponder];
   }
   return superclassDidResignFirstResponder;
 }
@@ -66,8 +66,8 @@
   BOOL superclassDidBecomeFirstResponder = [super becomeFirstResponder];
   SEL selector = @selector(textAreaTextView:willBecomeFirstResponder:);
   if ([self.textAreaTextViewDelegate respondsToSelector:selector]) {
-    [self.textAreaTextViewDelegate
-     textAreaTextView:self willBecomeFirstResponder:superclassDidBecomeFirstResponder];
+    [self.textAreaTextViewDelegate textAreaTextView:self
+                           willBecomeFirstResponder:superclassDidBecomeFirstResponder];
   }
   return superclassDidBecomeFirstResponder;
 }

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -1,0 +1,71 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCBaseTextAreaTextView.h"
+#import "MDCTextControl.h"
+
+@implementation MDCBaseTextAreaTextView
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    [self commonMDCBaseTextAreaTextViewInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCBaseTextAreaTextViewInit];
+  }
+  return self;
+}
+
+- (void)commonMDCBaseTextAreaTextViewInit {
+  self.backgroundColor = UIColor.clearColor;
+  self.textContainerInset = UIEdgeInsetsZero;
+  self.layoutMargins = UIEdgeInsetsZero;
+  self.textContainer.lineFragmentPadding = 0;
+  self.font = MDCTextControlDefaultUITextFieldFont();
+  self.clipsToBounds = NO;
+}
+
+- (void)setFont:(UIFont *)font {
+  [super setFont:font ?: MDCTextControlDefaultUITextFieldFont()];
+}
+
+- (UIFont *)font {
+  return [super font] ?: MDCTextControlDefaultUITextFieldFont();
+}
+
+- (BOOL)resignFirstResponder {
+  BOOL superclassDidResignFirstResponder = [super resignFirstResponder];
+  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillResignFirstResponder:)]) {
+    [self.textAreaTextViewDelegate
+     textAreaTextViewWillResignFirstResponder:superclassDidResignFirstResponder];
+  }
+  return superclassDidResignFirstResponder;
+}
+
+- (BOOL)becomeFirstResponder {
+  BOOL superclassDidBecomeFirstResponder = [super becomeFirstResponder];
+  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillBecomeFirstResponder:)]) {
+    [self.textAreaTextViewDelegate
+     textAreaTextViewWillBecomeFirstResponder:superclassDidBecomeFirstResponder];
+  }
+  return superclassDidBecomeFirstResponder;
+}
+
+@end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -54,18 +54,20 @@
 
 - (BOOL)resignFirstResponder {
   BOOL superclassDidResignFirstResponder = [super resignFirstResponder];
-  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillResignFirstResponder:)]) {
+  SEL selector = @selector(textAreaTextView:willResignFirstResponder:);
+  if ([self.textAreaTextViewDelegate respondsToSelector:selector]) {
     [self.textAreaTextViewDelegate
-     textAreaTextViewWillResignFirstResponder:superclassDidResignFirstResponder];
+     textAreaTextView:self willResignFirstResponder:superclassDidResignFirstResponder];
   }
   return superclassDidResignFirstResponder;
 }
 
 - (BOOL)becomeFirstResponder {
   BOOL superclassDidBecomeFirstResponder = [super becomeFirstResponder];
-  if ([self.textAreaTextViewDelegate respondsToSelector:@selector(textAreaTextViewWillBecomeFirstResponder:)]) {
+  SEL selector = @selector(textAreaTextView:willBecomeFirstResponder:);
+  if ([self.textAreaTextViewDelegate respondsToSelector:selector]) {
     [self.textAreaTextViewDelegate
-     textAreaTextViewWillBecomeFirstResponder:superclassDidBecomeFirstResponder];
+     textAreaTextView:self willBecomeFirstResponder:superclassDidBecomeFirstResponder];
   }
   return superclassDidBecomeFirstResponder;
 }

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaTextView.m
@@ -40,6 +40,8 @@
   self.textContainer.lineFragmentPadding = 0;
   self.font = MDCTextControlDefaultUITextFieldFont();
   self.clipsToBounds = NO;
+  self.showsVerticalScrollIndicator = NO;
+  self.showsHorizontalScrollIndicator = NO;
 }
 
 - (void)setFont:(UIFont *)font {

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -496,16 +496,11 @@
 #pragma mark Fonts
 
 - (UIFont *)normalFont {
-  return self.font ?: [self uiTextFieldDefaultFont];
+  return self.font ?: MDCTextControlDefaultUITextFieldFont();
 }
 
 - (UIFont *)floatingFont {
   return [self.containerStyle floatingFontWithNormalFont:self.normalFont];
-}
-
-- (UIFont *)uiTextFieldDefaultFont {
-  // This value comes from https://developer.apple.com/documentation/uikit/uitextfield/1619604-font
-  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 #pragma mark Dynamic Type

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
@@ -23,6 +23,10 @@
 #import "MDCTextControlState.h"
 #import "MDCTextControlVerticalPositioningReference.h"
 
+static inline UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont() {
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+}
+
 static const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
 
 @protocol MDCTextControlStyle;


### PR DESCRIPTION
Because CI wasn't working earlier this week I merged the initial text area PRs (https://github.com/material-components/material-components-ios/pull/9682 and https://github.com/material-components/material-components-ios/pull/9684) into a [feature branch](https://github.com/material-components/material-components-ios/tree/text-area-feature-branch) in the main repo. This PR contains those changes, as well as a commit to update the BUILD file and podspec (3da2803), a commit that makes it compile (6a06594), and a commit to run clang (078cd70). The changes in these last three commits have not been reviewed, unlike the ones from the PRs into the feature branch.

Related to #9407.