### PR TITLE
[Dialogs] Moving actions layout out to simplify layoutSubviews.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -672,23 +672,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
-
-  for (MDCButton *button in buttons) {
-    [button sizeToFit];
-    CGRect buttonFrame = button.frame;
-    buttonFrame.size.width = MAX(CGRectGetWidth(buttonFrame), MDCDialogActionButtonMinimumWidth);
-    buttonFrame.size.height = MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonMinimumHeight);
-    button.frame = buttonFrame;
-    CGFloat verticalInsets = (CGRectGetHeight(button.frame) - MDCDialogActionMinTouchTarget) / 2.0f;
-    CGFloat horizontalInsets =
-        (CGRectGetWidth(button.frame) - MDCDialogActionMinTouchTarget) / 2.0f;
-    verticalInsets = MIN(0.0f, verticalInsets);
-    horizontalInsets = MIN(0.0f, horizontalInsets);
-    button.hitAreaInsets =
-        UIEdgeInsetsMake(verticalInsets, horizontalInsets, verticalInsets, horizontalInsets);
-  }
-
   // Used to calculate the height of the scrolling content, so we limit the width.
   CGSize boundsSize = CGRectInfinite.size;
   boundsSize.width = CGRectGetWidth(self.bounds);
@@ -757,7 +740,23 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   self.accessoryView.frame = accessoryViewFrame;
 
   // Actions
-  [self layoutButtons:buttons inBoundsSize:boundsSize];
+  NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
+  CGSize actionSize = [self calculateActionsSizeThatFitsWidth:boundsSize.width];
+
+  CGRect actionsFrame = CGRectZero;
+  actionsFrame.size.width = CGRectGetWidth(self.bounds);
+  if (buttons.count > 0) {
+    actionsFrame.size.height = actionSize.height;
+  }
+  self.actionsScrollView.contentSize = actionsFrame.size;
+
+  [self setHitAreaForButtons:buttons];
+
+  if (self.isVerticalActionsLayout) {
+    [self layoutVerticalButtons:buttons];
+  } else {
+    [self layoutHorizontalButtons:buttons];
+  }
 
   // Place scrollviews
   CGRect contentScrollViewRect = CGRectZero;
@@ -790,71 +789,73 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   self.contentScrollView.frame = contentScrollViewRect;
 }
 
