### PR TITLE
Add outlined text areas

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -1648,6 +1648,49 @@ Pod::Spec.new do |mdc|
     end
   end
 
+  # TextControls+OutlinedTextAreas
+
+  mdc.subspec "TextControls+OutlinedTextAreas" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
+    component.source_files = [
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}",
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/Availability"
+    component.dependency "MaterialComponents/TextControls+BaseTextAreas"
+    component.dependency "MaterialComponents/private/TextControlsPrivate+OutlinedStyle"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
+      ]
+      unit_tests.dependency "MaterialComponents/schemes/Container"
+    end
+  end
+
+  # TextControls+OutlinedTextAreasTheming
+
+  mdc.subspec "TextControls+OutlinedTextAreasTheming" do |component|
+    component.ios.deployment_target = '9.0'
+    component.public_header_files = "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.h"
+    component.source_files = [
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/*.{h,m}",
+      "components/#{component.base_name.split('+')[0]}/src/#{component.base_name.split('+')[1]}/private/*.{h,m}"
+    ]
+
+    component.dependency "MaterialComponents/TextControls+OutlinedTextAreas"
+    component.dependency "MaterialComponents/schemes/Container"
+
+    component.test_spec 'UnitTests' do |unit_tests|
+      unit_tests.source_files = [
+      "components/#{component.base_name.split('+')[0]}/tests/unit/#{component.base_name.split('+')[1]}/*.{h,m,swift}"
+      ]
+      unit_tests.dependency "MaterialComponents/Availability"
+    end
+  end
+
   # TextControls+OutlinedTextFields
 
   mdc.subspec "TextControls+OutlinedTextFields" do |component|

--- a/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
+++ b/catalog/MDCCatalog.xcodeproj/xcshareddata/xcschemes/MDCCatalog.xcscheme
@@ -853,6 +853,76 @@
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BCA0A4911AC055D6165735C1400F041B"
+               BuildableName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2EFD41E19B8B93BADBCA41C2B13D11BA"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A2407A93442EBDC88E2DEAF37B0F9A2"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFieldsTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFieldsTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C078E40782E82430B310BF59569168FC"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextAreas-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextAreas-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "92E58EA1EB004E18958A93657122103F"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextAreasTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextAreasTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "47A774766875750D260F80E7F22FACF0"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2AC9E3643D14CD25E2EC2E848498B2DA"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextFieldsTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextFieldsTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
+++ b/catalog/MDCDragons.xcodeproj/xcshareddata/xcschemes/MDCDragons.xcscheme
@@ -884,6 +884,76 @@
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BCA0A4911AC055D6165735C1400F041B"
+               BuildableName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+BaseTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2EFD41E19B8B93BADBCA41C2B13D11BA"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A2407A93442EBDC88E2DEAF37B0F9A2"
+               BuildableName = "MaterialComponents-Unit-TextControls+FilledTextFieldsTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+FilledTextFieldsTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C078E40782E82430B310BF59569168FC"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextAreas-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextAreas-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "92E58EA1EB004E18958A93657122103F"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextAreasTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextAreasTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "47A774766875750D260F80E7F22FACF0"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextFields-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextFields-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2AC9E3643D14CD25E2EC2E848498B2DA"
+               BuildableName = "MaterialComponents-Unit-TextControls+OutlinedTextFieldsTheming-UnitTests.xctest"
+               BlueprintName = "MaterialComponents-Unit-TextControls+OutlinedTextFieldsTheming-UnitTests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/catalog/Podfile
+++ b/catalog/Podfile
@@ -75,6 +75,8 @@ target "MDCCatalog" do
     'TextControls+BaseTextFields/UnitTests',
     'TextControls+FilledTextFields/UnitTests',
     'TextControls+FilledTextFieldsTheming/UnitTests',
+    'TextControls+OutlinedTextAreas/UnitTests',
+    'TextControls+OutlinedTextAreasTheming/UnitTests',
     'TextControls+OutlinedTextFields/UnitTests',
     'TextControls+OutlinedTextFieldsTheming/UnitTests',
     'Themes/UnitTests',

--- a/components/TextControls/BUILD
+++ b/components/TextControls/BUILD
@@ -95,6 +95,22 @@ mdc_extension_objc_library(
 )
 
 mdc_extension_objc_library(
+    name = "OutlinedTextAreas",
+    deps = [
+        ":BaseTextAreas",
+        "//components/private/TextControlsPrivate:OutlinedStyle",
+    ],
+)
+
+mdc_extension_objc_library(
+    name = "OutlinedTextAreasTheming",
+    deps = [
+        ":OutlinedTextAreas",
+        "//components/schemes/Container",
+    ],
+)
+
+mdc_extension_objc_library(
     name = "OutlinedTextFields",
     deps = [
         ":BaseTextFields",
@@ -147,8 +163,11 @@ mdc_unit_test_objc_library(
         ":BaseTextFieldsPrivate",
         ":FilledTextFields",
         ":FilledTextFieldsTheming",
+        ":OutlinedTextAreas",
+        ":OutlinedTextAreasTheming",
         ":OutlinedTextFields",
         ":OutlinedTextFieldsTheming",
+        "//components/Availability",
     ],
 )
 

--- a/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.h
+++ b/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.h
@@ -1,0 +1,36 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCBaseTextArea.h"
+
+/**
+ An implementation of a Material outlined text area.
+ */
+__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextArea : MDCBaseTextArea
+
+/**
+ Sets the outline color for a given state.
+ @param outlineColor The UIColor for the given state.
+ @param state The MDCTextControlState.
+ */
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state;
+/**
+ Returns the outline color for a given state.
+ @param state The MDCTextControlState.
+ */
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state;
+
+@end

--- a/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.h
+++ b/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.h
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.m
+++ b/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #import "MDCOutlinedTextArea.h"
-
-#import <Foundation/Foundation.h>
 
 #import "MaterialTextControlsPrivate+OutlinedStyle.h"
 #import "MaterialTextControlsPrivate+Shared.h"
@@ -44,8 +42,7 @@
 }
 
 - (void)commonMDCOutlinedTextAreaInit {
-  MDCTextControlStyleOutlined *outlinedStyle = [[MDCTextControlStyleOutlined alloc] init];
-  self.containerStyle = outlinedStyle;
+  self.containerStyle = [[MDCTextControlStyleOutlined alloc] init];
 }
 
 #pragma mark Stateful Color APIs

