### PR TITLE
[Snackbar] Add 'snackbarDidDisappear' to MDCSnackbarManagerDelegate.

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.h
+++ b/components/Snackbar/src/MDCSnackbarManager.h
@@ -35,6 +35,13 @@
  */
 - (void)willPresentSnackbarWithMessageView:(nullable MDCSnackbarMessageView *)messageView;
 
+@optional
+
+/**
+ This method is called after a Snackbar's dismissal animation is finished.
+ */
+- (void)snackbarDidDisappear;
+
 @end
 
 /**

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -299,28 +299,33 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                                                                  completion:nil];
                      }];
 
-  [self.overlayView dismissSnackbarViewAnimated:YES
-                                     completion:^{
-                                       self.overlayView.hidden = YES;
-                                       [self deactivateOverlay:self.overlayView];
+  [self.overlayView
+      dismissSnackbarViewAnimated:YES
+                       completion:^{
+                         self.overlayView.hidden = YES;
+                         [self deactivateOverlay:self.overlayView];
 
-                                       // If the snackbarView was transient and
-                                       // accessibilityViewIsModal is NO, the Snackbar was just
-                                       // announced (layout was not reported as changed) so there is
-                                       // no need to post a layout change here.
-                                       if (self.overlayView.accessibilityViewIsModal ||
-                                           ![self isSnackbarTransient:snackbarView]) {
-                                         UIAccessibilityPostNotification(
-                                             UIAccessibilityLayoutChangedNotification, nil);
-                                       }
+                         // If the snackbarView was transient and
+                         // accessibilityViewIsModal is NO, the Snackbar was just
+                         // announced (layout was not reported as changed) so there is
+                         // no need to post a layout change here.
+                         if (self.overlayView.accessibilityViewIsModal ||
+                             ![self isSnackbarTransient:snackbarView]) {
+                           UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                                           nil);
+                         }
 
-                                       self.currentSnackbar = nil;
+                         self.currentSnackbar = nil;
 
-                                       // Now that the snackbarView is offscreen, we can allow more
-                                       // messages to be shown.
-                                       self.showingMessage = NO;
-                                       [self showNextMessageIfNecessaryMainThread];
-                                     }];
+                         if ([self.delegate respondsToSelector:@selector(snackbarDidDisappear)]) {
+                           [self.delegate snackbarDidDisappear];
+                         }
+
+                         // Now that the snackbarView is offscreen, we can allow more
+                         // messages to be shown.
+                         self.showingMessage = NO;
+                         [self showNextMessageIfNecessaryMainThread];
+                       }];
 }
 
 #pragma mark - Helper methods

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -535,4 +535,16 @@
   XCTAssertNotNil(self.manager.internalManager.currentSnackbar);
 }
 
+- (void)testSnackbarDidDisappearDelegateCalled {
+  // Given
+  const CGFloat kSnackbarDuration = 0.1;
+  self.message.duration = kSnackbarDuration;
+  // When
+  [self.manager showMessage:self.message];
+  self.delegate.disappearExpectation = [self expectationWithDescription:@"disappeared"];
+  // Then
+  // Expect 'snackbarDidDisappear' delegate method to be called.
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+}
+
 @end

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -537,7 +537,7 @@
 
 - (void)testSnackbarDidDisappearDelegateCalled {
   // Given
-  const CGFloat kSnackbarDuration = 0.1;
+  const CGFloat kSnackbarDuration = (CGFloat)0.1;
   self.message.duration = kSnackbarDuration;
   // When
   [self.manager showMessage:self.message];

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.h
@@ -20,6 +20,7 @@
 
 @property(nonatomic, strong) MDCSnackbarMessageView *presentedView;
 @property(nonatomic, assign) BOOL shouldSetSnackbarViewAccessibilityViewIsModal;
+@property(nonatomic, assign) XCTestExpectation *disappearExpectation;
 
 - (void)willPresentSnackbarWithMessageView:(MDCSnackbarMessageView *)messageView;
 

--- a/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
+++ b/components/Snackbar/tests/unit/supplemental/MDCFakeMDCSnackbarManagerDelegate.m
@@ -23,4 +23,8 @@
   }
 }
 
+- (void)snackbarDidDisappear {
+  [self.disappearExpectation fulfill];
+}
+
 @end


### PR DESCRIPTION
[Snackbar] Add 'snackbarDidDisappear' to MDCSnackbarManagerDelegate.

If you made changes to accommodate the snackbar, this lets you un-make them after the snackbar disappears (rather than when it starts disappearing).
