### PR TITLE
[Dialogs] Fix adjustable insets for title icon.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -535,8 +535,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   UIEdgeInsets insets = self.enableAdjustableInsets ? self.titleIconInsets : MDCDialogContentInsets;
 
   // match the titleIcon alignment to the title alignment
-  CGFloat leftInset =
-      self.enableAdjustableInsets ? self.titleInsets.left : MDCDialogContentInsets.left;
+  CGFloat leftInset = insets.left;
   if (self.titleAlignment == NSTextAlignmentCenter) {
     leftInset =
         CGRectGetMinX(titleFrame) + (CGRectGetWidth(titleFrame) - titleIconViewSize.width) / 2.0f;


### PR DESCRIPTION
# Description

Fixing the left adjustable inset for title icons in dialogs. 
This change only affects dialogs whose enableAdjustableInsets is enabled (currently a private API).

AFTER:
![image](https://user-images.githubusercontent.com/2329102/74698275-36ee0180-51cb-11ea-8de3-3b9fb88b281c.png)

BEFORE:
![image](https://user-images.githubusercontent.com/2329102/74698534-268a5680-51cc-11ea-973e-bf2cc9b99189.png)

## Issue:
b/148802180