--- a/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.m
+++ b/components/TextControls/src/OutlinedTextAreas/MDCOutlinedTextArea.m
@@ -1,0 +1,70 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextArea.h"
+
+#import <Foundation/Foundation.h>
+
+#import "MaterialTextControlsPrivate+OutlinedStyle.h"
+#import "MaterialTextControlsPrivate+Shared.h"
+
+@interface MDCOutlinedTextArea (Private) <MDCTextControl>
+@end
+
+@interface MDCOutlinedTextArea ()
+@end
+
+@implementation MDCOutlinedTextArea
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self commonMDCOutlinedTextAreaInit];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self) {
+    [self commonMDCOutlinedTextAreaInit];
+  }
+  return self;
+}
+
+- (void)commonMDCOutlinedTextAreaInit {
+  MDCTextControlStyleOutlined *outlinedStyle = [[MDCTextControlStyleOutlined alloc] init];
+  self.containerStyle = outlinedStyle;
+}
+
+#pragma mark Stateful Color APIs
+
+- (void)setOutlineColor:(nonnull UIColor *)outlineColor forState:(MDCTextControlState)state {
+  [self.outlinedStyle setOutlineColor:outlineColor forState:state];
+  [self setNeedsLayout];
+}
+
+- (nonnull UIColor *)outlineColorForState:(MDCTextControlState)state {
+  return [self.outlinedStyle outlineColorForState:state];
+}
+
+- (MDCTextControlStyleOutlined *)outlinedStyle {
+  MDCTextControlStyleOutlined *outlinedStyle = nil;
+  if ([self.containerStyle isKindOfClass:[MDCTextControlStyleOutlined class]]) {
+    outlinedStyle = (MDCTextControlStyleOutlined *)self.containerStyle;
+  }
+  return outlinedStyle;
+}
+
+@end

--- a/components/TextControls/src/OutlinedTextAreas/MaterialTextControls+OutlinedTextAreas.h
+++ b/components/TextControls/src/OutlinedTextAreas/MaterialTextControls+OutlinedTextAreas.h
@@ -1,0 +1,15 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextArea.h"

