### PR TITLE
[TextControls] add filled text areas

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1606,6 +1606,48 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  # TextControls+FilledTextAreas
+
+  mdc.subspec "TextControls+FilledTextAreas" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
+    component.source_files = [
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}",
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/Availability"
+    component.dependency "MaterialComponents/TextControls+BaseTextAreas"
+    component.dependency "MaterialComponents/private/TextControlsPrivate+FilledStyle"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
+      ]
+      unit_tests.dependency "MaterialComponents/schemes/Container"
+    end
+  end
+
+  # TextControls+FilledTextAreasTheming
+
+  mdc.subspec "TextControls+FilledTextAreasTheming" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
+    component.source_files = [
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}",
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/TextControls+FilledTextAreas"
+    component.dependency "MaterialComponents/schemes/Container"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
+      ]
+    end
+  end
+
   # TextControls+FilledTextFields
 
   mdc.subspec "TextControls+FilledTextFields" do |component|

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -933,6 +933,26 @@
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0C31D9622E82595763A57F2CFA923FB2"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextAreasTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextAreasTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2EFD41E19B8B93BADBCA41C2B13D11BA"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -857,6 +857,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "163F8970040122C9AFAD3898D1FFEC01"
+               BuildableName = "MaterialComponents-Unit-TextControls+BaseTextAreas-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+BaseTextAreas-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "BCA0A4911AC055D6165735C1400F041B"
                BuildableName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests.xctest"
                BlueprintName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests"
@@ -867,9 +877,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2EFD41E19B8B93BADBCA41C2B13D11BA"
-               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests.xctest"
-               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests"
+               BlueprintIdentifier = "E67D7ECFD06F594B824049745696DBDD"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextAreas-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextAreas-UnitTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -954,6 +954,26 @@
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E67D7ECFD06F594B824049745696DBDD"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextAreas-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextAreas-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0C31D9622E82595763A57F2CFA923FB2"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextAreasTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextAreasTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -73,6 +73,8 @@ target "MDCCatalog" do
     'TextFields+Theming/UnitTests',
     'TextControls+BaseTextAreas/UnitTests',
     'TextControls+BaseTextFields/UnitTests',
+    'TextControls+FilledTextAreas/UnitTests',
+    'TextControls+FilledTextAreasTheming/UnitTests',
     'TextControls+FilledTextFields/UnitTests',
     'TextControls+FilledTextFieldsTheming/UnitTests',
     'TextControls+OutlinedTextAreas/UnitTests',

