### PR TITLE
[Dialogs] Group UIViewController methods of MDCAlertController.

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -492,6 +492,96 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, announcement);
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+  [super viewDidAppear:animated];
+
+  [self.alertView.titleScrollView flashScrollIndicators];
+  [self.alertView.contentScrollView flashScrollIndicators];
+  [self.alertView.actionsScrollView flashScrollIndicators];
+}
+
+- (void)viewDidLayoutSubviews {
+  // Recalculate preferredContentSize and potentially the view frame.
+  BOOL boundsSizeChanged =
+      !CGSizeEqualToSize(CGRectStandardize(self.view.bounds).size, _previousLayoutSize);
+
+  // UIContentSizeCategoryAdjusting behavior only updates fonts after -viewWillLayoutSubviews and
+  // before -viewDidLayoutSubviews. Because `preferredContentSize` may have changed as a result,
+  // it is necessary to check if it changed here and possibly require a second layout pass.
+  CGSize currentPreferredContentSize = self.preferredContentSize;
+  CGSize calculatedPreferredContentSize = [self.alertView
+      calculatePreferredContentSizeForBounds:CGRectStandardize(self.alertView.bounds).size];
+  BOOL preferredContentSizeChanged =
+      !CGSizeEqualToSize(currentPreferredContentSize, calculatedPreferredContentSize);
+  if (preferredContentSizeChanged) {
+    // NOTE: Setting the preferredContentSize can lead to a change to self.view.bounds.
+    self.preferredContentSize = calculatedPreferredContentSize;
+  }
+
+  if (preferredContentSizeChanged || boundsSizeChanged) {
+    _previousLayoutSize = CGRectStandardize(self.alertView.bounds).size;
+    [self.view setNeedsLayout];
+    [self.view layoutIfNeeded];
+  }
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+
+  // Recalculate preferredSize, which is based on width available, if the viewSize has changed.
+  if (CGRectGetWidth(self.view.bounds) != _previousLayoutSize.width ||
+      CGRectGetHeight(self.view.bounds) != _previousLayoutSize.height) {
+    CGSize currentPreferredContentSize = self.preferredContentSize;
+    CGSize contentSize = CGRectStandardize(self.alertView.bounds).size;
+    CGSize calculatedPreferredContentSize =
+        [self.alertView calculatePreferredContentSizeForBounds:contentSize];
+
+    if (!CGSizeEqualToSize(currentPreferredContentSize, calculatedPreferredContentSize)) {
+      // NOTE: Setting the preferredContentSize can lead to a change to self.view.bounds.
+      self.preferredContentSize = calculatedPreferredContentSize;
+    }
+
+    _previousLayoutSize = CGRectStandardize(self.alertView.bounds).size;
+  }
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+  [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+  [coordinator
+      animateAlongsideTransition:^(
+          __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+        // Reset preferredContentSize on viewWIllTransition to take advantage of additional width
+        self.preferredContentSize =
+            [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
+      }
+                      completion:nil];
+}
+
+#pragma mark - Resource bundle
+
++ (NSBundle *)bundle {
+  static NSBundle *bundle = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    bundle = [NSBundle bundleWithPath:[self bundlePathWithName:kMaterialDialogsBundle]];
+  });
+
+  return bundle;
+}
+
++ (NSString *)bundlePathWithName:(NSString *)bundleName {
+  // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
+  // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
+  // and use that as the search location.
+  NSBundle *bundle = [NSBundle bundleForClass:[MDCAlertController class]];
+  NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
+  return [resourcePath stringByAppendingPathComponent:bundleName];
+}
+
+#pragma mark - Setup Alert View
+
 - (void)setupAlertView {
   self.alertView.titleLabel.text = self.title;
   if (@available(iOS 10.0, *)) {
@@ -540,94 +630,6 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   if (self.mdc_adjustsFontForContentSizeCategory) {
     self.alertView.mdc_adjustsFontForContentSizeCategory = YES;
   }
-}
-
-- (void)viewDidLayoutSubviews {
-  // Recalculate preferredContentSize and potentially the view frame.
-  BOOL boundsSizeChanged =
-      !CGSizeEqualToSize(CGRectStandardize(self.view.bounds).size, _previousLayoutSize);
-
-  // UIContentSizeCategoryAdjusting behavior only updates fonts after -viewWillLayoutSubviews and
-  // before -viewDidLayoutSubviews. Because `preferredContentSize` may have changed as a result,
-  // it is necessary to check if it changed here and possibly require a second layout pass.
-  CGSize currentPreferredContentSize = self.preferredContentSize;
-  CGSize calculatedPreferredContentSize = [self.alertView
-      calculatePreferredContentSizeForBounds:CGRectStandardize(self.alertView.bounds).size];
-  BOOL preferredContentSizeChanged =
-      !CGSizeEqualToSize(currentPreferredContentSize, calculatedPreferredContentSize);
-  if (preferredContentSizeChanged) {
-    // NOTE: Setting the preferredContentSize can lead to a change to self.view.bounds.
-    self.preferredContentSize = calculatedPreferredContentSize;
-  }
-
-  if (preferredContentSizeChanged || boundsSizeChanged) {
-    _previousLayoutSize = CGRectStandardize(self.alertView.bounds).size;
-    [self.view setNeedsLayout];
-    [self.view layoutIfNeeded];
-  }
-}
-
-#pragma mark - Resource bundle
-
-+ (NSBundle *)bundle {
-  static NSBundle *bundle = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    bundle = [NSBundle bundleWithPath:[self bundlePathWithName:kMaterialDialogsBundle]];
-  });
-
-  return bundle;
-}
-
-+ (NSString *)bundlePathWithName:(NSString *)bundleName {
-  // In iOS 8+, we could be included by way of a dynamic framework, and our resource bundles may
-  // not be in the main .app bundle, but rather in a nested framework, so figure out where we live
-  // and use that as the search location.
-  NSBundle *bundle = [NSBundle bundleForClass:[MDCAlertController class]];
-  NSString *resourcePath = [(nil == bundle ? [NSBundle mainBundle] : bundle) resourcePath];
-  return [resourcePath stringByAppendingPathComponent:bundleName];
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-
-  // Recalculate preferredSize, which is based on width available, if the viewSize has changed.
-  if (CGRectGetWidth(self.view.bounds) != _previousLayoutSize.width ||
-      CGRectGetHeight(self.view.bounds) != _previousLayoutSize.height) {
-    CGSize currentPreferredContentSize = self.preferredContentSize;
-    CGSize contentSize = CGRectStandardize(self.alertView.bounds).size;
-    CGSize calculatedPreferredContentSize =
-        [self.alertView calculatePreferredContentSizeForBounds:contentSize];
-
-    if (!CGSizeEqualToSize(currentPreferredContentSize, calculatedPreferredContentSize)) {
-      // NOTE: Setting the preferredContentSize can lead to a change to self.view.bounds.
-      self.preferredContentSize = calculatedPreferredContentSize;
-    }
-
-    _previousLayoutSize = CGRectStandardize(self.alertView.bounds).size;
-  }
-}
-
-- (void)viewWillTransitionToSize:(CGSize)size
-       withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
-  [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-
-  [coordinator
-      animateAlongsideTransition:^(
-          __unused id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
-        // Reset preferredContentSize on viewWIllTransition to take advantage of additional width
-        self.preferredContentSize =
-            [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
-      }
-                      completion:nil];
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-  [super viewDidAppear:animated];
-
-  [self.alertView.titleScrollView flashScrollIndicators];
-  [self.alertView.contentScrollView flashScrollIndicators];
-  [self.alertView.actionsScrollView flashScrollIndicators];
 }
 
 #pragma mark - UIAccessibilityAction


### PR DESCRIPTION
# Description
Refactoring MDCAlertController to group UIViewController methods. 
Moving related methods near each other. No logic changes.

## Issue

cl/296042619
