### PR TITLE
[Dialogs] Add reference images for MDCAlertControllerConfigurationsTests

### DIFF
--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasAccessoryViewInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasAccessoryViewInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74087874bbd37a26dab513509a56b2a15d9271d03e671d6faf4ee4cdac062bd4
+size 9869

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d43645bc3688f699f473d8d248ce07954568642ad6e0ef5da1208658aa72b7b
+size 12137

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasMessageAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasMessageAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73301dd235c8103e86c2bd486b047d78480bb403a21132955818b26282a08476
+size 53016

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasMessage_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasMessage_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:480e0299f8ee23859fa72481a5ecdc2e14e6735f83a1e84cc8f079ef67d530fd
+size 42740

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22acb043b2b358eafec29ed421595a3b001a36b2b8fa446e617e13a0fd157155
+size 14671

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ef5386468c116c0a5501eef158385915e7a35300508e365481638b2362d4a24
+size 14060

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndMessageAndAccessoryViewInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndMessageAndAccessoryViewInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe0ff1a31af181857a691c2cf30627febaa79d15b505ede775deed466d62e8e1
+size 61244

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndMessageAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleIconAndMessageAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bf88508384434691a63064053b375f646e7f21adcc8c13bd355e6be44a14d30
+size 61217

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleImageAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleImageAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe8651ee85bf7bd14c7620dd21fa452a3d3b7f05852f5b99ef9e860a03bc4f0
+size 22620

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleImageAndMessageAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleAndTitleImageAndMessageAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1bd8f20609d6ddc91afe691bbfec15f95afcfebdc62d12732ca75fb96b8747f
+size 66128

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3746b8bd0e7704a7de54733e149a2dc7d5daf8e515cf02c60924210eedc613d1
+size 11822

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndMessageAndAccessoryViewAndVerticalButtons_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndMessageAndAccessoryViewAndVerticalButtons_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c62145770913af2262fd72f5d767b200d758fe1ed653cd893dfd6036b4acf24
+size 33189

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndMessage_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIconAndMessage_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:064f09c6231c877ff3505f7bf0eafafd707d12cf5bd1a527c5b929c338768e16
+size 8110

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIcon_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleIcon_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b960191432fa6348e957ce11ce572a81ef935c0318ba364539b717bbd21c8321
+size 3931

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndAccessoryView_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndAccessoryView_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d74c99d925a9fc8c152f67f360f88c32c5d4acd38845ad5cb13a2f1fca8cbd26
+size 17697

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndMessage_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndMessage_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c0a2b90e700d5f49722569c297c3133a8db47646149753519d5923715c4a25
+size 47888

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndVerticalButtons_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImageAndVerticalButtons_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e695c3f5d5a167f6e56d0c6263953ecabd03a79e6b244b9c2fb9cf3b3dace787
+size 20995

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImage_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitleImage_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ded96de31c90c5dcfd137c96e17c8f71df0d0535b5a5a0a57e5e18512593df8a
+size 6329

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitle_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testAlertHasTitle_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6befe26e713145625c33a707bc1c1798f69d97a9f91a74bffb59ceff66581bc6
+size 8138


### PR DESCRIPTION
Adds the missing reference images required for the tests introduced by 31c2f236fd172a0303d599013c349687049cb60f to pass.