### PR TITLE
[Chips] Refactor MDCChipCollectionViewFlowLayout

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -32,10 +32,14 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
   NSMutableArray *customLayoutAttributes =
       [NSMutableArray arrayWithCapacity:layoutAttributes.count];
 
+  // Left-align cells
   UICollectionViewLayoutAttributes *prevAttrs;
   for (UICollectionViewLayoutAttributes *attrs in layoutAttributes) {
     UICollectionViewLayoutAttributes *newAttrs = [attrs copy];
     if (newAttrs.representedElementCategory == UICollectionElementCategoryCell) {
+      // If the attributes are for a cell that isn't on the same line as the previous cell, set the
+      // x origin of the frame to 0. Otherwise, align the frame to the right end of the previous
+      // frame (accounting for minimumInteritemSpacing).
       if (!prevAttrs || (CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
         newAttrs.frame = CGRectLeftAlign(newAttrs.frame);
       } else {

--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -39,7 +39,8 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
       if (!prevAttrs || (CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
         newAttrs.frame = CGRectLeftAlign(newAttrs.frame);
       } else {
-        newAttrs.frame = CGRectLeftAlignToRect(newAttrs.frame, prevAttrs.frame, self.minimumInteritemSpacing);
+        newAttrs.frame =
+            CGRectLeftAlignToRect(newAttrs.frame, prevAttrs.frame, self.minimumInteritemSpacing);
       }
 
       prevAttrs = newAttrs;

--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -40,7 +40,8 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
       // If the attributes are for a cell that isn't on the same line as the previous cell, set the
       // x origin of the frame to 0. Otherwise, align the frame to the right end of the previous
       // frame (accounting for minimumInteritemSpacing).
-      if (!prevAttrs || (CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
+      BOOL isNewLine = CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame);
+      if (!prevAttrs || isNewLine) {
         newAttrs.frame = CGRectLeftAlign(newAttrs.frame);
       } else {
         newAttrs.frame =

--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -32,23 +32,19 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
   NSMutableArray *customLayoutAttributes =
       [NSMutableArray arrayWithCapacity:layoutAttributes.count];
 
-  if (layoutAttributes.count > 0) {
-    UICollectionViewLayoutAttributes *attrs = [layoutAttributes[0] copy];
-    attrs.frame = CGRectLeftAlign(attrs.frame);
-    [customLayoutAttributes addObject:attrs];
-  }
+  UICollectionViewLayoutAttributes *prevAttrs;
+  for (UICollectionViewLayoutAttributes *attrs in layoutAttributes) {
+    UICollectionViewLayoutAttributes *newAttrs = [attrs copy];
+    if (newAttrs.representedElementCategory == UICollectionElementCategoryCell) {
+      if (!prevAttrs || (CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame))) {
+        newAttrs.frame = CGRectLeftAlign(newAttrs.frame);
+      } else {
+        newAttrs.frame = CGRectLeftAlignToRect(newAttrs.frame, prevAttrs.frame, self.minimumInteritemSpacing);
+      }
 
-  for (NSUInteger i = 1; i < layoutAttributes.count; i++) {
-    UICollectionViewLayoutAttributes *attrs = [layoutAttributes[i] copy];
-    UICollectionViewLayoutAttributes *prevAttrs = customLayoutAttributes[i - 1];
-
-    if (CGRectGetMinY(prevAttrs.frame) == CGRectGetMinY(attrs.frame)) {
-      attrs.frame =
-          CGRectLeftAlignToRect(attrs.frame, prevAttrs.frame, self.minimumInteritemSpacing);
-    } else {
-      attrs.frame = CGRectLeftAlign(attrs.frame);
+      prevAttrs = newAttrs;
     }
-    [customLayoutAttributes addObject:attrs];
+    [customLayoutAttributes addObject:newAttrs];
   }
 
   return [customLayoutAttributes copy];


### PR DESCRIPTION
Cleans up MDCChipCollectionViewFlowLayout's implementation of `layoutAttributesForElementsInRect:`

Prework for #7597, will be followed by https://github.com/bryanoltman/material-components-ios/pull/1