### PR TITLE
[List] Add MDCSelfSizingLayoutAttributes

### DIFF
--- a/components/List/src/MDCBaseCell.m
+++ b/components/List/src/MDCBaseCell.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "MDCBaseCell.h"
+#import "MDCSelfSizingLayoutAttributes.h"
 
 #import "MaterialInk.h"
 #import "MaterialRipple.h"
@@ -135,6 +136,32 @@
   self.rippleColor = nil;
   [self.inkView cancelAllAnimationsAnimated:NO];
   [self.rippleView cancelAllRipplesAnimated:NO completion:nil];
+}
+
+- (UICollectionViewLayoutAttributes *)preferredLayoutAttributesFittingAttributes:
+    (UICollectionViewLayoutAttributes *)layoutAttributes {
+  if (![layoutAttributes conformsToProtocol:@protocol(MDCSelfSizingLayoutAttributes)]) {
+    return [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
+  }
+  UICollectionViewLayoutAttributes<MDCSelfSizingLayoutAttributes> *attr = (id)layoutAttributes;
+  BOOL isFixedWidth = [attr respondsToSelector:@selector(isFixedWidth)] ? attr.isFixedWidth : NO;
+  BOOL isFixedHeight = [attr respondsToSelector:@selector(isFixedHeight)] ? attr.isFixedHeight : NO;
+  NSLayoutConstraint *constraint;
+  if (isFixedWidth && isFixedHeight) {
+    return layoutAttributes;
+  } else if (isFixedWidth) {
+    constraint = [self.contentView.widthAnchor constraintEqualToConstant:attr.size.width];
+  } else if (isFixedHeight) {
+    constraint = [self.contentView.heightAnchor constraintEqualToConstant:attr.size.height];
+  } else {
+    return [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
+  }
+  constraint.active = YES;
+  [self layoutIfNeeded];
+  UICollectionViewLayoutAttributes *preferredAttributes =
+      [super preferredLayoutAttributesFittingAttributes:layoutAttributes];
+  constraint.active = NO;
+  return preferredAttributes;
 }
 
 #pragma mark Accessors

--- a/components/List/src/MDCSelfSizingLayoutAttributes.h
+++ b/components/List/src/MDCSelfSizingLayoutAttributes.h
@@ -1,0 +1,40 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+/**
+ * Allows `UICollectionViewLayout` subclasses to inform `MDCBaseCell` what size the cell can be.
+ *
+ * Conform your `UICollectionViewLayoutAttributes` subclass to this protocol.
+ */
+@protocol MDCSelfSizingLayoutAttributes <NSObject>
+
+@optional
+
+/**
+ * Whether the cell has a fixed horizontal size.
+ *
+ * Return YES to inform the cell it won't be allowed to resize horizontally. Default is NO.
+ */
+@property(nonatomic, readonly) BOOL isFixedWidth;
+
+/**
+ * Whether the cell has a fixed vertical size.
+ *
+ * Return YES to inform the cell it won't be allowed to resize vertically. Default is NO.
+ */
+@property(nonatomic, readonly) BOOL isFixedHeight;
+
+@end

--- a/components/List/src/MaterialList.h
+++ b/components/List/src/MaterialList.h
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 #import "MDCBaseCell.h"
+#import "MDCSelfSizingLayoutAttributes.h"
 #import "MDCSelfSizingStereoCell.h"


### PR DESCRIPTION
Add MDCSelfSizingLayoutAttributes

This protocol allows custom UICollectionViewLayouts to let the cell know how to self-size. For example, a column layout might have fixed column widths, but allow the cells to self-size vertically, so it can return YES from isFixedWidth and the cell will then only resize vertically.

Cells can either manually implement this behavior, or subclass MDCBaseCell to get it automatically.

This PR was migrated from [cl/298369495](http://cl/298369495).