### PR TITLE
[Chips] Add support for sectionInset to MDCChipCollectionViewFlowLayout

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -18,10 +18,8 @@
 @implementation MDCChipCollectionViewFlowLayout
 
 - (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
-  NSArray<UICollectionViewLayoutAttributes *> *layoutAttributes =
-      [super layoutAttributesForElementsInRect:rect];
-
-  NSMutableArray<UICollectionViewLayoutAttributes *> *customLayoutAttributes =
+  NSArray *layoutAttributes = [super layoutAttributesForElementsInRect:rect];
+  NSMutableArray *customLayoutAttributes =
       [NSMutableArray arrayWithCapacity:layoutAttributes.count];
 
   UICollectionViewLayoutAttributes *prevAttrs;
@@ -41,7 +39,7 @@
                        CGRectGetMinY(frame), CGRectGetWidth(frame), CGRectGetHeight(frame));
       }
 
-      prevAttrs = attrs;
+      prevAttrs = newAttrs;
     }
 
     [customLayoutAttributes addObject:newAttrs];

--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -16,8 +16,8 @@
 #import "MDCChipCollectionViewFlowLayout.h"
 
 @implementation MDCChipCollectionViewFlowLayout
-- (nullable NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:
-    (CGRect)rect {
+
+- (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
   NSArray<UICollectionViewLayoutAttributes *> *layoutAttributes =
       [super layoutAttributesForElementsInRect:rect];
 
@@ -29,30 +29,25 @@
     UICollectionViewLayoutAttributes *newAttrs = [attrs copy];
 
     if (newAttrs.representedElementCategory == UICollectionElementCategoryCell) {
-      prevAttrs = [self alignNewAttributes:newAttrs toPreviousAttributes:prevAttrs];
+      CGRect frame = newAttrs.frame;
+
+      // If previous value is nil or the two arguments are on different lines, then left align
+      if (prevAttrs == nil || (CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
+        newAttrs.frame = CGRectMake(self.sectionInset.left, CGRectGetMinY(frame),
+                                    CGRectGetWidth(frame), CGRectGetHeight(frame));
+      } else {
+        newAttrs.frame =
+            CGRectMake(CGRectGetMaxX(prevAttrs.frame) + self.minimumInteritemSpacing,
+                       CGRectGetMinY(frame), CGRectGetWidth(frame), CGRectGetHeight(frame));
+      }
+
+      prevAttrs = attrs;
     }
 
     [customLayoutAttributes addObject:newAttrs];
   }
 
   return [customLayoutAttributes copy];
-}
-
-- (UICollectionViewLayoutAttributes *)alignNewAttributes:(UICollectionViewLayoutAttributes *)attrs
-                                    toPreviousAttributes:
-                                        (UICollectionViewLayoutAttributes *)prevAttrs {
-  CGRect frame = attrs.frame;
-
-  // If previous value is nil or the two arguments are on different lines, then left align
-  if (prevAttrs == nil || (CGRectGetMinY(attrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
-    attrs.frame = CGRectMake(self.sectionInset.left, CGRectGetMinY(frame), CGRectGetWidth(frame),
-                             CGRectGetHeight(frame));
-  } else {
-    attrs.frame = CGRectMake(CGRectGetMaxX(prevAttrs.frame) + self.minimumInteritemSpacing,
-                             CGRectGetMinY(frame), CGRectGetWidth(frame), CGRectGetHeight(frame));
-  }
-
-  return attrs;
 }
 
 - (BOOL)flipsHorizontallyInOppositeLayoutDirection {

--- a/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47455c226b764adbd633b74b0111bfbae08424eddeefe830f48920e908089b52
-size 18660
+oid sha256:781ef29e9ae26204f8b95ceb38099055bb3497cb380de2cf7127d401809e3db0
+size 18821


### PR DESCRIPTION
Updates MDCChipCollectionViewFlowLayout's `layoutAttributesForElementsInRect:` to respect the `sectionInset` property.

Fixes #7597