### PR TITLE
[Ink] Remove unnecessary strong reference to self.layer

### DIFF
--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -35,7 +35,7 @@
 @property(nonatomic, strong) MDCInkLayer *activeInkLayer;
 
 // Legacy ink ripple
-@property(nonatomic, readonly) MDCLegacyInkLayer *inkLayer;
+@property(nonatomic, readonly, weak) MDCLegacyInkLayer *inkLayer;
 
 @end
 


### PR DESCRIPTION
Because inkLayer is a convenience for self.layer (which is already strongly referenced), we don't need to maintain an additional strong reference to it. This fixes a memory leak associated with the internal issue b/149094748.

Part of #9643