### PR TITLE
[TextControls] Remove empty test_spec from podspec

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1570,13 +1570,6 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/private/TextControlsPrivate+Shared"
     component.dependency "MaterialComponents/private/TextControlsPrivate+BaseStyle"
     component.dependency "MDFInternationalization"
-
-    component.test_spec 'UnitTests' do |unit_tests|
-      unit_tests.source_files = [
-      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
-      ]
-      unit_tests.dependency "MaterialComponents/schemes/Container"
-    end
   end
 
   # TextControls+BaseTextFields


### PR DESCRIPTION
https://github.com/material-components/material-components-ios/pull/9711 causes the library to fail pod lib lint validations because there are currently no source files in the test spec. This will of course change very soon but in case there's a release before it does we should land this PR.

Related to #9407.