-- (void)layoutButtons:(NSArray<MDCButton *> *)buttons inBoundsSize:(CGSize)boundsSize {
-  CGSize actionSize = [self calculateActionsSizeThatFitsWidth:boundsSize.width];
-
-  CGRect actionsFrame = CGRectZero;
-  actionsFrame.size.width = CGRectGetWidth(self.bounds);
-  if (0 < buttons.count) {
-    actionsFrame.size.height = actionSize.height;
+- (void)setHitAreaForButtons:(NSArray<MDCButton *> *)buttons {
+  for (MDCButton *button in buttons) {
+    [button sizeToFit];
+    CGRect buttonFrame = button.frame;
+    buttonFrame.size.width = MAX(CGRectGetWidth(buttonFrame), MDCDialogActionButtonMinimumWidth);
+    buttonFrame.size.height = MAX(CGRectGetHeight(buttonFrame), MDCDialogActionButtonMinimumHeight);
+    button.frame = buttonFrame;
+    CGFloat verticalInsets = (CGRectGetHeight(button.frame) - MDCDialogActionMinTouchTarget) / 2.0f;
+    CGFloat horizontalInsets =
+        (CGRectGetWidth(button.frame) - MDCDialogActionMinTouchTarget) / 2.0f;
+    verticalInsets = MIN(0.0f, verticalInsets);
+    horizontalInsets = MIN(0.0f, horizontalInsets);
+    button.hitAreaInsets =
+        UIEdgeInsetsMake(verticalInsets, horizontalInsets, verticalInsets, horizontalInsets);
   }
-  self.actionsScrollView.contentSize = actionsFrame.size;
+}
+
+- (void)layoutHorizontalButtons:(NSArray<MDCButton *> *)buttons {
   UIEdgeInsets actionsInsets =
       self.enableAdjustableInsets ? self.actionsInsets : MDCDialogActionsInsets;
+  CGPoint buttonOrigin = CGPointZero;
+  buttonOrigin.x = self.actionsScrollView.contentSize.width - actionsInsets.right;
+  buttonOrigin.y = actionsInsets.top;
+  for (UIButton *button in buttons) {
+    CGRect buttonRect = button.frame;
 
-  // Place buttons in actionsScrollView
-  if (self.isVerticalActionsLayout) {
-    CGPoint buttonCenter;
-    buttonCenter.x = self.actionsScrollView.contentSize.width / 2.0f;
-    buttonCenter.y = self.orderVerticalActionsByEmphasis
-                         ? actionsInsets.bottom
-                         : self.actionsScrollView.contentSize.height - actionsInsets.bottom;
-    CGFloat multiplier = self.orderVerticalActionsByEmphasis ? 1.f : -1.f;
-    CGFloat maxButtonWidth =
-        self.actionsScrollView.contentSize.width - (actionsInsets.left + actionsInsets.right);
-    for (UIButton *button in buttons) {
-      CGRect buttonRect = button.bounds;
+    buttonOrigin.x -= buttonRect.size.width;
+    buttonRect.origin = buttonOrigin;
 
-      if (CGRectGetWidth(buttonRect) > maxButtonWidth) {
-        buttonRect.size.width = maxButtonWidth;
-        button.bounds = buttonRect;
-      }
+    button.frame = buttonRect;
 
-      buttonCenter.y += multiplier * (buttonRect.size.height / 2.0f);
-
-      button.center = buttonCenter;
-
-      if (button != buttons.lastObject) {
-        buttonCenter.y += multiplier * (buttonRect.size.height / 2.0f);
-        buttonCenter.y +=
-            multiplier * (self.enableAdjustableInsets ? self.actionsVerticalMargin
-                                                      : MDCDialogActionsVerticalPadding);
-      }
+    if (button != buttons.lastObject) {
+      buttonOrigin.x -= MDCDialogActionsHorizontalPadding;
     }
-  } else {
-    CGPoint buttonOrigin = CGPointZero;
-    buttonOrigin.x = self.actionsScrollView.contentSize.width - actionsInsets.right;
-    buttonOrigin.y = actionsInsets.top;
+  }
+  // Handle RTL
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
     for (UIButton *button in buttons) {
-      CGRect buttonRect = button.frame;
-
-      buttonOrigin.x -= buttonRect.size.width;
-      buttonRect.origin = buttonOrigin;
-
-      button.frame = buttonRect;
-
-      if (button != buttons.lastObject) {
-        buttonOrigin.x -= self.enableAdjustableInsets ? self.actionsHorizontalMargin
-                                                      : MDCDialogActionsHorizontalPadding;
-      }
+      CGRect flippedRect = MDFRectFlippedHorizontally(button.frame, CGRectGetWidth(self.bounds));
+      button.frame = flippedRect;
     }
-    // Handle RTL
-    if (self.mdf_effectiveUserInterfaceLayoutDirection ==
-        UIUserInterfaceLayoutDirectionRightToLeft) {
-      for (UIButton *button in buttons) {
-        CGRect flippedRect = MDFRectFlippedHorizontally(button.frame, CGRectGetWidth(self.bounds));
-        button.frame = flippedRect;
-      }
+  }
+}
+
+- (void)layoutVerticalButtons:(NSArray<MDCButton *> *)buttons {
+  UIEdgeInsets actionsInsets =
+      self.enableAdjustableInsets ? self.actionsInsets : MDCDialogActionsInsets;
+  CGPoint buttonCenter;
+  buttonCenter.x = self.actionsScrollView.contentSize.width / 2.0f;
+  buttonCenter.y = self.actionsScrollView.contentSize.height - actionsInsets.bottom;
+  CGFloat maxButtonWidth =
+      self.actionsScrollView.contentSize.width - (actionsInsets.left + actionsInsets.right);
+  for (UIButton *button in buttons) {
+    CGRect buttonRect = button.bounds;
+
+    if (CGRectGetWidth(buttonRect) > maxButtonWidth) {
+      buttonRect.size.width = maxButtonWidth;
+      button.bounds = buttonRect;
+    }
+
+    buttonCenter.y -= buttonRect.size.height / 2.0f;
+
+    button.center = buttonCenter;
+
+    if (button != buttons.lastObject) {
+      buttonCenter.y -= buttonRect.size.height / 2.0f;
+      buttonCenter.y -= MDCDialogActionsVerticalPadding;
     }
   }
 }


### PR DESCRIPTION
# Description

Further simplifying layoutSubviews by refactoring all actions layout calculations into separate methods. No logic changes.

## Issue
b/122654717, cl/297333235 
