### PR TITLE
[Ink] Conditionally maskToBounds on MDCInkView layer

### DIFF
--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -126,9 +126,11 @@
   } else {
     switch (inkStyle) {
       case MDCInkStyleBounded:
+        self.inkLayer.masksToBounds = YES;
         self.inkLayer.maxRippleRadius = 0;
         break;
       case MDCInkStyleUnbounded:
+        self.inkLayer.masksToBounds = NO;
         self.inkLayer.maxRippleRadius = _maxRippleRadius;
         break;
     }

--- a/components/Ink/tests/unit/MDCInkViewTests.m
+++ b/components/Ink/tests/unit/MDCInkViewTests.m
@@ -148,4 +148,19 @@
   XCTAssertEqual(testInkView.inkColor, defaultInkColor);
 }
 
+- (void)testInkViewLayerDoesntMaskToBoundsWithInkStyleUnbounded {
+  // Given
+  MDCInkView *testInkView = [[MDCInkView alloc] init];
+
+  // When
+  testInkView.inkStyle = MDCInkStyleUnbounded;
+  BOOL masksToBoundsWhenUnbounded = testInkView.layer.masksToBounds;
+  testInkView.inkStyle = MDCInkStyleBounded;
+  BOOL masksToBoundsWhenBounded = testInkView.layer.masksToBounds;
+
+  // Then
+  XCTAssertTrue(masksToBoundsWhenBounded);
+  XCTAssertFalse(masksToBoundsWhenUnbounded);
+}
+
 @end


### PR DESCRIPTION
This change makes it so that the `masksToBounds` property on an MDCButton's MDCInkView's MDCLegacyInkLayer is set according to whether `inkStyle` is `.unbounded` or not, regardless of whether `usesLegacyInkRipple` is set on the MDCButton.

An MDCInkView's layer is always an MDCLegacyInkLayer, even when `usesLegacyInkRipple` is set to NO. In this scenario it acts as the MDCInkView's layer, even if it's not acting as the thing that triggers the ink/ripple animation.

There was a very similar bug to this recently that https://github.com/material-components/material-components-ios/pull/9254 was intended to address. That PR addressed it in the Catalog, as you can see in the before and after gifs in the PR description, but a different client was still experiencing the issue. I built the second client's app to test this PR and it seems to fix it for them.

I wonder if we should try to get rid of MDCLegacyInkLayer, or if we should bypass that and just get rid of MDCInkView entirely, now that we have MDCRippleView.

Closes #9762.