--- a/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.h
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.h
@@ -1,0 +1,40 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MDCOutlinedTextArea.h"
+#import "MaterialContainerScheme.h"
+
+/**
+ This category is used to style MDCOutlinedTextArea instances with an MDCContainerScheme.
+ */
+@interface MDCOutlinedTextArea (MaterialTheming)
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+/**
+ Applies a container scheme's subsystem-specific schemes to the receiver in a manner best suited to
+ convey an error state.
+
+ @param scheme A container scheme instance.
+ */
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)scheme;
+
+@end

--- a/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.h
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.h
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.m
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.m
@@ -1,0 +1,160 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextArea+MaterialTheming.h"
+
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kOutlineColorNormalOpacity = (CGFloat)0.38;
+
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+
+@implementation MDCOutlinedTextArea (MaterialTheming)
+
+- (void)applyThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyDefaultColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyErrorThemeWithScheme:(nonnull id<MDCContainerScheming>)containerScheme {
+  [self applyTypographyScheme:containerScheme.typographyScheme];
+  [self applyErrorColorScheme:containerScheme.colorScheme];
+}
+
+- (void)applyTypographyScheme:(id<MDCTypographyScheming>)mdcTypographyScheming {
+  self.textView.font = mdcTypographyScheming.subtitle1;
+  self.leadingAssistiveLabel.font = mdcTypographyScheming.caption;
+  self.trailingAssistiveLabel.font = mdcTypographyScheming.caption;
+}
+
+- (void)applyDefaultColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
+  UIColor *floatingLabelColorEditing =
+      [colorScheme.primaryColor colorWithAlphaComponent:kFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *outlineColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlineColorNormalOpacity];
+  UIColor *outlineColorEditing = colorScheme.primaryColor;
+  UIColor *outlineColorDisabled =
+      [outlineColorNormal colorWithAlphaComponent:kOutlineColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *tintColor = colorScheme.primaryColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [self setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [self setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+  self.tintColor = tintColor;
+}
+
+- (void)applyErrorColorScheme:(id<MDCColorScheming>)colorScheme {
+  UIColor *textColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = colorScheme.errorColor;
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = colorScheme.errorColor;
+  UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *outlineColorNormal = colorScheme.errorColor;
+  UIColor *outlineColorEditing = outlineColorNormal;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *tintColor = colorScheme.errorColor;
+
+  [self setFloatingLabelColor:floatingLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setFloatingLabelColor:floatingLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setFloatingLabelColor:floatingLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setNormalLabelColor:normalLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setNormalLabelColor:normalLabelColorEditing forState:MDCTextControlStateEditing];
+  [self setNormalLabelColor:normalLabelColorDisabled forState:MDCTextControlStateDisabled];
+  [self setTextColor:textColorNormal forState:MDCTextControlStateNormal];
+  [self setTextColor:textColorEditing forState:MDCTextControlStateEditing];
+  [self setTextColor:textColorDisabled forState:MDCTextControlStateDisabled];
+  [self setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [self setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [self setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorNormal forState:MDCTextControlStateNormal];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorEditing
+                             forState:MDCTextControlStateEditing];
+  [self setLeadingAssistiveLabelColor:assistiveLabelColorDisabled
+                             forState:MDCTextControlStateDisabled];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorNormal
+                              forState:MDCTextControlStateNormal];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorEditing
+                              forState:MDCTextControlStateEditing];
+  [self setTrailingAssistiveLabelColor:assistiveLabelColorDisabled
+                              forState:MDCTextControlStateDisabled];
+  self.tintColor = tintColor;
+}
+
+@end

--- a/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.m
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MDCOutlinedTextArea+MaterialTheming.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/TextControls/src/OutlinedTextAreasTheming/MaterialTextControls+OutlinedTextAreasTheming.h
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MaterialTextControls+OutlinedTextAreasTheming.h
@@ -1,0 +1,15 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MDCOutlinedTextArea+MaterialTheming.h"

--- a/components/TextControls/src/OutlinedTextAreasTheming/MaterialTextControls+OutlinedTextAreasTheming.h
+++ b/components/TextControls/src/OutlinedTextAreasTheming/MaterialTextControls+OutlinedTextAreasTheming.h
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@
 
 - (void)testOutlineColorDefaults {
   // Given
-  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
-  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] initWithFrame:textAreaFrame];
+  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] init];
   UIColor *defaultOutlineColor = UIColor.blackColor;
 #if MDC_AVAILABLE_SDK_IOS(13_0)
   if (@available(iOS 13.0, *)) {
@@ -46,8 +45,7 @@
 
 - (void)testOutlineColorAccessors {
   // Given
-  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
-  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] initWithFrame:textAreaFrame];
+  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] init];
   UIColor *outlineColorNormal = [UIColor blueColor];
   UIColor *outlineColorEditing = [UIColor greenColor];
   UIColor *outlineColorDisabled = [UIColor purpleColor];

