### PR TITLE
[Chips] Add snapshot tests for MDCChipCollectionViewFlowLayout

### DIFF
--- a/components/Chips/tests/snapshot/MDCChipCollectionViewFlowLayoutSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipCollectionViewFlowLayoutSnapshotTests.m
@@ -31,7 +31,6 @@
   MDCChipCollectionViewCell *cell =
       [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
   cell.chipView.titleLabel.text = [NSString stringWithFormat:@"Chip %@", @(indexPath.row)];
-  cell.chipView.backgroundColor = [UIColor redColor];
   return cell;
 }
 

--- a/components/Chips/tests/snapshot/MDCChipCollectionViewFlowLayoutSnapshotTests.m
+++ b/components/Chips/tests/snapshot/MDCChipCollectionViewFlowLayoutSnapshotTests.m
@@ -1,0 +1,98 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "MaterialSnapshot.h"
+
+#import "MaterialChips.h"
+
+@interface DummyCollectionViewDataSource : NSObject <UICollectionViewDataSource>
+@end
+
+@implementation DummyCollectionViewDataSource
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView
+     numberOfItemsInSection:(NSInteger)section {
+  return 5;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+  MDCChipCollectionViewCell *cell =
+      [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
+  cell.chipView.titleLabel.text = [NSString stringWithFormat:@"Chip %@", @(indexPath.row)];
+  cell.chipView.backgroundColor = [UIColor redColor];
+  return cell;
+}
+
+@end
+
+@interface MDCChipCollectionViewFlowLayoutSnapshotTests : MDCSnapshotTestCase
+/** The collection view being tested. */
+@property(nonatomic, strong) UICollectionView *collectionView;
+
+/** The collection view layout being tested */
+@property(nonatomic, strong) MDCChipCollectionViewFlowLayout *collectionViewLayout;
+
+/** A simple data source for the collection view that vends a fixed number of dummy cells */
+@property(nonatomic, strong) DummyCollectionViewDataSource *dataSource;
+@end
+
+@implementation MDCChipCollectionViewFlowLayoutSnapshotTests
+
+- (void)setUp {
+  [super setUp];
+
+  // Uncomment below to recreate all the goldens (or add the following line to the specific
+  // test you wish to recreate the golden for).
+  // self.recordMode = YES;
+
+  self.collectionViewLayout = [[MDCChipCollectionViewFlowLayout alloc] init];
+  self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)
+                                           collectionViewLayout:self.collectionViewLayout];
+  self.collectionView.backgroundColor = [UIColor whiteColor];
+  [self.collectionView registerClass:[MDCChipCollectionViewCell class]
+          forCellWithReuseIdentifier:@"Cell"];
+
+  MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
+  self.collectionViewLayout.estimatedItemSize = [cell intrinsicContentSize];
+  self.dataSource = [[DummyCollectionViewDataSource alloc] init];
+  self.collectionView.dataSource = self.dataSource;
+}
+
+- (void)tearDown {
+  self.collectionView = nil;
+  self.collectionViewLayout = nil;
+  self.dataSource = nil;
+
+  [super tearDown];
+}
+
+- (void)testWithDefaultConfiguration {
+  // Then
+  [self generateSnapshotAndVerifyForView:self.collectionView];
+}
+
+- (void)testRespectsSectionInsets {
+  // When
+  self.collectionViewLayout.sectionInset = UIEdgeInsetsMake(20, 20, 0, 20);
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.collectionView];
+}
+
+- (void)generateSnapshotAndVerifyForView:(UIView *)view {
+  UIView *snapshotView = [view mdc_addToBackgroundView];
+  [self snapshotVerifyView:snapshotView];
+}
+@end

--- a/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47455c226b764adbd633b74b0111bfbae08424eddeefe830f48920e908089b52
+size 18660

--- a/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testWithDefaultConfiguration_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testWithDefaultConfiguration_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dc847634c16104acd9aa01a0f5dd03d6f4f6cd6e84b123e3d9e60868ebc0106
+size 17567


### PR DESCRIPTION
Add two simple snapshot tests for MDCChipCollectionViewFlowLayout. The first snapshot test verifies the default behavior of the layout, and the second exposes a bug where MDCChipCollectionViewFlowLayout does not respect the horizontal components of the sectionInset property.

Exposes the issue reported in #7597