### PR TITLE
[FlexibleHeader] Subtract minimumHeaderViewHeight from fhv_accumulatorMax.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -748,7 +748,8 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
   CGFloat statusBarHeight = [UIApplication mdc_safeSharedApplication].statusBarFrame.size.height;
   return (shouldCollapseToStatusBar
               ? MAX(0, self.minMaxHeight.minimumHeightWithTopSafeArea - statusBarHeight)
-              : self.minMaxHeight.minimumHeightWithTopSafeArea);
+              : self.minMaxHeight.minimumHeightWithTopSafeArea) -
+         self.minimumHeaderViewHeight;
 }
 
 #pragma mark Logical short forms

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderShiftedOffscreenWithShiftBehaviorHideableTests.m
@@ -61,6 +61,19 @@
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
 }
 
+- (void)testCanBeShiftedOffScreenWithMinimumHeaderViewHeight {
+  // Given
+  self.fhvc.minimumHeaderViewHeight = 32.0;
+
+  // When
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame),
+                             -self.fhvc.maximumHeight + self.fhvc.minimumHeaderViewHeight, 0.001);
+}
+
 - (void)testStaysShiftedOffScreenWhenScrolledUpByHeaderHeight {
   // Given
   [self.fhvc shiftHeaderOffScreenAnimated:NO];
@@ -72,6 +85,21 @@
   // Then
   XCTAssertTrue(self.fhvc.isShiftedOffscreen);
   XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame), -self.fhvc.maximumHeight, 0.001);
+}
+
+- (void)testStaysShiftedOffScreenWhenScrolledUpByHeaderHeightWithMinimumHeaderViewHeight {
+  // Given
+  self.fhvc.minimumHeaderViewHeight = 32.0;
+  [self.fhvc shiftHeaderOffScreenAnimated:NO];
+
+  // When
+  self.scrollView.contentOffset = CGPointMake(0, self.fhvc.maximumHeight);
+  [self.fhvc trackingScrollViewDidScroll];
+
+  // Then
+  XCTAssertTrue(self.fhvc.isShiftedOffscreen);
+  XCTAssertEqualWithAccuracy(CGRectGetMinY(self.fhvc.frame),
+                             -self.fhvc.maximumHeight + self.fhvc.minimumHeaderViewHeight, 0.001);
 }
 
 - (void)testDoesNotShiftBackOnScreenWhenDragged {


### PR DESCRIPTION
Problem statement: Attached banner on MDCFlexibleHeaderView are not intractable. Gestures on attached banner are not received, but rather goes through to view underneath the MDCFlexibleHeaderView.
Cause and Fix: MDCFlexibleHeaderView, after shifted to the top, with minimumHeaderViewHeight enabled, is shorter than intended. This was because fhv_accumulatorMax did not take minimumHeaderViewHeight into calculation. This corrects header view height after shifting.

Tested in cl/296232605.