### PR TITLE
[Dialogs] Remove DialogThemer from Podspec

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -763,7 +763,6 @@ Pod::Spec.new do |mdc|
         "components/#{component.base_name}/tests/unit/supplemental/*.{h,m,swift}"
       ]
       unit_tests.resources = "components/#{component.base_name}/tests/unit/resources/*"
-      unit_tests.dependency "MaterialComponents/Dialogs+DialogThemer"
     end
   end
 
@@ -793,21 +792,6 @@ Pod::Spec.new do |mdc|
     extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
     extension.dependency "MaterialComponents/schemes/Typography"
     extension.dependency "MaterialComponents/Buttons+TypographyThemer"
-  end
-
-  mdc.subspec "Dialogs+DialogThemer" do |extension|
-    extension.ios.deployment_target = '9.0'
-    extension.public_header_files = [
-      "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.h"
-    ]
-    extension.source_files = [
-      "components/#{extension.base_name.split('+')[0]}/src/#{extension.base_name.split('+')[1]}/*.{h,m}"
-    ]
-
-    extension.dependency "MaterialComponents/#{extension.base_name.split('+')[0]}"
-    extension.dependency "MaterialComponents/Dialogs+ColorThemer"
-    extension.dependency "MaterialComponents/Dialogs+TypographyThemer"
-    extension.dependency "MaterialComponents/Buttons+ButtonThemer"
   end
 
   mdc.subspec "Dialogs+Theming" do |extension|


### PR DESCRIPTION
In #9776 we removed the DialogThemer but did not remove it from the CocoaPods `podspec` file. This causes pod validation to fail rather than reverting #9776 we should remove this target from the `podspec`.


