### PR TITLE
[Dialogs] Adding action alignment API in a private header.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -34,6 +34,57 @@
 /** The scroll view that holds all of the buttons created for each action. */
 @property(nonatomic, nonnull, strong) UIScrollView *actionsScrollView;
 
+/** Content alignment for Alert actions. */
+typedef NS_ENUM(NSInteger, MDCContentHorizontalAlignment) {
+  /** Actions are centered. */
+  MDCContentHorizontalAlignmentCenter = 0,
+  /** Actions are left aligned in LTR and right aligned in RTL.  */
+  MDCContentHorizontalAlignmentLeading = 1,
+  /** Actions are right aligned in LTR and left aligned in RTL.  */
+  MDCContentHorizontalAlignmentTrailing = 2,
+  /**
+   Actions fill the entire width of the alert (minus the insets). If more than one action is
+   presented, equal width is applied to all actions so they fill the space evenly.
+   */
+  MDCContentHorizontalAlignmentJustified = 3
+};
+
+/**
+ The alert actions alignment in horizontal layout.  This property controls both alignment and order
+ of the actions in the horizontal layout.  Actions that are added first, are presented first based
+ on the alignment: when alignment is trailing, the first action is presented on the trailing side
+ (right in LTR). For all other alignments, the action added first is presented on the
+ leading side (left in LTR).
+
+ Default value is @c MDCContentAlignmentTrailing.
+ */
+@property(nonatomic, assign) MDCContentHorizontalAlignment actionsHorizontalAlignment;
+
+/**
+ The horizontal alignment of the alert's actions when in vertical layout. When not enough
+ horizontal space is available to present all actions, actions will layout vertically. That may
+ happen in the portrait orientation on smaller devices. Actions may have centered, leading,
+ trailing or filled alignment. In filled alignment, all actions
+ will be as wide as the alert (minus insets).
+
+ @note: Actions that are added first will be displayed on the bottom, unless overriden by
+        orderVerticalActionsByEmphasis.
+
+ Default value is @c MDCContentAlignmentCenter.
+ */
+@property(nonatomic, assign)
+    MDCContentHorizontalAlignment actionsHorizontalAlignmentInVerticalLayout;
+
+/**
+ Enables ordering actions by emphasis when they are vertically aligned.
+ When set to @c YES, horizontally trailing actions, which typically have higher emphasis, will be
+ displayed on top when presented vertically (for instance, in the portrait orientation on smaller
+ devices). When set to @c NO, the higher emphasis actions will be displayed on the bottom.
+
+ Default value is @c NO.
+*/
+@property(nonatomic, assign) BOOL orderVerticalActionsByEmphasis;
+
 - (void)addActionButton:(nonnull MDCButton *)button;
 + (void)styleAsTextButton:(nonnull MDCButton *)button;
 
@@ -54,17 +105,6 @@
  Default value is @c YES.
  */
 @property(nonatomic, assign) BOOL adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable;
-
-/**
- This enables ordering actions by emphasis when they are vertically aligned.
- When set to @c YES, horizontally trailing actions, which typically have higher
- emphasis, will be displayed on top when presented vertically (for instance, in
- the portrait orientation on smaller devices). When set to @c NO, the higher
- emphasis actions will be displayed on the bottom.
-
- Default value is @c NO.
-*/
-@property(nonatomic, assign) BOOL orderVerticalActionsByEmphasis;
 
 /**
  Whether adjustable insets mode is enabled for the dialog view. If set to @c

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -62,6 +62,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.clipsToBounds = YES;
 
     self.orderVerticalActionsByEmphasis = NO;
+    self.actionsHorizontalAlignment = MDCContentHorizontalAlignmentTrailing;
+    self.actionsHorizontalAlignmentInVerticalLayout = MDCContentHorizontalAlignmentCenter;
+
     self.enableAdjustableInsets = NO;
     self.titleIconInsets = UIEdgeInsetsMake(24.f, 24.f, 12.f, 24.f);
     self.titleInsets = UIEdgeInsetsMake(24.f, 24.f, 20.f, 24.f);


### PR DESCRIPTION
# Description

Adding action alignment API in a private header. API includes alignment for actions in both the horizontal and vertical layouts. Note that in both layouts, the alignment is horizontal (center, leading, trailing, etc.).

Inspiration for the content enum and values is from Apple's UIControlContentHorizontalAlignmen enum. We will not use that API, however, mainly because the leading/trailing values in Apple's API are only supported in iOS 11 or above.

## Issue
b/122654717, cl/296667130.
