### PR TITLE
[ButtonBar] Do not allow implicit downcasting of item views.

### DIFF
--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -302,7 +302,8 @@ static NSString *const kEnabledSelector = @"enabled";
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tintColor))]) {
           buttonView.tintColor = newValue;
           if ([buttonView isKindOfClass:[UIButton class]]) {
-            [self->_defaultBuilder updateTitleColorForButton:((UIButton *)buttonView) withItem:object];
+            [self->_defaultBuilder updateTitleColorForButton:((UIButton *)buttonView)
+                                                    withItem:object];
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {

--- a/components/ButtonBar/src/MDCButtonBar.m
+++ b/components/ButtonBar/src/MDCButtonBar.m
@@ -31,7 +31,7 @@ static NSString *const kEnabledSelector = @"enabled";
 
 @implementation MDCButtonBar {
   id _buttonItemsLock;
-  NSArray<__kindof UIView *> *_buttonViews;
+  NSArray<UIView *> *_buttonViews;
   UIColor *_inkColor;
   MDCAppBarButtonBarBuilder *_defaultBuilder;
 }
@@ -265,7 +265,7 @@ static NSString *const kEnabledSelector = @"enabled";
         if (itemIndex == NSNotFound || itemIndex > [self->_buttonViews count]) {
           return;
         }
-        UIButton *button = self->_buttonViews[itemIndex];
+        UIView *buttonView = self->_buttonViews[itemIndex];
 
         id newValue = [object valueForKey:keyPath];
         if (newValue == [NSNull null]) {
@@ -273,41 +273,41 @@ static NSString *const kEnabledSelector = @"enabled";
         }
 
         if ([keyPath isEqualToString:kEnabledSelector]) {
-          if ([button respondsToSelector:@selector(setEnabled:)]) {
-            [button setValue:newValue forKey:keyPath];
+          if ([buttonView respondsToSelector:@selector(setEnabled:)]) {
+            [buttonView setValue:newValue forKey:keyPath];
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityHint))]) {
-          button.accessibilityHint = newValue;
+          buttonView.accessibilityHint = newValue;
 
         } else if ([keyPath
                        isEqualToString:NSStringFromSelector(@selector(accessibilityIdentifier))]) {
-          button.accessibilityIdentifier = newValue;
+          buttonView.accessibilityIdentifier = newValue;
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityLabel))]) {
-          button.accessibilityLabel = newValue;
+          buttonView.accessibilityLabel = newValue;
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(accessibilityValue))]) {
-          button.accessibilityValue = newValue;
+          buttonView.accessibilityValue = newValue;
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(image))]) {
-          if ([button isKindOfClass:[UIButton class]]) {
-            [((UIButton *)button) setImage:newValue forState:UIControlStateNormal];
+          if ([buttonView isKindOfClass:[UIButton class]]) {
+            [((UIButton *)buttonView) setImage:newValue forState:UIControlStateNormal];
             [self invalidateIntrinsicContentSize];
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tag))]) {
-          button.tag = [newValue integerValue];
+          buttonView.tag = [newValue integerValue];
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(tintColor))]) {
-          button.tintColor = newValue;
-          if ([button isKindOfClass:[UIButton class]]) {
-            [self->_defaultBuilder updateTitleColorForButton:((UIButton *)button) withItem:object];
+          buttonView.tintColor = newValue;
+          if ([buttonView isKindOfClass:[UIButton class]]) {
+            [self->_defaultBuilder updateTitleColorForButton:((UIButton *)buttonView) withItem:object];
           }
 
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(title))]) {
-          if ([button isKindOfClass:[UIButton class]]) {
-            [((UIButton *)button) setTitle:newValue forState:UIControlStateNormal];
+          if ([buttonView isKindOfClass:[UIButton class]]) {
+            [((UIButton *)buttonView) setTitle:newValue forState:UIControlStateNormal];
             [self invalidateIntrinsicContentSize];
           }
 


### PR DESCRIPTION
Prior to this change, it was possible to implicitly downcast item views to UIButton or MDCButton, potentially causing crashes by treating custom views incorrectly as a button and invoking UIButton selectors on it.

This change removes the `__kindof` implicit casting for the _buttonViews ivar so that the buttonViews need to be explicitly casted to a button type.

Related to https://github.com/material-components/material-components-ios/issues/9760