--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -79,6 +79,22 @@ mdc_objc_library(
 )
 
 mdc_extension_objc_library(
+    name = "FilledTextAreas",
+    deps = [
+        ":BaseTextAreas",
+        "//components/private/TextControlsPrivate:FilledStyle",
+    ],
+)
+
+mdc_extension_objc_library(
+    name = "FilledTextAreasTheming",
+    deps = [
+        ":FilledTextAreas",
+        "//components/schemes/Container",
+    ],
+)
+
+mdc_extension_objc_library(
     name = "FilledTextFields",
     deps = [
         ":BaseTextFields",
@@ -161,6 +177,8 @@ mdc_unit_test_objc_library(
         ":BaseTextAreasPrivate",
         ":BaseTextFields",
         ":BaseTextFieldsPrivate",
+        ":FilledTextAreas",
+        ":FilledTextAreasTheming",
         ":FilledTextFields",
         ":FilledTextFieldsTheming",
         ":OutlinedTextAreas",

--- a/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.h
+++ b/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.h
@@ -1,0 +1,50 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCBaseTextArea.h"
+
+/**
+ An implementation of a Material filled text area.
+ */
+__attribute__((objc_subclassing_restricted)) @interface MDCFilledTextArea : MDCBaseTextArea
+
+/**
+ Sets the filled background color for a given state.
+ @param filledBackgroundColor The UIColor for the given state.
+ @param state The MDCTextControlState.
+ */
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
+                        forState:(MDCTextControlState)state;
+/**
+ Returns the filled background color for a given state.
+ @param state The MDCTextControlState.
+ */
+- (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state;
+
+/**
+ Sets the underline color for a given state.
+ @param underlineColor The UIColor for the given state.
+ @param state The MDCTextControlState.
+ */
+- (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state;
+
+/**
+ Returns the underline color for a given state.
+ @param state The MDCTextControlState.
+ */
+- (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state;
+
+@end

--- a/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.m
+++ b/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.m
@@ -1,0 +1,80 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFilledTextArea.h"
+
+#import <Foundation/Foundation.h>
+
+#import "MaterialTextControlsPrivate+FilledStyle.h"
+#import "MaterialTextControlsPrivate+Shared.h"
+
+@interface MDCFilledTextArea (Private) <MDCTextControl>
+@end
+
+@interface MDCFilledTextArea ()
+@end
+
+@implementation MDCFilledTextArea
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCFilledTextAreaInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonMDCFilledTextAreaInit];
+  }
+  return self;
+}
+
+- (void)commonMDCFilledTextAreaInit {
+  MDCTextControlStyleFilled *filledStyle = [[MDCTextControlStyleFilled alloc] init];
+  self.containerStyle = filledStyle;
+}
+
+#pragma mark Stateful Color APIs
+
+- (void)setFilledBackgroundColor:(nonnull UIColor *)filledBackgroundColor
+                        forState:(MDCTextControlState)state {
+  [self.filledStyle setFilledBackgroundColor:filledBackgroundColor forState:state];
+  [self setNeedsLayout];
+}
+
+- (nonnull UIColor *)filledBackgroundColorForState:(MDCTextControlState)state {
+  return [self.filledStyle filledBackgroundColorForState:state];
+}
+
+- (void)setUnderlineColor:(nonnull UIColor *)underlineColor forState:(MDCTextControlState)state {
+  [self.filledStyle setUnderlineColor:underlineColor forState:state];
+  [self setNeedsLayout];
+}
+
+- (nonnull UIColor *)underlineColorForState:(MDCTextControlState)state {
+  return [self.filledStyle underlineColorForState:state];
+}
+
+- (MDCTextControlStyleFilled *)filledStyle {
+  MDCTextControlStyleFilled *filledStyle = nil;
+  if ([self.containerStyle isKindOfClass:[MDCTextControlStyleFilled class]]) {
+    filledStyle = (MDCTextControlStyleFilled *)self.containerStyle;
+  }
+  return filledStyle;
+}
+
+@end

--- a/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.m
+++ b/components/TextControls/src/FilledTextAreas/MDCFilledTextArea.m
@@ -14,15 +14,10 @@
 
 #import "MDCFilledTextArea.h"
 
-#import <Foundation/Foundation.h>
-
 #import "MaterialTextControlsPrivate+FilledStyle.h"
 #import "MaterialTextControlsPrivate+Shared.h"
 
 @interface MDCFilledTextArea (Private) <MDCTextControl>
-@end
-
-@interface MDCFilledTextArea ()
 @end
 
 @implementation MDCFilledTextArea
@@ -44,8 +39,7 @@
 }
 
 - (void)commonMDCFilledTextAreaInit {
-  MDCTextControlStyleFilled *filledStyle = [[MDCTextControlStyleFilled alloc] init];
-  self.containerStyle = filledStyle;
+  self.containerStyle = [[MDCTextControlStyleFilled alloc] init];
 }
 
 #pragma mark Stateful Color APIs

--- a/components/TextControls/src/FilledTextAreas/MaterialTextControls+FilledTextAreas.h
+++ b/components/TextControls/src/FilledTextAreas/MaterialTextControls+FilledTextAreas.h
@@ -1,0 +1,15 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFilledTextArea.h"

--- a/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.h
+++ b/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCFilledTextArea.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCFilledTextArea instances with an MDCContainerScheme.
+ */
+@interface MDCFilledTextArea (MaterialTheming)
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver in a manner best suited to
+ convey an error state.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.m
+++ b/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.m
@@ -1,0 +1,183 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFilledTextArea+MaterialTheming.h"
+
+#import <Foundation/Foundation.h>
+
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+
+static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+
+@implementation MDCFilledTextArea (MaterialTheming)
+
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyDefaultColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyErrorColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyTypographyScheme:(id<MDCTypographyScheming>)mdcTypographyScheming {
+  self.textView.font = mdcTypographyScheming.subtitle1;
+  self.leadingAssistiveLabel.font = mdcTypographyScheming.caption;
+  self.trailingAssistiveLabel.font = mdcTypographyScheming.caption;
+}
+
+- (void)applyDefaultColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
+  UIColor *floatingLabelColorEditing =
+      [colorScheme.primaryColor colorWithAlphaComponent:kPrimaryFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *underlineColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity];
+  UIColor *underlineColorEditing = colorScheme.primaryColor;
+  UIColor *underlineColorDisabled = [underlineColorNormal
+      colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *filledSublayerFillColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
+  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
+
+  self.tintColor = colorScheme.primaryColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setUnderlineColor:underlineColorNormal forState:MDCTextControlStateNormal];
+  [self setUnderlineColor:underlineColorEditing forState:MDCTextControlStateEditing];
+  [self setUnderlineColor:underlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setFilledBackgroundColor:filledSublayerFillColorNormal forState:MDCTextControlStateNormal];
+  [self setFilledBackgroundColor:filledSublayerFillColorEditing
+                        forState:MDCTextControlStateEditing];
+  [self setFilledBackgroundColor:filledSublayerFillColorDisabled
+                        forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+}
+
+- (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = colorScheme.errorColor;
+  UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *underlineColorNormal = colorScheme.errorColor;
+  UIColor *underlineColorEditing = underlineColorNormal;
+  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *filledSublayerFillColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
+  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
+
+  self.tintColor = colorScheme.errorColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setUnderlineColor:underlineColorNormal forState:MDCTextControlStateNormal];
+  [self setUnderlineColor:underlineColorEditing forState:MDCTextControlStateEditing];
+  [self setUnderlineColor:underlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setFilledBackgroundColor:filledSublayerFillColorNormal forState:MDCTextControlStateNormal];
+  [self setFilledBackgroundColor:filledSublayerFillColorEditing
+                        forState:MDCTextControlStateEditing];
+  [self setFilledBackgroundColor:filledSublayerFillColorDisabled
+                        forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+}
+
+@end

--- a/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.m
+++ b/components/TextControls/src/FilledTextAreasTheming/MDCFilledTextArea+MaterialTheming.m
@@ -14,8 +14,6 @@
 
 #import "MDCFilledTextArea+MaterialTheming.h"
 
-#import <Foundation/Foundation.h>
-
 static const CGFloat kDisabledOpacity = (CGFloat)0.60;
 
 static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;

--- a/components/TextControls/src/FilledTextAreasTheming/MaterialTextControls+FilledTextAreasTheming.h
+++ b/components/TextControls/src/FilledTextAreasTheming/MaterialTextControls+FilledTextAreasTheming.h
@@ -1,0 +1,15 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCFilledTextArea+MaterialTheming.h"

--- a/components/TextControls/tests/unit/FilledTextAreas/MDCFilledTextAreaTests.m
+++ b/components/TextControls/tests/unit/FilledTextAreas/MDCFilledTextAreaTests.m
@@ -25,11 +25,10 @@
 
 - (void)testFilledBackgroundColorAccessors {
   // Given
-  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
-  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] initWithFrame:textAreaFrame];
-  UIColor *filledBackgroundColorNormal = [UIColor blueColor];
-  UIColor *filledBackgroundColorEditing = [UIColor greenColor];
-  UIColor *filledBackgroundColorDisabled = [UIColor purpleColor];
+  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] init];
+  UIColor *filledBackgroundColorNormal = UIColor.blueColor;
+  UIColor *filledBackgroundColorEditing = UIColor.greenColor;
+  UIColor *filledBackgroundColorDisabled = UIColor.purpleColor;
 
   // When
   [textArea setFilledBackgroundColor:filledBackgroundColorNormal
@@ -50,11 +49,10 @@
 
 - (void)testUnderlineColorAccessors {
   // Given
-  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
-  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] initWithFrame:textAreaFrame];
-  UIColor *underlineColorNormal = [UIColor blueColor];
-  UIColor *underlineColorEditing = [UIColor greenColor];
-  UIColor *underlineColorDisabled = [UIColor purpleColor];
+  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] init];
+  UIColor *underlineColorNormal = UIColor.blueColor;
+  UIColor *underlineColorEditing = UIColor.greenColor;
+  UIColor *underlineColorDisabled = UIColor.purpleColor;
 
   // When
   [textArea setUnderlineColor:underlineColorNormal forState:MDCTextControlStateNormal];

