### PR TITLE
[Dialogs] Fix custom title icon view layout - top inset

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -501,9 +501,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
                   UIUserInterfaceLayoutDirectionRightToLeft)) {
     titleIconLeftPadding = CGRectGetMaxX(titleFrame) - titleIconViewSize.width;
   }
-  CGRect titleIconFrame = CGRectMake(titleIconLeftPadding, MDCDialogContentInsets.top,
-                                     titleIconViewSize.width, titleIconViewSize.height);
-  return titleIconFrame;
+  CGFloat top = (self.titleIconImageView != nil) ? MDCDialogContentInsets.top : 0.0f;
+  return CGRectMake(titleIconLeftPadding, top, titleIconViewSize.width, titleIconViewSize.height);
 }
 
 // @param boundsSize should not include any internal margins or padding


### PR DESCRIPTION
# Description
Fix for the custom title icon view layout, top inset.

# Before / After

### Before the fix
Same offset for the custom view as for the UIImageView: 

![image](https://user-images.githubusercontent.com/2329102/74476990-72f62f00-4e78-11ea-95b4-8863cae80473.png)

### After the fix: 
Can be used for full bleed image implementation:

![image](https://user-images.githubusercontent.com/2329102/74477137-b9e42480-4e78-11ea-9ec0-c9555109a381.png)

## Issue
b/148802180, cl/292838545 
