### PR TITLE
[Dialogs] Add reference images for snapshot test

### DIFF
--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreLeadingInVerticalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreLeadingInVerticalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50eb7c2c053f8adef6291e9fc4262f2eb9560888aefad7b4845148fcd3e882d5
-size 52655
+oid sha256:51aaec3c7d3988cd0ca61d53d86e698a716ed79723c58c89ee9768e2b5f0aafb
+size 52616

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreTrailingInVerticalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreTrailingInVerticalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50eb7c2c053f8adef6291e9fc4262f2eb9560888aefad7b4845148fcd3e882d5
-size 52655
+oid sha256:e4b23e9b876f27254bbe1aa82e2ea57d92db33b48985e09cbf9a6b635536b02f
+size 53342

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreJustifiedInVerticalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreJustifiedInVerticalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81aa1ad09f9c321d1cb693a1fa4c6360a13bebcd4cfba86e24e5b6f87106700a
-size 53997
+oid sha256:e5c779d346b55b2f3b631f15c1d9365e800879d19a2e9d34497a8c941ca8132d
+size 53507

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreLeadingInVerticalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreLeadingInVerticalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81aa1ad09f9c321d1cb693a1fa4c6360a13bebcd4cfba86e24e5b6f87106700a
-size 53997
+oid sha256:bf2cd827009098df479f96cf8d178a9830eb24491c0aa60e23e423700d84313f
+size 53561

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreTrailingInVerticalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreTrailingInVerticalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81aa1ad09f9c321d1cb693a1fa4c6360a13bebcd4cfba86e24e5b6f87106700a
-size 53997
+oid sha256:18fdf5d0c83ef5d3e85f469bfef18cc00396aca6b7a81b95b2112218e81f3b06
+size 54706


### PR DESCRIPTION
Reference images generated using `./.kokoro -d bazel -t //components/Dialogs:snapshot_tests` with the following files in record mode:
components/Dialogs/tests/snapshot/MDCAlertControllerActionsTests.m
components/TextFields/tests/snapshot/MDCTextFieldFilledControllerPreferredFontXSSnapshotTests.m