### PR TITLE
[TextFields] Lower the error VoiceOver announcement delay to near zero.

### DIFF
--- a/components/TextFields/src/MDCTextInputControllerBase.m
+++ b/components/TextFields/src/MDCTextInputControllerBase.m
@@ -41,7 +41,7 @@ static const NSTimeInterval
     MDCTextInputControllerBaseDefaultFloatingPlaceholderDownAnimationDuration = (CGFloat)0.266666;
 static const NSTimeInterval
     MDCTextInputControllerBaseDefaultFloatingPlaceholderUpAnimationDuration = (CGFloat)0.3;
-static const NSTimeInterval kDefaultErrorAnnouncementDelay = (CGFloat)0.500;
+static const NSTimeInterval kDefaultErrorAnnouncementDelay = (CGFloat)0.050;
 
 static inline UIColor *MDCTextInputControllerBaseDefaultInlinePlaceholderTextColorDefault() {
   return [UIColor colorWithWhite:0 alpha:MDCTextInputControllerBaseDefaultHintTextOpacity];


### PR DESCRIPTION
Prior to this change, error VoiceOver announcements would be initiated half a second after the error state was set, potentially resulting in about half a second of other VoiceOver notifications being announced before being interrupted by the error announcement.

The error announcement is intended to take precedent over the other informative announcements (such as character counts). Unfortunately, the error state is often set before the internal textInputDidChange: event which means that if we fire the error announcement immediately, then the error announcement will be cut off by the textInputDidChange: announcement for character counts. To combat this, https://github.com/material-components/material-components-ios/pull/7256 had introduced a dispatch_after to kick off the error event half a second later.

To address the first problem without breaking the second, this change reduces the delay of the error announcement to 0.05 seconds, a window of time small enough to avoid hearing any of the character count announcement, but large enough to happen after the character count announcement is posted, resulting in the error announcement being the one that is read out.

Closes https://github.com/material-components/material-components-ios/issues/7625