--- a/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
@@ -15,19 +15,19 @@
 #import <XCTest/XCTest.h>
 
 #import "MaterialAvailability.h"
-#import "MaterialTextControls+OutlinedTextFields.h"
+#import "MaterialTextControls+OutlinedTextAreas.h"
 
-@interface MDCOutlinedTextFieldTests : XCTestCase
+@interface MDCOutlinedTextAreaTests : XCTestCase
 @end
 
-@implementation MDCOutlinedTextFieldTests
+@implementation MDCOutlinedTextAreaTests
 
 #pragma mark Tests
 
 - (void)testOutlineColorDefaults {
   // Given
-  CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);
-  MDCOutlinedTextField *textField = [[MDCOutlinedTextField alloc] initWithFrame:textFieldFrame];
+  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
+  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] initWithFrame:textAreaFrame];
   UIColor *defaultOutlineColor = UIColor.blackColor;
 #if MDC_AVAILABLE_SDK_IOS(13_0)
   if (@available(iOS 13.0, *)) {
@@ -37,32 +37,32 @@
 
   // Then
   XCTAssertEqualObjects(defaultOutlineColor,
-                        [textField outlineColorForState:MDCTextControlStateNormal]);
+                        [textArea outlineColorForState:MDCTextControlStateNormal]);
   XCTAssertEqualObjects(defaultOutlineColor,
-                        [textField outlineColorForState:MDCTextControlStateEditing]);
+                        [textArea outlineColorForState:MDCTextControlStateEditing]);
   XCTAssertEqualObjects([defaultOutlineColor colorWithAlphaComponent:(CGFloat)0.60],
-                        [textField outlineColorForState:MDCTextControlStateDisabled]);
+                        [textArea outlineColorForState:MDCTextControlStateDisabled]);
 }
 
 - (void)testOutlineColorAccessors {
   // Given
-  CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);
-  MDCOutlinedTextField *textField = [[MDCOutlinedTextField alloc] initWithFrame:textFieldFrame];
+  CGRect textAreaFrame = CGRectMake(0, 0, 130, 40);
+  MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] initWithFrame:textAreaFrame];
   UIColor *outlineColorNormal = [UIColor blueColor];
   UIColor *outlineColorEditing = [UIColor greenColor];
   UIColor *outlineColorDisabled = [UIColor purpleColor];
 
   // When
-  [textField setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
-  [textField setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
-  [textField setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
+  [textArea setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];
+  [textArea setOutlineColor:outlineColorEditing forState:MDCTextControlStateEditing];
+  [textArea setOutlineColor:outlineColorDisabled forState:MDCTextControlStateDisabled];
   // Then
   XCTAssertEqualObjects(outlineColorNormal,
-                        [textField outlineColorForState:MDCTextControlStateNormal]);
+                        [textArea outlineColorForState:MDCTextControlStateNormal]);
   XCTAssertEqualObjects(outlineColorEditing,
-                        [textField outlineColorForState:MDCTextControlStateEditing]);
+                        [textArea outlineColorForState:MDCTextControlStateEditing]);
   XCTAssertEqualObjects(outlineColorDisabled,
-                        [textField outlineColorForState:MDCTextControlStateDisabled]);
+                        [textArea outlineColorForState:MDCTextControlStateDisabled]);
 }
 
 @end

