### PR TITLE
[ButtonBar] Fix crash when assigning tint color, title, or image to bar button item with custom view.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -299,7 +299,9 @@ static NSString *const kEnabledSelector = @"enabled";
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tintColor))]) {
           button.tintColor = newValue;
-          [self->_defaultBuilder updateTitleColorForButton:button withItem:object];
+          if ([button isKindOfClass:[MDCButton class]]) {
+            [self->_defaultBuilder updateTitleColorForButton:button withItem:object];
+          }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
           [button setTitle:newValue forState:UIControlStateNormal];

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -291,8 +291,10 @@ static NSString *const kEnabledSelector = @"enabled";
           button.accessibilityValue = newValue;
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(image))]) {
-          [button setImage:newValue forState:UIControlStateNormal];
-          [self invalidateIntrinsicContentSize];
+          if ([button isKindOfClass:[MDCButton class]]) {
+            [button setImage:newValue forState:UIControlStateNormal];
+            [self invalidateIntrinsicContentSize];
+          }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tag))]) {
           button.tag = [newValue integerValue];
@@ -304,8 +306,10 @@ static NSString *const kEnabledSelector = @"enabled";
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
-          [button setTitle:newValue forState:UIControlStateNormal];
-          [self invalidateIntrinsicContentSize];
+          if ([button isKindOfClass:[MDCButton class]]) {
+            [button setTitle:newValue forState:UIControlStateNormal];
+            [self invalidateIntrinsicContentSize];
+          }
 
         } else {
           NSLog(@"Unknown key path notification received by %@ for %@.",

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -291,8 +291,8 @@ static NSString *const kEnabledSelector = @"enabled";
           button.accessibilityValue = newValue;
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(image))]) {
-          if ([button isKindOfClass:[MDCButton class]]) {
-            [button setImage:newValue forState:UIControlStateNormal];
+          if ([button isKindOfClass:[UIButton class]]) {
+            [((UIButton *)button) setImage:newValue forState:UIControlStateNormal];
             [self invalidateIntrinsicContentSize];
           }
 
@@ -301,13 +301,13 @@ static NSString *const kEnabledSelector = @"enabled";
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tintColor))]) {
           button.tintColor = newValue;
-          if ([button isKindOfClass:[MDCButton class]]) {
-            [self->_defaultBuilder updateTitleColorForButton:button withItem:object];
+          if ([button isKindOfClass:[UIButton class]]) {
+            [self->_defaultBuilder updateTitleColorForButton:((UIButton *)button) withItem:object];
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
-          if ([button isKindOfClass:[MDCButton class]]) {
-            [button setTitle:newValue forState:UIControlStateNormal];
+          if ([button isKindOfClass:[UIButton class]]) {
+            [((UIButton *)button) setTitle:newValue forState:UIControlStateNormal];
             [self invalidateIntrinsicContentSize];
           }
 

--- a/components/ButtonBar/tests/unit/ButtonBarCustomViewTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarCustomViewTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialButtonBar
 
-class ButtonBarTintColorTests: XCTestCase {
+class ButtonBarCustomViewTests: XCTestCase {
 
   var buttonBar: MDCButtonBar!
 

--- a/components/ButtonBar/tests/unit/ButtonBarCustomViewTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarCustomViewTests.swift
@@ -44,5 +44,28 @@ class ButtonBarCustomViewTests: XCTestCase {
     XCTAssertEqual(customView.tintColor, item.tintColor)
   }
 
+  func testSettingImageToNilOnItemDoesNothing() {
+    // Given
+    let customView = UIView()
+    let item = UIBarButtonItem(customView: customView)
+    buttonBar.items = [item]
+
+    // When
+    item.image = nil
+
+    // Then, doesn't crash.
+  }
+
+  func testSettingTitleOnItemDoesNothing() {
+    // Given
+    let customView = UIView()
+    let item = UIBarButtonItem(customView: customView)
+    buttonBar.items = [item]
+
+    // When
+    item.title = "Hello"
+
+    // Then, doesn't crash.
+  }
 }
 

--- a/components/ButtonBar/tests/unit/ButtonBarTintColorTests.swift
+++ b/components/ButtonBar/tests/unit/ButtonBarTintColorTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialButtonBar
+
+class ButtonBarTintColorTests: XCTestCase {
+
+  var buttonBar: MDCButtonBar!
+
+  override func setUp() {
+    super.setUp()
+
+    buttonBar = MDCButtonBar()
+  }
+
+  override func tearDown() {
+    buttonBar = nil
+
+    super.tearDown()
+  }
+
+  func testSettingTintColorOnItemModifiesCustomViewTintColor() {
+    // Given
+    let customView = UIView()
+    let item = UIBarButtonItem(customView: customView)
+    buttonBar.items = [item]
+
+    // When
+    item.tintColor = .red
+
+    // Then
+    XCTAssertEqual(customView.tintColor, item.tintColor)
+  }
+
+}
+


### PR DESCRIPTION
When a bar button item with a custom view is provided to the button bar, the custom view is used in place of an MDCButton instance.  6ec9f334f0e093e1d2bf04165895ca725455150e introduced a change that unconditionally called a UIButton API on the views when the tintColor was changed, resulting in a crash when a custom view was used.

This change adds a test that, prior to this fix in this change, crashed, but after the fix included in this change now passes.

Upon inspection of the culprit code, it was revealed that image and title similarly could result in crashes, so those crashes have been fixed as part of this change as well.

Closes https://github.com/material-components/material-components-ios/issues/9760
