### PR TITLE
[BottomSheet] KVO `contentInset` property

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -18,9 +18,12 @@
 #import "MDCSheetBehavior.h"
 #import "MaterialKeyboardWatcher.h"
 
-// KVO key for monitoring the content size for the content view if it is a scrollview.
+/** KVO key for monitoring the content size for the content view if it is a scrollview. */
 static NSString *kContentSizeKey = nil;
-static void *kContentSizeContext = &kContentSizeContext;
+/** KVO key for monitoring the content inset for the content view if it is a scrollview. */
+static NSString *kContentInsetKey = nil;
+/** KVO context unique to this class. */
+static void *kObservingContext = &kObservingContext;
 
 // We add an extra padding to the sheet height, so that if the user swipes upwards, fast, the
 // bounce does not reveal a gap between the sheet and the bottom of the screen.
@@ -47,6 +50,7 @@ static const CGFloat kSheetBounceBuffer = 150;
     return;
   }
   kContentSizeKey = NSStringFromSelector(@selector(contentSize));
+  kContentInsetKey = NSStringFromSelector(@selector(contentInset));
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -83,7 +87,11 @@ static const CGFloat kSheetBounceBuffer = 150;
     [scrollView addObserver:self
                  forKeyPath:kContentSizeKey
                     options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
-                    context:kContentSizeContext];
+                    context:kObservingContext];
+    [scrollView addObserver:self
+                 forKeyPath:kContentInsetKey
+                    options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+                    context:kObservingContext];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(voiceOverStatusDidChange)
                                                  name:UIAccessibilityVoiceOverStatusChanged
@@ -116,6 +124,7 @@ static const CGFloat kSheetBounceBuffer = 150;
 
 - (void)dealloc {
   [self.sheet.scrollView removeObserver:self forKeyPath:kContentSizeKey];
+  [self.sheet.scrollView removeObserver:self forKeyPath:kContentInsetKey];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -178,7 +187,15 @@ static const CGFloat kSheetBounceBuffer = 150;
                       ofObject:(id)object
                         change:(NSDictionary *)change
                        context:(void *)context {
-  if ([keyPath isEqualToString:kContentSizeKey] && context == kContentSizeContext) {
+  // As long as this class added the KVO observation, it doesn't matter which of the two properties
+  // has been updated. A change in either warrants repositioning the sheet.
+  // If contentSize was updated, then there's likely more or less content to see so it's worth
+  // repositioning.  If contentInset was updated, then the visible content has changed and the
+  // sheet should reposition to keep it visible.
+  // Notably, ActionSheet changes contentInset when it calculates its header height. If contentInset
+  // were not observed, then the sheet wouldn't be able to fully show the contentSize portion of
+  // that view.
+  if (context == kObservingContext) {
     NSValue *oldValue = change[NSKeyValueChangeOldKey];
     NSValue *newValue = change[NSKeyValueChangeNewKey];
     if (self.window && !self.isDragging && ![oldValue isEqual:newValue]) {


### PR DESCRIPTION
When a client or implementation updates the `contentInset` property, the
presented content may no longer be visible. Similar to observing the
`contentSize` property, when a change to `contentInset` takes place, the sheet
should reposition itself to make its content visible once more.

This change is specifically required for ActionSheet. ActionSheet adds a
header view above its table view and adjusts the table view's `contentInset`
to account for the header view's height. If this height changes, then the
`contentInset` value will change, but the `contentSize` will not. If the
`contentInset` value is not directly observed, the presented ActionSheet may
end up showing less than the total available content (when the height is less
than half the screen height).  By observing the `contentInset` property, the
sheet is presented with all content visible on-screen.

Part of #8709