--- a/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextAreas/MDCOutlinedTextAreaTests.m
@@ -46,9 +46,9 @@
 - (void)testOutlineColorAccessors {
   // Given
   MDCOutlinedTextArea *textArea = [[MDCOutlinedTextArea alloc] init];
-  UIColor *outlineColorNormal = [UIColor blueColor];
-  UIColor *outlineColorEditing = [UIColor greenColor];
-  UIColor *outlineColorDisabled = [UIColor purpleColor];
+  UIColor *outlineColorNormal = UIColor.blueColor;
+  UIColor *outlineColorEditing = UIColor.greenColor;
+  UIColor *outlineColorDisabled = UIColor.purpleColor;
 
   // When
   [textArea setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];

--- a/components/TextControls/tests/unit/OutlinedTextAreasTheming/MDCOutlinedTextAreaThemingTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextAreasTheming/MDCOutlinedTextAreaThemingTests.m
@@ -1,0 +1,309 @@
+// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "MaterialContainerScheme.h"
+#import "MaterialTextControls+OutlinedTextAreasTheming.h"
+
+static const CGFloat kDisabledOpacity = (CGFloat)0.60;
+
+static const CGFloat kTextColorNormalOpacity = (CGFloat)0.87;
+static const CGFloat kFloatingLabelColorEditingOpacity = (CGFloat)0.87;
+static const CGFloat kNormalLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kOutlineColorNormalOpacity = (CGFloat)0.38;
+
+static const CGFloat kPrimaryFloatingLabelColorNormalOpacity = (CGFloat)0.60;
+static const CGFloat kPrimaryAssistiveLabelColorNormalOpacity = (CGFloat)0.60;
+
+@interface MDCOutlinedTextAreaThemingTest : XCTestCase
+@property(nonatomic, strong) MDCOutlinedTextArea *textArea;
+@property(nonatomic, strong) MDCSemanticColorScheme *colorScheme;
+@property(nonatomic, strong) MDCTypographyScheme *typographyScheme;
+@property(nonatomic, strong) MDCContainerScheme *containerScheme;
+@end
+
+@implementation MDCOutlinedTextAreaThemingTest
+
+- (void)setUp {
+  [super setUp];
+
+  self.textArea = [[MDCOutlinedTextArea alloc] init];
+  self.colorScheme =
+      [[MDCSemanticColorScheme alloc] initWithDefaults:MDCColorSchemeDefaultsMaterial201907];
+  self.typographyScheme =
+      [[MDCTypographyScheme alloc] initWithDefaults:MDCTypographySchemeDefaultsMaterial201902];
+  self.containerScheme = [[MDCContainerScheme alloc] init];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+}
+
+- (void)tearDown {
+  self.textArea = nil;
+  self.colorScheme = nil;
+  self.typographyScheme = nil;
+  self.containerScheme = nil;
+
+  [super tearDown];
+}
+
+- (void)testTextAreaPrimaryThemingDefault {
+  // When
+  [self.textArea applyThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaPrimaryTheming];
+}
+
+- (void)testTextAreaPrimaryThemingCustom {
+  // Given
+  self.colorScheme = [self customColorScheme];
+  self.typographyScheme = [self customTypographyScheme];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+
+  // When
+  [self.textArea applyThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaPrimaryTheming];
+}
+
+- (void)testTextAreaErrorThemingDefault {
+  // When
+  [self.textArea applyErrorThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaErrorTheming];
+}
+
+- (void)testTextAreaErrorThemingCustom {
+  // Given
+  self.colorScheme = [self customColorScheme];
+  self.typographyScheme = [self customTypographyScheme];
+  self.containerScheme.colorScheme = self.colorScheme;
+  self.containerScheme.typographyScheme = self.typographyScheme;
+
+  // When
+  [self.textArea applyErrorThemeWithScheme:self.containerScheme];
+
+  // Then
+  [self verifyTextAreaErrorTheming];
+}
+
+#pragma mark - Test helpers
+
+- (MDCSemanticColorScheme *)customColorScheme {
+  MDCSemanticColorScheme *colorScheme = [[MDCSemanticColorScheme alloc] init];
+
+  colorScheme.primaryColor = [UIColor colorWithWhite:(CGFloat)0.9 alpha:0];
+  colorScheme.primaryColorVariant = [UIColor colorWithWhite:(CGFloat)0.8 alpha:(CGFloat)0.1];
+  colorScheme.secondaryColor = [UIColor colorWithWhite:(CGFloat)0.7 alpha:(CGFloat)0.2];
+  colorScheme.errorColor = [UIColor colorWithWhite:(CGFloat)0.6 alpha:(CGFloat)0.3];
+  colorScheme.surfaceColor = [UIColor colorWithWhite:(CGFloat)0.5 alpha:(CGFloat)0.4];
+  colorScheme.backgroundColor = [UIColor colorWithWhite:(CGFloat)0.4 alpha:(CGFloat)0.5];
+  colorScheme.onPrimaryColor = [UIColor colorWithWhite:(CGFloat)0.3 alpha:(CGFloat)0.6];
+  colorScheme.onSecondaryColor = [UIColor colorWithWhite:(CGFloat)0.2 alpha:(CGFloat)0.7];
+  colorScheme.onSurfaceColor = [UIColor colorWithWhite:(CGFloat)0.1 alpha:(CGFloat)0.8];
+  colorScheme.onBackgroundColor = [UIColor colorWithWhite:0 alpha:(CGFloat)0.9];
+
+  return colorScheme;
+}
+
+- (MDCTypographyScheme *)customTypographyScheme {
+  MDCTypographyScheme *typographyScheme = [[MDCTypographyScheme alloc] init];
+
+  typographyScheme.headline1 = [UIFont systemFontOfSize:1];
+  typographyScheme.headline2 = [UIFont systemFontOfSize:2];
+  typographyScheme.headline3 = [UIFont systemFontOfSize:3];
+  typographyScheme.headline4 = [UIFont systemFontOfSize:4];
+  typographyScheme.headline5 = [UIFont systemFontOfSize:5];
+  typographyScheme.headline6 = [UIFont systemFontOfSize:6];
+  typographyScheme.subtitle1 = [UIFont systemFontOfSize:7];
+  typographyScheme.subtitle2 = [UIFont systemFontOfSize:8];
+  typographyScheme.body1 = [UIFont systemFontOfSize:9];
+  typographyScheme.body2 = [UIFont systemFontOfSize:10];
+  typographyScheme.caption = [UIFont systemFontOfSize:11];
+  typographyScheme.button = [UIFont systemFontOfSize:12];
+  typographyScheme.overline = [UIFont systemFontOfSize:13];
+
+  return typographyScheme;
+}
+
+- (void)verifyTextAreaPrimaryTheming {
+  // Color
+  UIColor *textColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity];
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled = [assistiveLabelColorNormal
+      colorWithAlphaComponent:kPrimaryAssistiveLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = [self.colorScheme.onSurfaceColor
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity];
+  UIColor *floatingLabelColorEditing =
+      [self.colorScheme.primaryColor colorWithAlphaComponent:kFloatingLabelColorEditingOpacity];
+  UIColor *floatingLabelColorDisabled = [floatingLabelColorNormal
+      colorWithAlphaComponent:kPrimaryFloatingLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *outlineColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kOutlineColorNormalOpacity];
+  UIColor *outlineColorEditing = self.colorScheme.primaryColor;
+  UIColor *outlineColorDisabled =
+      [outlineColorNormal colorWithAlphaComponent:kOutlineColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *tintColor = self.colorScheme.primaryColor;
+
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateNormal],
+                        floatingLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateEditing],
+                        floatingLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateDisabled],
+                        floatingLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateNormal],
+                        normalLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateEditing],
+                        normalLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateDisabled],
+                        normalLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateNormal],
+                        textColorNormal);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateEditing],
+                        textColorEditing);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateDisabled],
+                        textColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateNormal],
+                        outlineColorNormal);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateEditing],
+                        outlineColorEditing);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateDisabled],
+                        outlineColorDisabled);
+  XCTAssertEqualObjects(self.textArea.tintColor, tintColor);
+
+  // Typography
+  XCTAssertEqualObjects(self.textArea.textView.font, self.typographyScheme.subtitle1);
+  XCTAssertEqualObjects(self.textArea.leadingAssistiveLabel.font, self.typographyScheme.caption);
+  XCTAssertEqualObjects(self.textArea.trailingAssistiveLabel.font, self.typographyScheme.caption);
+}
+
+- (void)verifyTextAreaErrorTheming {
+  // Color
+  UIColor *textColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kTextColorNormalOpacity];
+  UIColor *textColorEditing = textColorNormal;
+  UIColor *textColorDisabled =
+      [textColorNormal colorWithAlphaComponent:kTextColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *assistiveLabelColorNormal = self.colorScheme.errorColor;
+  UIColor *assistiveLabelColorEditing = assistiveLabelColorNormal;
+  UIColor *assistiveLabelColorDisabled =
+      [assistiveLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *floatingLabelColorNormal = self.colorScheme.errorColor;
+  UIColor *floatingLabelColorEditing = floatingLabelColorNormal;
+  UIColor *floatingLabelColorDisabled =
+      [floatingLabelColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *normalLabelColorNormal =
+      [self.colorScheme.onSurfaceColor colorWithAlphaComponent:kNormalLabelColorNormalOpacity];
+  UIColor *normalLabelColorEditing = normalLabelColorNormal;
+  UIColor *normalLabelColorDisabled = [normalLabelColorNormal
+      colorWithAlphaComponent:kNormalLabelColorNormalOpacity * kDisabledOpacity];
+
+  UIColor *outlineColorNormal = self.colorScheme.errorColor;
+  UIColor *outlineColorEditing = outlineColorNormal;
+  UIColor *outlineColorDisabled = [outlineColorNormal colorWithAlphaComponent:kDisabledOpacity];
+
+  UIColor *tintColor = self.colorScheme.errorColor;
+
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateNormal],
+                        floatingLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateEditing],
+                        floatingLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea floatingLabelColorForState:MDCTextControlStateDisabled],
+                        floatingLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateNormal],
+                        normalLabelColorNormal);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateEditing],
+                        normalLabelColorEditing);
+  XCTAssertEqualObjects([self.textArea normalLabelColorForState:MDCTextControlStateDisabled],
+                        normalLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateNormal],
+                        textColorNormal);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateEditing],
+                        textColorEditing);
+  XCTAssertEqualObjects([self.textArea textColorForState:MDCTextControlStateDisabled],
+                        textColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea leadingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateNormal],
+      assistiveLabelColorNormal);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateEditing],
+      assistiveLabelColorEditing);
+  XCTAssertEqualObjects(
+      [self.textArea trailingAssistiveLabelColorForState:MDCTextControlStateDisabled],
+      assistiveLabelColorDisabled);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateNormal],
+                        outlineColorNormal);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateEditing],
+                        outlineColorEditing);
+  XCTAssertEqualObjects([self.textArea outlineColorForState:MDCTextControlStateDisabled],
+                        outlineColorDisabled);
+  XCTAssertEqualObjects(self.textArea.tintColor, tintColor);
+
+  // Typography
+  XCTAssertEqualObjects(self.textArea.textView.font, self.typographyScheme.subtitle1);
+  XCTAssertEqualObjects(self.textArea.leadingAssistiveLabel.font, self.typographyScheme.caption);
+  XCTAssertEqualObjects(self.textArea.trailingAssistiveLabel.font, self.typographyScheme.caption);
+}
+
+@end

