### PR TITLE
[Chips] MDCChipCollectionViewCell to correctly support increased touch target

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -99,6 +99,11 @@
   return view;
 }
 
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+  CGRect hitAreaRect = UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), _chipView.hitAreaInsets);
+  return CGRectContainsPoint(hitAreaRect, point);
+}
+
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
   if (self.chipView.enableRippleBehavior) {
     // This method needs to be invoked before the super.

--- a/components/Chips/src/MDCChipCollectionViewCell.m
+++ b/components/Chips/src/MDCChipCollectionViewCell.m
@@ -100,7 +100,8 @@
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  CGRect hitAreaRect = UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), _chipView.hitAreaInsets);
+  CGRect hitAreaRect =
+      UIEdgeInsetsInsetRect(CGRectStandardize(self.bounds), _chipView.hitAreaInsets);
   return CGRectContainsPoint(hitAreaRect, point);
 }
 

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -475,4 +475,54 @@ static inline UIImage *TestImage(CGSize size) {
   XCTAssertEqual(passedChipView, chipView);
 }
 
+- (void)testChipCellPointInsideWithCustomHitAreaInsets {
+  // Given
+  MDCChipCollectionViewCell *cell = [[MDCChipCollectionViewCell alloc] init];
+  cell.chipView.titleLabel.text = @"Chip";
+  [cell sizeToFit];
+
+  // When
+  UIEdgeInsets hitAreaInsets = UIEdgeInsetsMake(-10, -8, -6, -4);
+
+  cell.chipView.hitAreaInsets = hitAreaInsets;
+
+  // Then
+  CGRect chipBounds = CGRectStandardize(cell.bounds);
+  const CGFloat delta = (CGFloat)0.001;
+  // Top-left corner
+  XCTAssertTrue([cell pointInside:CGPointMake(CGRectGetMinX(chipBounds) + hitAreaInsets.left,
+                                              CGRectGetMinY(chipBounds) + hitAreaInsets.top)
+                        withEvent:nil]);
+  XCTAssertFalse([cell
+      pointInside:CGPointMake(CGRectGetMinX(chipBounds) + hitAreaInsets.left - delta,
+                              CGRectGetMinY(chipBounds) + hitAreaInsets.top - delta)
+        withEvent:nil]);
+  // Top-right corner
+  XCTAssertTrue([cell
+      pointInside:CGPointMake(CGRectGetMaxX(chipBounds) - hitAreaInsets.right - delta,
+                              CGRectGetMinY(chipBounds) + hitAreaInsets.top)
+        withEvent:nil]);
+  XCTAssertFalse([cell
+      pointInside:CGPointMake(CGRectGetMaxX(chipBounds) - hitAreaInsets.right,
+                              CGRectGetMinY(chipBounds) + hitAreaInsets.top - delta)
+        withEvent:nil]);
+  // Bottom-left corner
+  XCTAssertTrue([cell
+      pointInside:CGPointMake(CGRectGetMinX(chipBounds) + hitAreaInsets.left,
+                              CGRectGetMaxY(chipBounds) - hitAreaInsets.bottom - delta)
+        withEvent:nil]);
+  XCTAssertFalse([cell
+      pointInside:CGPointMake(CGRectGetMinX(chipBounds) + hitAreaInsets.left - delta,
+                              CGRectGetMaxY(chipBounds) - hitAreaInsets.bottom)
+        withEvent:nil]);
+  // Bottom-right corner
+  XCTAssertTrue([cell
+      pointInside:CGPointMake(CGRectGetMaxX(chipBounds) - hitAreaInsets.right - delta,
+                              CGRectGetMaxY(chipBounds) - hitAreaInsets.bottom - delta)
+        withEvent:nil]);
+  XCTAssertFalse([cell pointInside:CGPointMake(CGRectGetMaxX(chipBounds) - hitAreaInsets.right,
+                                               CGRectGetMaxY(chipBounds) - hitAreaInsets.bottom)
+                         withEvent:nil]);
+}
+
 @end


### PR DESCRIPTION
Currently, the Chips component uses the `hitAreaInsets` API to allow an increase of the touch target of the view. However, when using MDCChipCollectionViewCell, setting the `hitAreaInsets` does not work, because there is no pointInside method to increase the tap target for the cell itself, which is responsible for the touches. This PR adds the same logic to the chip cell, borrowing the value of the hitAreaInsets from the chip view.

Tested in catalog with iOS 13 and iPhone Max Pro simulator and added unit tests.

Closes #9276 