### PR TITLE
[TextFields] implement resignFirstResponder in MDCMultilineTextField

### DIFF
--- a/components/BottomSheet/BUILD
+++ b/components/BottomSheet/BUILD
@@ -85,6 +85,7 @@ mdc_examples_swift_library(
         "//components/Buttons:ButtonThemer",
         "//components/Buttons:Theming",
         "//components/schemes/Container",
+        "//components/TextFields",
     ],
 )
 

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -17,6 +17,7 @@ import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialContainerScheme
+import MaterialComponents.MaterialTextFields
 
 class BottomSheetFirstResponderExample: UIViewController {
   @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
@@ -39,8 +40,8 @@ class BottomSheetFirstResponderExample: UIViewController {
     return label
   }()
 
-  let textField: UITextField = {
-    let textField = UITextField()
+  let textField: MDCMultilineTextField = {
+    let textField = MDCMultilineTextField()
     textField.backgroundColor = UIColor.blue.withAlphaComponent(0.3)
     return textField
   }()
@@ -80,6 +81,7 @@ class BottomSheetFirstResponderExample: UIViewController {
   @objc func didTapButton() {
     let menu = BottomSheetUIControl()
     let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+    textField.resignFirstResponder()
     present(bottomSheet, animated: true)
   }
 }

--- a/components/TextFields/src/MDCMultilineTextField.m
+++ b/components/TextFields/src/MDCMultilineTextField.m
@@ -180,6 +180,10 @@ static NSString *const kAccessibilityLocalizationStringsTableName = @"MaterialTe
   return self.textView.isFirstResponder;
 }
 
+- (BOOL)resignFirstResponder {
+  return [self.textView resignFirstResponder];
+}
+
 #pragma mark - TextView Implementation
 
 - (void)setupTextView {


### PR DESCRIPTION
Implements `resignFirstResponder` to forward calls to `resignFirstResponder` to MDCMultilineTextField's underlying textView. `becomeFirstResponder` and `isFirstResponder` are already both implemented as wrappers around the state of the internal textView.

Fixes #9773