--- a/components/TextControls/tests/unit/OutlinedTextAreasTheming/MDCOutlinedTextAreaThemingTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextAreasTheming/MDCOutlinedTextAreaThemingTests.m
@@ -1,4 +1,4 @@
-// Copyright 2019-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/components/TextControls/tests/unit/OutlinedTextFields/MDCOutlinedTextFieldTests.m
+++ b/components/TextControls/tests/unit/OutlinedTextFields/MDCOutlinedTextFieldTests.m
@@ -48,9 +48,9 @@
   // Given
   CGRect textFieldFrame = CGRectMake(0, 0, 130, 40);
   MDCOutlinedTextField *textField = [[MDCOutlinedTextField alloc] initWithFrame:textFieldFrame];
-  UIColor *outlineColorNormal = [UIColor blueColor];
-  UIColor *outlineColorEditing = [UIColor greenColor];
-  UIColor *outlineColorDisabled = [UIColor purpleColor];
+  UIColor *outlineColorNormal = UIColor.blueColor;
+  UIColor *outlineColorEditing = UIColor.greenColor;
+  UIColor *outlineColorDisabled = UIColor.purpleColor;
 
   // When
   [textField setOutlineColor:outlineColorNormal forState:MDCTextControlStateNormal];


### PR DESCRIPTION
This PR adds the TextControl outlined text areas, as well as their theming extensions, and a bunch of unit tests. Snapshot tests to follow.

Related to #9407.

