### PR TITLE
[Material][Availability] Migrates activity indicator to MDCAvailability.

### DIFF
--- a/components/ActivityIndicator/BUILD
+++ b/components/ActivityIndicator/BUILD
@@ -99,6 +99,7 @@ mdc_snapshot_objc_library(
     name = "snapshot_test_lib",
     deps = [
         ":ActivityIndicator",
+        "//components/Availability",
     ],
 )
 

--- a/components/ActivityIndicator/tests/snapshot/MDCActivityIndicatorSnapshotTests.m
+++ b/components/ActivityIndicator/tests/snapshot/MDCActivityIndicatorSnapshotTests.m
@@ -15,6 +15,7 @@
 #import "MaterialSnapshot.h"
 
 #import "MaterialActivityIndicator.h"
+#import "MaterialAvailability.h"
 
 @interface MDCActivityIndicatorSnapshotFake : MDCActivityIndicator
 @property(nonatomic, strong) UITraitCollection *traitCollectionOverride;
@@ -160,7 +161,7 @@
 }
 
 - (void)testProgressViewSupportsDynamicColor {
-#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+#if MDC_AVAILABLE_SDK_IOS(13_0)
   if (@available(iOS 13.0, *)) {
     // Given
     MDCActivityIndicatorSnapshotFake *indicator =
@@ -187,7 +188,7 @@
     UIView *snapshotView = [indicator mdc_addToBackgroundView];
     [self snapshotVerifyViewForIOS13:snapshotView];
   }
-#endif
+#endif  // MDC_AVAILABLE_SDK_IOS(13_0)
 }
 
 @end


### PR DESCRIPTION
[Material][Availability] Migrates activity indicator to MDCAvailability.
