### PR TITLE
[Chips] Update MDCChipCollectionViewFlowLayout to respect sectionInset

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -15,16 +15,6 @@
 
 #import "MDCChipCollectionViewFlowLayout.h"
 
-/* Left aligns one rect to another with a given padding */
-static inline CGRect CGRectLeftAlignToRect(CGRect rect, CGRect staticRect, CGFloat padding) {
-  return CGRectMake(CGRectGetMaxX(staticRect) + padding, CGRectGetMinY(rect), CGRectGetWidth(rect),
-                    CGRectGetHeight(rect));
-}
-
-static inline CGRect CGRectLeftAlign(CGRect rect) {
-  return CGRectMake(0, CGRectGetMinY(rect), CGRectGetWidth(rect), CGRectGetHeight(rect));
-}
-
 @implementation MDCChipCollectionViewFlowLayout
 
 - (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
@@ -40,14 +30,14 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
       // If the attributes are for a cell that isn't on the same line as the previous cell, set the
       // x origin of the frame to 0. Otherwise, align the frame to the right end of the previous
       // frame (accounting for minimumInteritemSpacing).
+      CGRect frame = newAttrs.frame;
       BOOL isNewLine = CGRectGetMinY(newAttrs.frame) != CGRectGetMinY(prevAttrs.frame);
       if (!prevAttrs || isNewLine) {
-        newAttrs.frame = CGRectLeftAlign(newAttrs.frame);
+        frame.origin.x = self.sectionInset.left;
       } else {
-        newAttrs.frame =
-            CGRectLeftAlignToRect(newAttrs.frame, prevAttrs.frame, self.minimumInteritemSpacing);
+        frame.origin.x = CGRectGetMaxX(prevAttrs.frame) + self.minimumInteritemSpacing;
       }
-
+      newAttrs.frame = frame;
       prevAttrs = newAttrs;
     }
     [customLayoutAttributes addObject:newAttrs];

--- a/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipCollectionViewFlowLayoutSnapshotTests/testRespectsSectionInsets_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47455c226b764adbd633b74b0111bfbae08424eddeefe830f48920e908089b52
-size 18660
+oid sha256:781ef29e9ae26204f8b95ceb38099055bb3497cb380de2cf7127d401809e3db0
+size 18821


### PR DESCRIPTION
Use `sectionInset.left` as the x origin for MDCChipCollectionViewFlowLayout rows. The snapshot test affected by this change sets `collectionViewLayout.sectionInset = UIEdgeInsetsMake(20, 20, 0, 20)`.

Fixes #7597