### PR TITLE
MDCTextControlLabelState renamed to MDCTextControlLabelPosition and other changes

### DIFF
--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -397,7 +397,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 #pragma mark Coloring
 
 - (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-             withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
+          withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
   UIColor *labelColor = [UIColor clearColor];
   if (labelPosition == MDCTextControlLabelPositionNormal) {
     labelColor = colorViewModel.normalLabelColor;

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -36,7 +36,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 @property(nonatomic, strong) MDCTextControlAssistiveLabelView *assistiveLabelView;
 @property(strong, nonatomic) MDCBaseTextAreaLayout *layout;
 @property(nonatomic, assign) MDCTextControlState textControlState;
-@property(nonatomic, assign) MDCTextControlLabelState labelState;
+@property(nonatomic, assign) MDCTextControlLabelPosition labelPosition;
 @property(nonatomic, assign) CGRect labelFrame;
 @property(nonatomic, assign) NSTimeInterval animationDuration;
 
@@ -57,7 +57,6 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 @synthesize assistiveLabelDrawPriority = _assistiveLabelDrawPriority;
 @synthesize customAssistiveLabelDrawPriority = _customAssistiveLabelDrawPriority;
 @synthesize preferredContainerHeight = _preferredContainerHeight;
-
 @synthesize adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
 
 #pragma mark Object Lifecycle
@@ -97,7 +96,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 - (void)initializeProperties {
   self.animationDuration = kMDCTextControlDefaultAnimationDuration;
   self.labelBehavior = MDCTextControlLabelBehaviorFloats;
-  self.labelState = [self determineCurrentLabelState];
+  self.labelPosition = [self determineCurrentLabelPosition];
   self.textControlState = [self determineCurrentTextControlState];
   self.containerStyle = [[MDCTextControlStyleBase alloc] init];
   self.colorViewModels = [[NSMutableDictionary alloc] init];
@@ -174,17 +173,17 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
   [self setNeedsLayout];
 }
 
-#pragma mark Layout
+#pragma mark Private Layout
 
 - (void)preLayoutSubviews {
   self.textControlState = [self determineCurrentTextControlState];
-  self.labelState = [self determineCurrentLabelState];
+  self.labelPosition = [self determineCurrentLabelPosition];
   MDCTextControlColorViewModel *colorViewModel =
       [self textControlColorViewModelForState:self.textControlState];
-  [self applyColorViewModel:colorViewModel withLabelState:self.labelState];
+  [self applyColorViewModel:colorViewModel withLabelState:self.labelPosition];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX);
   self.layout = [self calculateLayoutWithSize:fittingSize];
-  self.labelFrame = [self.layout labelFrameWithLabelState:self.labelState];
+  self.labelFrame = [self.layout labelFrameWithLabelPosition:self.labelPosition];
 }
 
 - (void)postLayoutSubviews {
@@ -210,7 +209,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
                                                 font:self.normalFont
                                         floatingFont:self.floatingFont
                                                label:self.label
-                                          labelState:self.labelState
+                                       labelPosition:self.labelPosition
                                        labelBehavior:self.labelBehavior
                                leadingAssistiveLabel:self.assistiveLabelView.leadingAssistiveLabel
                               trailingAssistiveLabel:self.assistiveLabelView.trailingAssistiveLabel
@@ -293,20 +292,9 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 #pragma mark MDCTextControlState
 
 - (MDCTextControlState)determineCurrentTextControlState {
-  return [self textControlStateWithIsEnabled:(self.enabled && self.baseTextAreaTextView.isEditable)
-                                   isEditing:self.textView.isFirstResponder];
-}
-
-- (MDCTextControlState)textControlStateWithIsEnabled:(BOOL)isEnabled isEditing:(BOOL)isEditing {
-  if (isEnabled) {
-    if (isEditing) {
-      return MDCTextControlStateEditing;
-    } else {
-      return MDCTextControlStateNormal;
-    }
-  } else {
-    return MDCTextControlStateDisabled;
-  }
+  BOOL isEnabled = self.enabled && self.baseTextAreaTextView.isEditable;
+  BOOL isEditing = self.textView.isFirstResponder;
+  return MDCTextControlStateDetermineState(isEnabled, isEditing);
 }
 
 #pragma mark Label
@@ -314,7 +302,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 - (void)animateLabel {
   __weak MDCBaseTextArea *weakSelf = self;
   [MDCTextControlLabelAnimation animateLabel:self.label
-                                       state:self.labelState
+                                       state:self.labelPosition
                             normalLabelFrame:self.layout.labelFrameNormal
                           floatingLabelFrame:self.layout.labelFrameFloating
                                   normalFont:self.normalFont
@@ -333,44 +321,9 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
   return self.labelBehavior == MDCTextControlLabelBehaviorFloats;
 }
 
-- (MDCTextControlLabelState)determineCurrentLabelState {
-  return [self labelStateWithLabelText:self.label.text
-                                  text:self.textView.text
-                         canLabelFloat:self.canLabelFloat
-                             isEditing:self.textView.isFirstResponder];
-}
-
-- (MDCTextControlLabelState)labelStateWithLabelText:(NSString *)labelText
-                                               text:(NSString *)text
-                                      canLabelFloat:(BOOL)canLabelFloat
-                                          isEditing:(BOOL)isEditing {
-  BOOL hasLabelText = labelText.length > 0;
-  BOOL hasText = text.length > 0;
-  if (hasLabelText) {
-    if (canLabelFloat) {
-      if (isEditing) {
-        return MDCTextControlLabelStateFloating;
-      } else {
-        if (hasText) {
-          return MDCTextControlLabelStateFloating;
-        } else {
-          return MDCTextControlLabelStateNormal;
-        }
-      }
-    } else {
-      if (isEditing) {
-        return MDCTextControlLabelStateNone;
-      } else {
-        if (hasText) {
-          return MDCTextControlLabelStateNone;
-        } else {
-          return MDCTextControlLabelStateNormal;
-        }
-      }
-    }
-  } else {
-    return MDCTextControlLabelStateNone;
-  }
+- (MDCTextControlLabelPosition)determineCurrentLabelPosition {
+  return MDCTextControlLabelPositionWith(self.label.text.length > 0, self.textView.text.length > 0,
+                                         self.canLabelFloat, self.textView.isFirstResponder);
 }
 
 #pragma mark Custom Accessors
@@ -379,15 +332,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
   return self.baseTextAreaTextView;
 }
 
-- (UILabel *)leadingAssistiveLabel {
-  return self.assistiveLabelView.leadingAssistiveLabel;
-}
-
-- (UILabel *)trailingAssistiveLabel {
-  return self.assistiveLabelView.trailingAssistiveLabel;
-}
-
-#pragma mark MDCTextControl Accessors
+#pragma mark MDCTextControl Protocol Accessors
 
 - (void)setContainerStyle:(id<MDCTextControlStyle>)containerStyle {
   id<MDCTextControlStyle> oldStyle = _containerStyle;
@@ -400,6 +345,14 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 
 - (CGRect)containerFrame {
   return CGRectMake(0, 0, CGRectGetWidth(self.frame), self.layout.containerHeight);
+}
+
+- (UILabel *)leadingAssistiveLabel {
+  return self.assistiveLabelView.leadingAssistiveLabel;
+}
+
+- (UILabel *)trailingAssistiveLabel {
+  return self.assistiveLabelView.trailingAssistiveLabel;
 }
 
 #pragma mark Fonts
@@ -444,11 +397,11 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 #pragma mark Coloring
 
 - (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-             withLabelState:(MDCTextControlLabelState)labelState {
+             withLabelState:(MDCTextControlLabelPosition)labelState {
   UIColor *labelColor = [UIColor clearColor];
-  if (labelState == MDCTextControlLabelStateNormal) {
+  if (labelState == MDCTextControlLabelPositionNormal) {
     labelColor = colorViewModel.normalLabelColor;
-  } else if (labelState == MDCTextControlLabelStateFloating) {
+  } else if (labelState == MDCTextControlLabelPositionFloating) {
     labelColor = colorViewModel.floatingLabelColor;
   }
   self.textView.textColor = colorViewModel.textColor;

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -180,7 +180,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
   self.labelPosition = [self determineCurrentLabelPosition];
   MDCTextControlColorViewModel *colorViewModel =
       [self textControlColorViewModelForState:self.textControlState];
-  [self applyColorViewModel:colorViewModel withLabelState:self.labelPosition];
+  [self applyColorViewModel:colorViewModel withLabelPosition:self.labelPosition];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.frame), CGFLOAT_MAX);
   self.layout = [self calculateLayoutWithSize:fittingSize];
   self.labelFrame = [self.layout labelFrameWithLabelPosition:self.labelPosition];
@@ -397,11 +397,11 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 #pragma mark Coloring
 
 - (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-             withLabelState:(MDCTextControlLabelPosition)labelState {
+             withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
   UIColor *labelColor = [UIColor clearColor];
-  if (labelState == MDCTextControlLabelPositionNormal) {
+  if (labelPosition == MDCTextControlLabelPositionNormal) {
     labelColor = colorViewModel.normalLabelColor;
-  } else if (labelState == MDCTextControlLabelPositionFloating) {
+  } else if (labelPosition == MDCTextControlLabelPositionFloating) {
     labelColor = colorViewModel.floatingLabelColor;
   }
   self.textView.textColor = colorViewModel.textColor;

--- a/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
+++ b/components/TextControls/src/BaseTextAreas/MDCBaseTextArea.m
@@ -294,7 +294,7 @@ static const CGFloat kMDCBaseTextAreaDefaultMaximumNumberOfVisibleLines = (CGFlo
 - (MDCTextControlState)determineCurrentTextControlState {
   BOOL isEnabled = self.enabled && self.baseTextAreaTextView.isEditable;
   BOOL isEditing = self.textView.isFirstResponder;
-  return MDCTextControlStateDetermineState(isEnabled, isEditing);
+  return MDCTextControlStateWith(isEnabled, isEditing);
 }
 
 #pragma mark Label

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.h
@@ -49,7 +49,7 @@
                                 font:(nonnull UIFont *)font
                         floatingFont:(nonnull UIFont *)floatingFont
                                label:(nonnull UILabel *)label
-                          labelState:(MDCTextControlLabelState)labelState
+                       labelPosition:(MDCTextControlLabelPosition)labelPosition
                        labelBehavior:(MDCTextControlLabelBehavior)labelBehavior
                leadingAssistiveLabel:(nonnull UILabel *)leadingAssistiveLabel
               trailingAssistiveLabel:(nonnull UILabel *)trailingAssistiveLabel
@@ -59,6 +59,6 @@
                                isRTL:(BOOL)isRTL
                            isEditing:(BOOL)isEditing;
 
-- (CGRect)labelFrameWithLabelState:(MDCTextControlLabelState)labelState;
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelState;
 
 @end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.h
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.h
@@ -59,6 +59,6 @@
                                isRTL:(BOOL)isRTL
                            isEditing:(BOOL)isEditing;
 
-- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelState;
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelPosition;
 
 @end

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.m
@@ -47,7 +47,7 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
                                 font:(nonnull UIFont *)font
                         floatingFont:(nonnull UIFont *)floatingFont
                                label:(nonnull UILabel *)label
-                          labelState:(MDCTextControlLabelState)labelState
+                       labelPosition:(MDCTextControlLabelPosition)labelPosition
                        labelBehavior:(MDCTextControlLabelBehavior)labelBehavior
                leadingAssistiveLabel:(UILabel *)leadingAssistiveLabel
               trailingAssistiveLabel:(UILabel *)trailingAssistiveLabel
@@ -64,7 +64,7 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
                                     font:font
                             floatingFont:floatingFont
                                    label:label
-                              labelState:labelState
+                           labelPosition:labelPosition
                            labelBehavior:labelBehavior
                    leadingAssistiveLabel:leadingAssistiveLabel
                   trailingAssistiveLabel:trailingAssistiveLabel
@@ -83,7 +83,7 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
                                 font:(UIFont *)font
                         floatingFont:(UIFont *)floatingFont
                                label:(UILabel *)label
-                          labelState:(MDCTextControlLabelState)labelState
+                       labelPosition:(MDCTextControlLabelPosition)labelPosition
                        labelBehavior:(MDCTextControlLabelBehavior)labelBehavior
                leadingAssistiveLabel:(UILabel *)leadingAssistiveLabel
               trailingAssistiveLabel:(UILabel *)trailingAssistiveLabel
@@ -117,7 +117,7 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
   CGFloat halfOfNormalLineHeight = (CGFloat)0.5 * font.lineHeight;
   CGFloat textViewMinYNormal = CGRectGetMidY(normalLabelFrame) - halfOfNormalLineHeight;
   CGFloat textViewMinY = textViewMinYNormal;
-  if (labelState == MDCTextControlLabelStateFloating) {
+  if (labelPosition == MDCTextControlLabelPositionFloating) {
     textViewMinY =
         floatingLabelMaxY + positioningReference.paddingBetweenFloatingLabelAndEditingText;
   }
@@ -306,10 +306,10 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
   ];
 }
 
-- (CGRect)labelFrameWithLabelState:(MDCTextControlLabelState)labelState {
-  if (labelState == MDCTextControlLabelStateFloating) {
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelState {
+  if (labelState == MDCTextControlLabelPositionFloating) {
     return self.labelFrameFloating;
-  } else if (labelState == MDCTextControlLabelStateNormal) {
+  } else if (labelState == MDCTextControlLabelPositionNormal) {
     return self.labelFrameNormal;
   } else {
     return CGRectZero;

--- a/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.m
+++ b/components/TextControls/src/BaseTextAreas/private/MDCBaseTextAreaLayout.m
@@ -306,10 +306,10 @@ static const CGFloat kGradientBlurLength = (CGFloat)4.0;
   ];
 }
 
-- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelState {
-  if (labelState == MDCTextControlLabelPositionFloating) {
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelPosition {
+  if (labelPosition == MDCTextControlLabelPositionFloating) {
     return self.labelFrameFloating;
-  } else if (labelState == MDCTextControlLabelPositionNormal) {
+  } else if (labelPosition == MDCTextControlLabelPositionNormal) {
     return self.labelFrameNormal;
   } else {
     return CGRectZero;

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -183,7 +183,7 @@
 }
 
 - (CGRect)textRectFromLayout:(MDCBaseTextFieldLayout *)layout
-                  labelPosition:(MDCTextControlLabelPosition)labelPosition {
+               labelPosition:(MDCTextControlLabelPosition)labelPosition {
   CGRect textRect = layout.textRectNormal;
   if (labelPosition == MDCTextControlLabelPositionFloating) {
     textRect = layout.textRectFloating;
@@ -537,12 +537,12 @@
 - (BOOL)shouldPlaceholderBeVisible {
   return [self shouldPlaceholderBeVisibleWithPlaceholder:self.placeholder
                                                     text:self.text
-                                              labelPosition:self.labelPosition];
+                                           labelPosition:self.labelPosition];
 }
 
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelPosition:(MDCTextControlLabelPosition)labelPosition {
+                                    labelPosition:(MDCTextControlLabelPosition)labelPosition {
   BOOL hasPlaceholder = placeholder.length > 0;
   BOOL hasText = text.length > 0;
 
@@ -593,7 +593,7 @@
 #pragma mark Coloring
 
 - (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-             withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
+          withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
   UIColor *labelColor = [UIColor clearColor];
   if (labelPosition == MDCTextControlLabelPositionNormal) {
     labelColor = colorViewModel.normalLabelColor;

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -531,7 +531,7 @@
 #pragma mark MDCTextControlState
 
 - (MDCTextControlState)determineCurrentTextControlState {
-  return MDCTextControlStateDetermineState(self.isEnabled, self.isEditing);
+  return MDCTextControlStateWith(self.isEnabled, self.isEditing);
 }
 
 #pragma mark Placeholder

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -206,8 +206,6 @@
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame {
   CGFloat systemDefinedHeight = CGRectGetHeight(parentClassTextAreaFrame);
   CGFloat minY = CGRectGetMidY(textRect) - (systemDefinedHeight * (CGFloat)0.5);
-  CGFloat offsetNeededToAlignNormalLabelAndText = (CGFloat)1.0;
-  minY += offsetNeededToAlignNormalLabelAndText;
   return CGRectMake(CGRectGetMinX(textRect), minY, CGRectGetWidth(textRect), systemDefinedHeight);
 }
 

--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.m
@@ -162,7 +162,7 @@
   self.labelPosition = [self determineCurrentLabelPosition];
   MDCTextControlColorViewModel *colorViewModel =
       [self textControlColorViewModelForState:self.textControlState];
-  [self applyColorViewModel:colorViewModel withLabelState:self.labelPosition];
+  [self applyColorViewModel:colorViewModel withLabelPosition:self.labelPosition];
   CGSize fittingSize = CGSizeMake(CGRectGetWidth(self.bounds), CGFLOAT_MAX);
   self.layout = [self calculateLayoutWithTextFieldSize:fittingSize];
   self.labelFrame = [self.layout labelFrameWithLabelPosition:self.labelPosition];
@@ -183,9 +183,9 @@
 }
 
 - (CGRect)textRectFromLayout:(MDCBaseTextFieldLayout *)layout
-                  labelState:(MDCTextControlLabelPosition)labelState {
+                  labelPosition:(MDCTextControlLabelPosition)labelPosition {
   CGRect textRect = layout.textRectNormal;
-  if (labelState == MDCTextControlLabelPositionFloating) {
+  if (labelPosition == MDCTextControlLabelPositionFloating) {
     textRect = layout.textRectFloating;
   }
   return textRect;
@@ -431,13 +431,13 @@
 #pragma mark UITextField Layout Overrides
 
 - (CGRect)textRectForBounds:(CGRect)bounds {
-  CGRect textRect = [self textRectFromLayout:self.layout labelState:self.labelPosition];
+  CGRect textRect = [self textRectFromLayout:self.layout labelPosition:self.labelPosition];
   return [self adjustTextAreaFrame:textRect
       withParentClassTextAreaFrame:[super textRectForBounds:bounds]];
 }
 
 - (CGRect)editingRectForBounds:(CGRect)bounds {
-  CGRect textRect = [self textRectFromLayout:self.layout labelState:self.labelPosition];
+  CGRect textRect = [self textRectFromLayout:self.layout labelPosition:self.labelPosition];
   return [self adjustTextAreaFrame:textRect
       withParentClassTextAreaFrame:[super editingRectForBounds:bounds]];
 }
@@ -537,12 +537,12 @@
 - (BOOL)shouldPlaceholderBeVisible {
   return [self shouldPlaceholderBeVisibleWithPlaceholder:self.placeholder
                                                     text:self.text
-                                              labelState:self.labelPosition];
+                                              labelPosition:self.labelPosition];
 }
 
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelState:(MDCTextControlLabelPosition)labelState {
+                                       labelPosition:(MDCTextControlLabelPosition)labelPosition {
   BOOL hasPlaceholder = placeholder.length > 0;
   BOOL hasText = text.length > 0;
 
@@ -550,7 +550,7 @@
     if (hasText) {
       return NO;
     } else {
-      if (labelState == MDCTextControlLabelPositionNormal) {
+      if (labelPosition == MDCTextControlLabelPositionNormal) {
         return NO;
       } else {
         return YES;
@@ -593,11 +593,11 @@
 #pragma mark Coloring
 
 - (void)applyColorViewModel:(MDCTextControlColorViewModel *)colorViewModel
-             withLabelState:(MDCTextControlLabelPosition)labelState {
+             withLabelPosition:(MDCTextControlLabelPosition)labelPosition {
   UIColor *labelColor = [UIColor clearColor];
-  if (labelState == MDCTextControlLabelPositionNormal) {
+  if (labelPosition == MDCTextControlLabelPositionNormal) {
     labelColor = colorViewModel.normalLabelColor;
-  } else if (labelState == MDCTextControlLabelPositionFloating) {
+  } else if (labelPosition == MDCTextControlLabelPositionFloating) {
     labelColor = colorViewModel.floatingLabelColor;
   }
   self.textColor = colorViewModel.textColor;

--- a/components/TextControls/src/BaseTextFields/private/MDCBaseTextFieldLayout.h
+++ b/components/TextControls/src/BaseTextFields/private/MDCBaseTextFieldLayout.h
@@ -67,6 +67,6 @@
                                         isRTL:(BOOL)isRTL
                                     isEditing:(BOOL)isEditing;
 
-- (CGRect)labelFrameWithLabelState:(MDCTextControlLabelState)labelState;
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelPosition;
 
 @end

--- a/components/TextControls/src/BaseTextFields/private/MDCBaseTextFieldLayout.m
+++ b/components/TextControls/src/BaseTextFields/private/MDCBaseTextFieldLayout.m
@@ -216,7 +216,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
                                                clearButtonSideLength, clearButtonSideLength);
 
   CGRect labelFrameNormal = [self labelFrameWithText:label.text
-                                          labelState:MDCTextControlLabelStateNormal
+                                       labelPosition:MDCTextControlLabelPositionNormal
                                                 font:font
                                         floatingFont:floatingFont
                                    floatingLabelMinY:floatingLabelMinY
@@ -225,7 +225,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
                                             textRect:textRectNormal
                                                isRTL:isRTL];
   CGRect labelFrameFloating = [self labelFrameWithText:label.text
-                                            labelState:MDCTextControlLabelStateFloating
+                                         labelPosition:MDCTextControlLabelPositionFloating
                                                   font:font
                                           floatingFont:floatingFont
                                      floatingLabelMinY:floatingLabelMinY
@@ -323,7 +323,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
 }
 
 - (CGRect)labelFrameWithText:(NSString *)text
-                  labelState:(MDCTextControlLabelState)labelState
+               labelPosition:(MDCTextControlLabelPosition)labelPosition
                         font:(UIFont *)font
                 floatingFont:(UIFont *)floatingFont
            floatingLabelMinY:(CGFloat)floatingLabelMinY
@@ -336,10 +336,10 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
   CGRect rect = CGRectZero;
   CGFloat originX = 0;
   CGFloat originY = 0;
-  switch (labelState) {
-    case MDCTextControlLabelStateNone:
+  switch (labelPosition) {
+    case MDCTextControlLabelPositionNone:
       break;
-    case MDCTextControlLabelStateFloating:
+    case MDCTextControlLabelPositionFloating:
       size = [self floatingLabelSizeWithText:text maxWidth:maxWidth font:floatingFont];
       originY = floatingLabelMinY;
       if (isRTL) {
@@ -349,7 +349,7 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
       }
       rect = CGRectMake(originX, originY, size.width, size.height);
       break;
-    case MDCTextControlLabelStateNormal:
+    case MDCTextControlLabelPositionNormal:
       size = [self floatingLabelSizeWithText:text maxWidth:maxWidth font:font];
       CGFloat textRectMidY = CGRectGetMidY(textRect);
       originY = textRectMidY - ((CGFloat)0.5 * size.height);
@@ -379,10 +379,10 @@ static const CGFloat kHorizontalPadding = (CGFloat)12.0;
   return MDCCeil(maxY);
 }
 
-- (CGRect)labelFrameWithLabelState:(MDCTextControlLabelState)labelState {
-  if (labelState == MDCTextControlLabelStateFloating) {
+- (CGRect)labelFrameWithLabelPosition:(MDCTextControlLabelPosition)labelPosition {
+  if (labelPosition == MDCTextControlLabelPositionFloating) {
     return self.labelFrameFloating;
-  } else if (labelState == MDCTextControlLabelStateNormal) {
+  } else if (labelPosition == MDCTextControlLabelPositionNormal) {
     return self.labelFrameNormal;
   } else {
     return CGRectZero;

--- a/components/TextControls/src/Enums/MDCTextControlLabelBehavior.h
+++ b/components/TextControls/src/Enums/MDCTextControlLabelBehavior.h
@@ -14,7 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
-/** This type is used to configure the behavior of an MDCBaseTextField's label. */
+/** This type is used to configure the behavior of an TextControl label. */
 typedef NS_ENUM(NSInteger, MDCTextControlLabelBehavior) {
   /** Indicates that the text field label animates to a position above the text when editing begins.
    */

--- a/components/TextControls/src/Enums/MDCTextControlState.h
+++ b/components/TextControls/src/Enums/MDCTextControlState.h
@@ -34,3 +34,5 @@ typedef NS_ENUM(NSInteger, MDCTextControlState) {
    */
   MDCTextControlStateDisabled,
 };
+
+MDCTextControlState MDCTextControlStateDetermineState(BOOL isEnabled, BOOL isEditing);

--- a/components/TextControls/src/Enums/MDCTextControlState.h
+++ b/components/TextControls/src/Enums/MDCTextControlState.h
@@ -35,4 +35,4 @@ typedef NS_ENUM(NSInteger, MDCTextControlState) {
   MDCTextControlStateDisabled,
 };
 
-MDCTextControlState MDCTextControlStateDetermineState(BOOL isEnabled, BOOL isEditing);
+MDCTextControlState MDCTextControlStateWith(BOOL isEnabled, BOOL isEditing);

--- a/components/TextControls/src/Enums/MDCTextControlState.m
+++ b/components/TextControls/src/Enums/MDCTextControlState.m
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "MDCTextControl.h"
-#import "MDCTextControlAssistiveLabelView.h"
-#import "MDCTextControlAssistiveLabelViewLayout.h"
-#import "MDCTextControlColorViewModel.h"
-#import "MDCTextControlGradientManager.h"
-#import "MDCTextControlLabelAnimation.h"
-#import "MDCTextControlLabelPosition.h"
-#import "MDCTextControlVerticalPositioningReference.h"
+#import "MDCTextControlState.h"
+
+MDCTextControlState MDCTextControlStateDetermineState(BOOL isEnabled, BOOL isEditing) {
+  if (isEnabled) {
+    if (isEditing) {
+      return MDCTextControlStateEditing;
+    } else {
+      return MDCTextControlStateNormal;
+    }
+  } else {
+    return MDCTextControlStateDisabled;
+  }
+}

--- a/components/TextControls/src/Enums/MDCTextControlState.m
+++ b/components/TextControls/src/Enums/MDCTextControlState.m
@@ -14,7 +14,7 @@
 
 #import "MDCTextControlState.h"
 
-MDCTextControlState MDCTextControlStateDetermineState(BOOL isEnabled, BOOL isEditing) {
+MDCTextControlState MDCTextControlStateWith(BOOL isEnabled, BOOL isEditing) {
   if (isEnabled) {
     if (isEditing) {
       return MDCTextControlStateEditing;

--- a/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldLayoutTests.m
+++ b/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldLayoutTests.m
@@ -146,15 +146,15 @@
   layout.labelFrameFloating = CGRectMake(5, 0, 100, 20);
 
   // Then
-  CGRect labelFrameWithLabelStateFloating =
-      [layout labelFrameWithLabelState:MDCTextControlLabelStateFloating];
-  CGRect labelFrameWithLabelStateNormal =
-      [layout labelFrameWithLabelState:MDCTextControlLabelStateNormal];
-  CGRect labelFrameWithLabelStateNone =
-      [layout labelFrameWithLabelState:MDCTextControlLabelStateNone];
-  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelStateFloating, layout.labelFrameFloating));
-  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelStateNormal, layout.labelFrameNormal));
-  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelStateNone, CGRectZero));
+  CGRect labelFrameWithLabelPositionFloating =
+      [layout labelFrameWithLabelPosition:MDCTextControlLabelPositionFloating];
+  CGRect labelFrameWithLabelPositionNormal =
+      [layout labelFrameWithLabelPosition:MDCTextControlLabelPositionNormal];
+  CGRect labelFrameWithLabelPositionNone =
+      [layout labelFrameWithLabelPosition:MDCTextControlLabelPositionNone];
+  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelPositionFloating, layout.labelFrameFloating));
+  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelPositionNormal, layout.labelFrameNormal));
+  XCTAssertTrue(CGRectEqualToRect(labelFrameWithLabelPositionNone, CGRectZero));
 }
 
 @end

--- a/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldLayoutTests.m
+++ b/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldLayoutTests.m
@@ -137,7 +137,7 @@
   XCTAssertTrue(editingLayout.rightViewHidden);
 }
 
-- (void)testLabelFrameWithLabelState {
+- (void)testLabelFrameWithLabelPosition {
   // Given
   MDCBaseTextFieldLayout *layout = [[MDCBaseTextFieldLayout alloc] init];
 

--- a/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
@@ -23,7 +23,7 @@
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame;
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelState:(MDCTextControlLabelPosition)labelState;
+                                       labelPosition:(MDCTextControlLabelPosition)labelPosition;
 @end
 
 @interface MDCBaseTextFieldTests : XCTestCase
@@ -322,19 +322,19 @@
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:nilPlaceholder
                                            text:text
-                                     labelState:MDCTextControlLabelPositionNormal]);
+                                     labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:text
-                                     labelState:MDCTextControlLabelPositionNormal]);
+                                     labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCTextControlLabelPositionNormal]);
+                                     labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertTrue([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCTextControlLabelPositionFloating]);
+                                     labelPosition:MDCTextControlLabelPositionFloating]);
 }
 
 - (void)testDefaultAccessibilityLabelWithOnlyLabelText {

--- a/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
@@ -23,7 +23,7 @@
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame;
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelPosition:(MDCTextControlLabelPosition)labelPosition;
+                                    labelPosition:(MDCTextControlLabelPosition)labelPosition;
 @end
 
 @interface MDCBaseTextFieldTests : XCTestCase
@@ -322,19 +322,19 @@
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:nilPlaceholder
                                            text:text
-                                     labelPosition:MDCTextControlLabelPositionNormal]);
+                                  labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:text
-                                     labelPosition:MDCTextControlLabelPositionNormal]);
+                                  labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelPosition:MDCTextControlLabelPositionNormal]);
+                                  labelPosition:MDCTextControlLabelPositionNormal]);
   XCTAssertTrue([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelPosition:MDCTextControlLabelPositionFloating]);
+                                  labelPosition:MDCTextControlLabelPositionFloating]);
 }
 
 - (void)testDefaultAccessibilityLabelWithOnlyLabelText {

--- a/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
+++ b/components/TextControls/tests/unit/BaseTextFields/MDCBaseTextFieldTests.m
@@ -23,7 +23,7 @@
     withParentClassTextAreaFrame:(CGRect)parentClassTextAreaFrame;
 - (BOOL)shouldPlaceholderBeVisibleWithPlaceholder:(NSString *)placeholder
                                              text:(NSString *)text
-                                       labelState:(MDCTextControlLabelState)labelState;
+                                       labelState:(MDCTextControlLabelPosition)labelState;
 @end
 
 @interface MDCBaseTextFieldTests : XCTestCase
@@ -322,19 +322,19 @@
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:nilPlaceholder
                                            text:text
-                                     labelState:MDCTextControlLabelStateNormal]);
+                                     labelState:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:text
-                                     labelState:MDCTextControlLabelStateNormal]);
+                                     labelState:MDCTextControlLabelPositionNormal]);
   XCTAssertFalse([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCTextControlLabelStateNormal]);
+                                     labelState:MDCTextControlLabelPositionNormal]);
   XCTAssertTrue([textField
       shouldPlaceholderBeVisibleWithPlaceholder:placeholder
                                            text:nilText
-                                     labelState:MDCTextControlLabelStateFloating]);
+                                     labelState:MDCTextControlLabelPositionFloating]);
 }
 
 - (void)testDefaultAccessibilityLabelWithOnlyLabelText {

--- a/components/private/TextControlsPrivate/src/OutlinedStyle/MDCTextControlStyleOutlined.m
+++ b/components/private/TextControlsPrivate/src/OutlinedStyle/MDCTextControlStyleOutlined.m
@@ -94,7 +94,7 @@ static const CGFloat kFilledFloatingLabelScaleFactor = (CGFloat)0.75;
 - (void)applyStyleToTextControl:(UIView<MDCTextControl> *)textControl
               animationDuration:(NSTimeInterval)animationDuration {
   CGRect labelFrame = textControl.labelFrame;
-  BOOL isLabelFloating = textControl.labelState == MDCTextControlLabelStateFloating;
+  BOOL isLabelFloating = textControl.labelPosition == MDCTextControlLabelPositionFloating;
   CGFloat containerHeight = CGRectGetMaxY(textControl.containerFrame);
   CGFloat lineWidth = (CGFloat)self.outlineLineWidths[@(textControl.textControlState)].doubleValue;
   [self applyStyleTo:textControl

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.h
@@ -19,13 +19,17 @@
 #import "MDCTextControlColorViewModel.h"
 #import "MDCTextControlLabelAnimation.h"
 #import "MDCTextControlLabelBehavior.h"
-#import "MDCTextControlLabelState.h"
+#import "MDCTextControlLabelPosition.h"
 #import "MDCTextControlState.h"
 #import "MDCTextControlVerticalPositioningReference.h"
 
-static inline UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont() {
-  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-}
+UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont(void);
+
+CGFloat MDCTextControlPaddingValueWithMinimumPadding(CGFloat minimumPadding,
+                                                     CGFloat maximumPadding,
+                                                     CGFloat density);
+
+CGFloat MDCTextControlNormalizeDensity(CGFloat density);
 
 FOUNDATION_EXTERN const CGFloat kMDCTextControlDefaultAnimationDuration;
 
@@ -47,11 +51,11 @@ FOUNDATION_EXTERN const CGFloat kMDCTextControlDefaultAnimationDuration;
 @property(nonatomic, assign, readonly) MDCTextControlState textControlState;
 
 /**
- Describes the current MDCTextControlLabelState of the contained input view. This
+ Describes the current MDCTextControlLabelPosition of the contained input view. This
  value is affected by things like the view's @c textControlState, its @c labelBehavior, and the
  text of the floating label.
  */
-@property(nonatomic, assign, readonly) MDCTextControlLabelState labelState;
+@property(nonatomic, assign, readonly) MDCTextControlLabelPosition labelPosition;
 
 /**
  The value for the label frame that should be used for style application. While style application

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControl.m
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControl.m
@@ -12,6 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 #import "MDCTextControl.h"
 
 const CGFloat kMDCTextControlDefaultAnimationDuration = (CGFloat)0.15;
+
+UIFont *_Nonnull MDCTextControlDefaultUITextFieldFont(void) {
+  return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+}
+
+CGFloat MDCTextControlPaddingValueWithMinimumPadding(CGFloat minimumPadding,
+                                                     CGFloat maximumPadding,
+                                                     CGFloat density) {
+  if (minimumPadding > maximumPadding) {
+    return 0;
+  } else if (minimumPadding == maximumPadding) {
+    return minimumPadding;
+  } else {
+    CGFloat minMaxPaddingDifference = maximumPadding - minimumPadding;
+    CGFloat additionToMinPadding = minMaxPaddingDifference * (1 - density);
+    return minimumPadding + additionToMinPadding;
+  }
+}
+
+CGFloat MDCTextControlNormalizeDensity(CGFloat density) {
+  CGFloat normalizedDensity = density;
+  if (normalizedDensity < 0) {
+    normalizedDensity = 0;
+  } else if (normalizedDensity > 1) {
+    normalizedDensity = 1;
+  }
+  return normalizedDensity;
+}

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.h
@@ -31,7 +31,7 @@
  no animation in progress.
  */
 + (void)animateLabel:(nonnull UILabel *)label
-                 state:(MDCTextControlLabelPosition)labelState
+                 state:(MDCTextControlLabelPosition)labelPosition
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "MDCTextControlLabelState.h"
+#import "MDCTextControlLabelPosition.h"
 
 /**
  The logic to animate labels is extracted into its own class so that any MDCTextControl can
@@ -31,7 +31,7 @@
  no animation in progress.
  */
 + (void)animateLabel:(nonnull UILabel *)label
-                 state:(MDCTextControlLabelState)labelState
+                 state:(MDCTextControlLabelPosition)labelState
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.m
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.m
@@ -20,7 +20,7 @@
 @implementation MDCTextControlLabelAnimation
 
 + (void)animateLabel:(nonnull UILabel *)label
-                 state:(MDCTextControlLabelState)labelState
+                 state:(MDCTextControlLabelPosition)labelState
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
@@ -37,7 +37,7 @@
 
   UIFont *targetFont;
   CGRect targetFrame;
-  if (labelState == MDCTextControlLabelStateFloating) {
+  if (labelState == MDCTextControlLabelPositionFloating) {
     targetFont = floatingFont;
     targetFrame = floatingLabelFrame;
   } else {

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.m
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelAnimation.m
@@ -20,7 +20,7 @@
 @implementation MDCTextControlLabelAnimation
 
 + (void)animateLabel:(nonnull UILabel *)label
-                 state:(MDCTextControlLabelPosition)labelState
+                 state:(MDCTextControlLabelPosition)labelPosition
       normalLabelFrame:(CGRect)normalLabelFrame
     floatingLabelFrame:(CGRect)floatingLabelFrame
             normalFont:(nonnull UIFont *)normalFont
@@ -37,7 +37,7 @@
 
   UIFont *targetFont;
   CGRect targetFrame;
-  if (labelState == MDCTextControlLabelPositionFloating) {
+  if (labelPosition == MDCTextControlLabelPositionFloating) {
     targetFont = floatingFont;
     targetFrame = floatingLabelFrame;
   } else {

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelPosition.h
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelPosition.h
@@ -17,17 +17,22 @@
 /**
  This enum represents different states the floating label can be in.
  */
-typedef NS_ENUM(NSUInteger, MDCTextControlLabelState) {
+typedef NS_ENUM(NSUInteger, MDCTextControlLabelPosition) {
   /**
    The state where the floating label is not visible.
    */
-  MDCTextControlLabelStateNone,
+  MDCTextControlLabelPositionNone,
   /**
    The state where the floating label is floating.
    */
-  MDCTextControlLabelStateFloating,
+  MDCTextControlLabelPositionFloating,
   /**
    The state where the floating label is occupying the normal text area.
    */
-  MDCTextControlLabelStateNormal,
+  MDCTextControlLabelPositionNormal,
 };
+
+MDCTextControlLabelPosition MDCTextControlLabelPositionWith(BOOL hasLabelText,
+                                                            BOOL hasText,
+                                                            BOOL canLabelFloat,
+                                                            BOOL isEditing);

--- a/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelPosition.m
+++ b/components/private/TextControlsPrivate/src/Shared/MDCTextControlLabelPosition.m
@@ -1,0 +1,47 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCTextControlLabelPosition.h"
+#import <UIKit/UIKit.h>
+
+MDCTextControlLabelPosition MDCTextControlLabelPositionWith(BOOL hasLabelText,
+                                                            BOOL hasText,
+                                                            BOOL canLabelFloat,
+                                                            BOOL isEditing) {
+  if (hasLabelText) {
+    if (canLabelFloat) {
+      if (isEditing) {
+        return MDCTextControlLabelPositionFloating;
+      } else {
+        if (hasText) {
+          return MDCTextControlLabelPositionFloating;
+        } else {
+          return MDCTextControlLabelPositionNormal;
+        }
+      }
+    } else {
+      if (isEditing) {
+        return MDCTextControlLabelPositionNone;
+      } else {
+        if (hasText) {
+          return MDCTextControlLabelPositionNone;
+        } else {
+          return MDCTextControlLabelPositionNormal;
+        }
+      }
+    }
+  } else {
+    return MDCTextControlLabelPositionNone;
+  }
+}


### PR DESCRIPTION
This follow up PR for #9731 includes the following:
* MDCTextControlLabelState has been renamed to MDCTextControlLabelPosition
* Identical methods in MDCTextField and MDCBaseArea have been consolidated as C functions in shared locations.
* A few methods have been renamed.
* A few pragma marks have been renamed.

Related to #9407.