--- a/components/TextControls/tests/unit/FilledTextAreas/MDCFilledTextAreaTests.m
+++ b/components/TextControls/tests/unit/FilledTextAreas/MDCFilledTextAreaTests.m
@@ -1,0 +1,72 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialTextControls+FilledTextAreas.h"
+
+@interface MDCFilledTextAreaTests : XCTestCase
+@end
+
+@implementation MDCFilledTextAreaTests
+
+#pragma mark Tests
+
+- (void)testFilledBackgroundColorAccessors {
+  // Given
+  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
+  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] initWithFrame:textAreaFrame];
+  UIColor *filledBackgroundColorNormal = [UIColor blueColor];
+  UIColor *filledBackgroundColorEditing = [UIColor greenColor];
+  UIColor *filledBackgroundColorDisabled = [UIColor purpleColor];
+
+  // When
+  [textArea setFilledBackgroundColor:filledBackgroundColorNormal
+                            forState:MDCTextControlStateNormal];
+  [textArea setFilledBackgroundColor:filledBackgroundColorEditing
+                            forState:MDCTextControlStateEditing];
+  [textArea setFilledBackgroundColor:filledBackgroundColorDisabled
+                            forState:MDCTextControlStateDisabled];
+
+  // Then
+  XCTAssertEqualObjects(filledBackgroundColorNormal,
+                        [textArea filledBackgroundColorForState:MDCTextControlStateNormal]);
+  XCTAssertEqualObjects(filledBackgroundColorEditing,
+                        [textArea filledBackgroundColorForState:MDCTextControlStateEditing]);
+  XCTAssertEqualObjects(filledBackgroundColorDisabled,
+                        [textArea filledBackgroundColorForState:MDCTextControlStateDisabled]);
+}
+
+- (void)testUnderlineColorAccessors {
+  // Given
+  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
+  MDCFilledTextArea *textArea = [[MDCFilledTextArea alloc] initWithFrame:textAreaFrame];
+  UIColor *underlineColorNormal = [UIColor blueColor];
+  UIColor *underlineColorEditing = [UIColor greenColor];
+  UIColor *underlineColorDisabled = [UIColor purpleColor];
+
+  // When
+  [textArea setUnderlineColor:underlineColorNormal forState:MDCTextControlStateNormal];
+  [textArea setUnderlineColor:underlineColorEditing forState:MDCTextControlStateEditing];
+  [textArea setUnderlineColor:underlineColorDisabled forState:MDCTextControlStateDisabled];
+  // Then
+  XCTAssertEqualObjects(underlineColorNormal,
+                        [textArea underlineColorForState:MDCTextControlStateNormal]);
+  XCTAssertEqualObjects(underlineColorEditing,
+                        [textArea underlineColorForState:MDCTextControlStateEditing]);
+  XCTAssertEqualObjects(underlineColorDisabled,
+                        [textArea underlineColorForState:MDCTextControlStateDisabled]);
+}
+
+@end

