### PR TITLE
[Dialogs] Add orderVerticalActionsByEmphasis flag

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -56,6 +56,17 @@
 @property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
 
 /**
+ This enables ordering actions by emphasis when they are vertically aligned.
+ When set to @c YES, horizontally trailing actions, which typically have higher
+ emphasis, will be displayed on top when presented vertically (for instance, in
+ the portrait orientation on smaller devices). When set to @c NO, the higher
+ emphasis actions will be displayed on the bottom.
+
+ Default value is @c NO.
+*/
+@property(nonatomic, assign) BOOL orderVerticalActionsByEmphasis;
+
+/**
  Whether adjustable insets mode is enabled for the dialog view. If set to @c
  YES, a new layout calculation that is customizable by the insets in this header
  file is used to layout the dialog. If set to @c NO, we fall back to the legacy

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -61,6 +61,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.autoresizesSubviews = NO;
     self.clipsToBounds = YES;
 
+    self.orderVerticalActionsByEmphasis = NO;
     self.enableAdjustableInsets = NO;
     self.titleIconInsets = UIEdgeInsetsMake(24.f, 24.f, 12.f, 24.f);
     self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);
@@ -766,7 +767,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   if (self.isVerticalActionsLayout) {
     CGPoint buttonCenter;
     buttonCenter.x = self.actionsScrollView.contentSize.width / 2.0f;
-    buttonCenter.y = self.actionsScrollView.contentSize.height - actionsInsets.bottom;
+    buttonCenter.y = self.orderVerticalActionsByEmphasis
+                         ? actionsInsets.bottom
+                         : self.actionsScrollView.contentSize.height - actionsInsets.bottom;
+    CGFloat multiplier = self.orderVerticalActionsByEmphasis ? 1.f : -1.f;
     CGFloat maxButtonWidth =
         self.actionsScrollView.contentSize.width - (actionsInsets.left + actionsInsets.right);
     for (UIButton *button in buttons) {
@@ -777,13 +781,15 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         button.bounds = buttonRect;
       }
 
-      buttonCenter.y -= buttonRect.size.height / 2.0f;
+      buttonCenter.y += multiplier * (buttonRect.size.height / 2.0f);
 
       button.center = buttonCenter;
 
       if (button != buttons.lastObject) {
-        buttonCenter.y -= buttonRect.size.height / 2.0f;
-        buttonCenter.y -= MDCDialogActionsVerticalPadding;
+        buttonCenter.y += multiplier * (buttonRect.size.height / 2.0f);
+        buttonCenter.y +=
+            multiplier * (self.enableAdjustableInsets ? self.actionsVerticalMargin
+                                                      : MDCDialogActionsVerticalPadding);
       }
     }
   } else {


### PR DESCRIPTION
# Description

The orderVerticalActionsByEmphasis flag enables ordering of actions by emphasis when they are horizontally or vertically aligned. When set to NO (default, old behavior), actions that are added first are displayed first on the right (in LTR) in horizontal alignment, and on
 the top in vertical alignment. When set to NO, horizontal alignment stays the same, however in the vertical alignment, actions that were added first are displayed at the bottom.

Default to NO to maintain backward compatibility.

## Issue
b/148802180, cl/296661619