### PR TITLE
[BottomSheet] Add example to reproduce issue 9773

### DIFF
--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -83,6 +83,7 @@ mdc_examples_swift_library(
         ":BottomSheet",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
+        "//components/Buttons:Theming",
         "//components/schemes/Container",
     ],
 )

--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -83,6 +83,7 @@ mdc_examples_swift_library(
         ":BottomSheet",
         "//components/Buttons",
         "//components/Buttons:ButtonThemer",
+        "//components/schemes/Container",
     ],
 )
 

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -15,6 +15,7 @@
 import Foundation
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialContainerScheme
 
 class BottomSheetFirstResponderExample: UIViewController {

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -59,7 +59,7 @@ class BottomSheetFirstResponderExample: UIViewController {
   }
 
   @objc func didTapButton() {
-    let menu = BottomSheetDummyCollectionViewController(numItems: 6)!
+    let menu = BottomSheetUIControl()
     let bottomSheet = MDCBottomSheetController(contentViewController: menu)
     present(bottomSheet, animated: true)
   }

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -1,0 +1,77 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import MaterialComponents.MaterialBottomSheet
+import MaterialComponents.MaterialButtons
+import MaterialComponents.MaterialContainerScheme
+
+class BottomSheetFirstResponderExample: UIViewController {
+  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  let textField: UITextField = {
+    let textField = UITextField()
+    textField.backgroundColor = UIColor.blue.withAlphaComponent(0.3)
+    return textField
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = containerScheme.colorScheme.backgroundColor
+
+    let button = MDCButton()
+    button.setTitle("Show bottom sheet", for: .normal)
+    button.addTarget(self,
+                     action: #selector(BottomSheetFirstResponderExample.didTapButton),
+                     for: .touchUpInside)
+
+    button.applyContainedTheme(withScheme: containerScheme)
+
+    button.sizeToFit()
+    button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
+    button.autoresizingMask = [
+      .flexibleLeftMargin,
+      .flexibleTopMargin,
+      .flexibleRightMargin,
+      .flexibleBottomMargin
+    ]
+
+    textField.frame = CGRect(x: 100, y: 200, width: 200, height: 50)
+
+    view.addSubview(button)
+    view.addSubview(textField)
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    textField.becomeFirstResponder()
+  }
+
+  @objc func didTapButton() {
+    let menu = BottomSheetDummyCollectionViewController(numItems: 6)!
+    let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+    present(bottomSheet, animated: true)
+  }
+}
+
+// MARK: Catalog by Convention
+extension BottomSheetFirstResponderExample {
+  @objc class func catalogMetadata() -> [String: Any] {
+    return [
+      "breadcrumbs": ["Bottom Sheet", "Over Focused Text Field (Swift)"],
+      "primaryDemo": false,
+      "presentable": false,
+    ]
+  }
+}

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -19,6 +19,25 @@ import MaterialComponents.MaterialContainerScheme
 
 class BottomSheetFirstResponderExample: UIViewController {
   @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+
+  let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 8
+    return stackView
+  }()
+
+  let issueDescriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    label.text = """
+    With VoiceOver on, the focused text field steals focus back from the bottom sheet
+    if resignFirstResponder is not called.
+    """
+    label.textColor = .black
+    return label
+  }()
+
   let textField: UITextField = {
     let textField = UITextField()
     textField.backgroundColor = UIColor.blue.withAlphaComponent(0.3)
@@ -37,20 +56,19 @@ class BottomSheetFirstResponderExample: UIViewController {
                      for: .touchUpInside)
 
     button.applyContainedTheme(withScheme: containerScheme)
-
     button.sizeToFit()
-    button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
-    button.autoresizingMask = [
-      .flexibleLeftMargin,
-      .flexibleTopMargin,
-      .flexibleRightMargin,
-      .flexibleBottomMargin
-    ]
 
-    textField.frame = CGRect(x: 100, y: 200, width: 200, height: 50)
+    contentStackView.addArrangedSubview(issueDescriptionLabel)
+    contentStackView.addArrangedSubview(textField)
+    contentStackView.addArrangedSubview(button)
 
-    view.addSubview(button)
-    view.addSubview(textField)
+    contentStackView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(contentStackView)
+    contentStackView.leadingAnchor
+        .constraint(equalTo: view.leadingAnchor, constant: 10).isActive = true
+    contentStackView.trailingAnchor
+        .constraint(equalTo: view.trailingAnchor, constant: -10).isActive = true
+    contentStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
   }
 
   override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
A reproduction of an issue found internally. To reproduce:

1. Navigate to this example
1. Turn VoiceOver on
1. Tap the button to display the bottom sheet

Expected behavior:
The bottom sheet becomes focused

Actual behavior:
The text field behind the bottom sheet reclaims focus after the bottom sheet finishes presenting

Reproduces #9773