--- a/components/TextControls/tests/unit/FilledTextAreasTheming/MDCFilledTextAreaThemingTests.m
+++ b/components/TextControls/tests/unit/FilledTextAreasTheming/MDCFilledTextAreaThemingTests.m
@@ -1,0 +1,334 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialContainerScheme.h"
+#import "MaterialTextControls+FilledTextAreasTheming.h"
+
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kFilledSublayerFillColorNormalOpacity = (CGFloat)0.12;
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kPrimaryUnderlineColorNormalOpacity = (CGFloat)0.42;
+
+@interface MDCFilledTextAreaThemingTest : XCTestCase
+@property(nonatomic, strong) MDCFilledTextArea *textArea;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@end
+
+@implementation MDCFilledTextAreaThemingTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.textArea = [[MDCFilledTextArea alloc] init];
+  self.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+  self.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+}
+
+- (void)tearDown {
+  self.textArea = nil;
+  self.colorScheme = nil;
+  self.typographyScheme = nil;
+  self.containerScheme = nil;
+
+  [super tearDown];
+}
+
+- (void)testTextAreaPrimaryThemingDefault {
+  // When
+  [self.textArea applyThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaPrimaryTheming];
+}
+
+- (void)testTextAreaPrimaryThemingCustom {
+  // Given
+  self.colorScheme = [self customColorScheme];
+  self.typographyScheme = [self customTypographyScheme];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+
+  // When
+  [self.textArea applyThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaPrimaryTheming];
+}
+
+- (void)testTextAreaErrorThemingDefault {
+  // When
+  [self.textArea applyErrorThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaErrorTheming];
+}
+
+- (void)testTextAreaErrorThemingCustom {
+  // Given
+  self.colorScheme = [self customColorScheme];
+  self.typographyScheme = [self customTypographyScheme];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+
+  // When
+  [self.textArea applyErrorThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaErrorTheming];
+}
+
+#pragma mark - Test helpers
+
+- (MDCSemanticColorScheme *)customColorScheme {
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+
+  colorScheme.primaryColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:0];
+  colorScheme.primaryColorVariant = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.1];
+  colorScheme.secondaryColor = [UIColor colorWithWhite:(CGFloat)0.7 alpha:(CGFloat)0.2];
+  colorScheme.errorColor = [UIColor colorWithWhite:(CGFloat)0.6 alpha:(CGFloat)0.3];
+  colorScheme.surfaceColor = [UIColor colorWithWhite:(CGFloat)0.5 alpha:(CGFloat)0.4];
+  colorScheme.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.4 alpha:(CGFloat)0.5];
+  colorScheme.onPrimaryColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.6];
+  colorScheme.onSecondaryColor = [UIColor colorWithWhite:(CGFloat)0.2 alpha:(CGFloat)0.7];
+  colorScheme.onSurfaceColor = [UIColor colorWithWhite:(CGFloat)0.1 alpha:(CGFloat)0.8];
+  colorScheme.onBackgroundColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.9];
+
+  return colorScheme;
+}
+
+- (MDCTypographyScheme *)customTypographyScheme {
+  MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+
+  typographyScheme.headline1 = [UIFont systemFontOfSize:1];
+  typographyScheme.headline2 = [UIFont systemFontOfSize:2];
+  typographyScheme.headline3 = [UIFont systemFontOfSize:3];
+  typographyScheme.headline4 = [UIFont systemFontOfSize:4];
+  typographyScheme.headline5 = [UIFont systemFontOfSize:5];
+  typographyScheme.headline6 = [UIFont systemFontOfSize:6];
+  typographyScheme.subtitle1 = [UIFont systemFontOfSize:7];
+  typographyScheme.subtitle2 = [UIFont systemFontOfSize:8];
+  typographyScheme.body1 = [UIFont systemFontOfSize:9];
+  typographyScheme.body2 = [UIFont systemFontOfSize:10];
+  typographyScheme.caption = [UIFont systemFontOfSize:11];
+  typographyScheme.button = [UIFont systemFontOfSize:12];
+  typographyScheme.overline = [UIFont systemFontOfSize:13];
+
+  return typographyScheme;
+}
+
+- (void)verifyTextAreaPrimaryTheming {
+  // Color
+  UIColor *textColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
+  UIColor *floatingLabelColorEditing = [self.colorScheme.primaryColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *underlineColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity];
+  UIColor *underlineColorEditing = self.colorScheme.primaryColor;
+  UIColor *underlineColorDisabled = [underlineColorNormal
+      colorWithAlphaComponent:kPrimaryUnderlineColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *filledSublayerFillColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
+  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *tintColor = self.colorScheme.primaryColor;
+
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateNormal],
+                        floatingLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateEditing],
+                        floatingLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateDisabled],
+                        floatingLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateNormal],
+                        normalLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateEditing],
+                        normalLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateDisabled],
+                        normalLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateNormal],
+                        textColorNormal);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateEditing],
+                        textColorEditing);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateDisabled],
+                        textColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateNormal],
+                        underlineColorNormal);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateEditing],
+                        underlineColorEditing);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateDisabled],
+                        underlineColorDisabled);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateNormal],
+                        filledSublayerFillColorNormal);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateEditing],
+                        filledSublayerFillColorEditing);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateDisabled],
+                        filledSublayerFillColorDisabled);
+  XCTAssertEqualObjects(self.textArea.tintColor, tintColor);
+
+  // Typography
+  XCTAssertEqualObjects(self.textArea.textView.font, self.typographyScheme.subtitle1);
+  XCTAssertEqualObjects(self.textArea.leadingAssistiveLabel.font, self.typographyScheme.caption);
+  XCTAssertEqualObjects(self.textArea.trailingAssistiveLabel.font, self.typographyScheme.caption);
+}
+
+- (void)verifyTextAreaErrorTheming {
+  // Color
+  UIColor *textColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = self.colorScheme.errorColor;
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = self.colorScheme.errorColor;
+  UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *underlineColorNormal = self.colorScheme.errorColor;
+  UIColor *underlineColorEditing = underlineColorNormal;
+  UIColor *underlineColorDisabled = [underlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *filledSublayerFillColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity];
+  UIColor *filledSublayerFillColorEditing = filledSublayerFillColorNormal;
+  UIColor *filledSublayerFillColorDisabled = [filledSublayerFillColorNormal
+      colorWithAlphaComponent:kFilledSublayerFillColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *tintColor = self.colorScheme.errorColor;
+
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateNormal],
+                        floatingLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateEditing],
+                        floatingLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateDisabled],
+                        floatingLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateNormal],
+                        normalLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateEditing],
+                        normalLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateDisabled],
+                        normalLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateNormal],
+                        textColorNormal);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateEditing],
+                        textColorEditing);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateDisabled],
+                        textColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateNormal],
+                        underlineColorNormal);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateEditing],
+                        underlineColorEditing);
+  XCTAssertEqualObjects([self.textArea underlineColorForState:MDCTextControlStateDisabled],
+                        underlineColorDisabled);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateNormal],
+                        filledSublayerFillColorNormal);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateEditing],
+                        filledSublayerFillColorEditing);
+  XCTAssertEqualObjects([self.textArea filledBackgroundColorForState:MDCTextControlStateDisabled],
+                        filledSublayerFillColorDisabled);
+  XCTAssertEqualObjects(self.textArea.tintColor, tintColor);
+
+  // Typography
+  XCTAssertEqualObjects(self.textArea.textView.font, self.typographyScheme.subtitle1);
+  XCTAssertEqualObjects(self.textArea.leadingAssistiveLabel.font, self.typographyScheme.caption);
+  XCTAssertEqualObjects(self.textArea.trailingAssistiveLabel.font, self.typographyScheme.caption);
+}
+
+@end

--- a/components/TextControls/tests/unit/FilledTextAreasTheming/MDCFilledTextAreaThemingTests.m
+++ b/components/TextControls/tests/unit/FilledTextAreasTheming/MDCFilledTextAreaThemingTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds the TextControl filled text areas, as well as their theming extensions, and a bunch of unit tests. Snapshot tests to follow.

Related to #9407.

