### PR TITLE
[Chips] Update MDCChipField to move long text from a line with chips to a new line.

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -623,8 +623,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   if (!CGRectIsEmpty(lastChipFrame)) {
     BOOL isTextTooWide = [self textInputDesiredWidth] >= [self availableWidthForTextInput];
     BOOL isTextFieldOnSameLineAsChips =
-        CGRectGetMinY(self.textField.frame) - CGRectGetMinY(lastChipFrame) <=
-        (CGRectGetHeight(lastChipFrame) - 5);
+        CGRectGetMidY(self.textField.frame) == CGRectGetMidY(lastChipFrame);
     if (isTextTooWide && isTextFieldOnSameLineAsChips) {
       // The text is on the same line as the chips and doesn't fit
       // Trigger layout to move the text field down to the next line

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -615,6 +615,26 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 - (void)textFieldDidChange {
   [self deselectAllChips];
   [self createNewChipWithTextField:self.textField delimiter:MDCChipFieldDelimiterSpace];
+  CGRect lastChipFrame = self.chips.lastObject.frame;
+  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+    lastChipFrame = MDFRectFlippedHorizontally(lastChipFrame, CGRectGetWidth(self.bounds));
+  }
+
+  if (!CGRectIsEmpty(lastChipFrame)) {
+    BOOL isTextTooWide = [self textInputDesiredWidth] >= [self availableWidthForTextInput];
+    BOOL isTextFieldOnSameLineAsChips =
+        CGRectGetMinY(self.textField.frame) - CGRectGetMinY(lastChipFrame) <=
+        (CGRectGetHeight(lastChipFrame) - 5);
+    if (isTextTooWide && isTextFieldOnSameLineAsChips) {
+      // The text is on the same line as the chips and doesn't fit
+      // Trigger layout to move the text field down to the next line
+      [self setNeedsLayout];
+    } else if (!isTextTooWide && !isTextFieldOnSameLineAsChips) {
+      // The text is on the line below the chips but can fit on the same line
+      // Trigger layout to move the text field up to the previous line
+      [self setNeedsLayout];
+    }
+  }
 
   if ([self.delegate respondsToSelector:@selector(chipField:didChangeInput:)]) {
     [self.delegate chipField:self didChangeInput:[self.textField.text copy]];
@@ -698,28 +718,62 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (CGRect)frameForTextFieldForLastChipFrame:(CGRect)lastChipFrame
                               chipFieldSize:(CGSize)chipFieldSize {
-  CGFloat textFieldWidth =
-      chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  CGFloat availableWidth = [self availableWidthForTextInput];
   CGFloat textFieldHeight = [self.textField sizeThatFits:chipFieldSize].height;
   CGFloat originY = lastChipFrame.origin.y + (self.chipHeight - textFieldHeight) / 2;
 
-  // If no chip exists, make the text field the full width minus padding.
+  // If no chip exists, make the text field the full width, adjusted for insets.
   if (CGRectIsEmpty(lastChipFrame)) {
-    // Adjust for the top inset
     originY += self.contentEdgeInsets.top;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    return CGRectMake(self.contentEdgeInsets.left, originY, availableWidth, textFieldHeight);
   }
 
-  CGFloat availableWidth = chipFieldSize.width - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-  CGFloat placeholderDesiredWidth = [self placeholderDesiredWidth];
-  if (availableWidth < placeholderDesiredWidth) {
+  CGFloat originX = 0;
+  CGFloat textFieldWidth = 0;
+  CGFloat desiredTextWidth = [self textInputDesiredWidth];
+  if (availableWidth < desiredTextWidth) {
     // The text field doesn't fit on the line with the last chip.
     originY += self.chipHeight + MDCChipFieldVerticalMargin;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    originX = self.contentEdgeInsets.left;
+    textFieldWidth =
+        chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  } else {
+    // The text field fits on the line with chips
+    originX += CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin;
+    textFieldWidth = availableWidth;
   }
 
-  return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+  return CGRectMake(originX, originY, textFieldWidth, textFieldHeight);
+}
+
+- (CGFloat)availableWidthForTextInput {
+  NSArray *chipFrames = [self chipFramesForSize:self.bounds.size];
+  CGFloat boundsWidth = CGRectGetWidth(CGRectStandardize(self.bounds));
+  if (chipFrames.count == 0) {
+    return boundsWidth - (self.contentEdgeInsets.right + self.contentEdgeInsets.left);
+  }
+
+  CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
+  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
+                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
+  return availableWidth;
+}
+
+// The width of the text input + the clear button.
+// Used to determine whether the text field can fit on a line with chips or whether it gets its
+// own line.
+- (CGFloat)textInputDesiredWidth {
+  UIFont *font = self.textField.placeholderLabel.font;
+  CGRect placeholderDesiredRect = [self.textField.text
+      boundingRectWithSize:CGSizeMake(UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric)
+                   options:NSStringDrawingUsesLineFragmentOrigin
+                attributes:@{
+                  NSFontAttributeName : font,
+                }
+                   context:nil];
+  return MAX([self placeholderDesiredWidth],
+             CGRectGetWidth(placeholderDesiredRect) + MDCChipFieldHorizontalMargin +
+                 self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
 }
 
 - (CGFloat)placeholderDesiredWidth {
@@ -742,21 +796,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets
     withSizeThatFitsWidthHint:(CGFloat)widthHint {
-  CGRect lastChipFrame = self.chips.lastObject.frame;
-  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    lastChipFrame = MDFRectFlippedHorizontally(lastChipFrame, CGRectGetWidth(self.bounds));
-  }
-
-  CGFloat availableWidth = CGRectGetWidth(self.bounds) - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-
-  CGFloat leftInset = MDCChipFieldIndent;
-  if (!CGRectIsEmpty(lastChipFrame) && availableWidth >= [self placeholderDesiredWidth]) {
-    leftInset +=
-        CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin - self.contentEdgeInsets.left;
-  }
-  defaultInsets.left = leftInset;
-
+  defaultInsets.left = MDCChipFieldIndent;
   return defaultInsets;
 }
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -616,10 +616,6 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   [self deselectAllChips];
   [self createNewChipWithTextField:self.textField delimiter:MDCChipFieldDelimiterSpace];
   CGRect lastChipFrame = self.chips.lastObject.frame;
-  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    lastChipFrame = MDFRectFlippedHorizontally(lastChipFrame, CGRectGetWidth(self.bounds));
-  }
-
   if (!CGRectIsEmpty(lastChipFrame)) {
     BOOL isTextTooWide = [self textInputDesiredWidth] >= [self availableWidthForTextInput];
     BOOL isTextFieldOnSameLineAsChips =


### PR DESCRIPTION
Call layoutSubviews on textChanged to reposition MDCChipField's textField if:

1. The textField is on the same line as chips and becomes too long to fit
1. The textField is on the line below chips but can fit on the line with chips

Fixes #9006 

Before:
![before 2020-03-03 15_08_50](https://user-images.githubusercontent.com/581764/75815310-2e680000-5d61-11ea-8623-62719a0d0f3a.gif)

After:
![after 2020-03-03 15_10_39](https://user-images.githubusercontent.com/581764/75815323-3031c380-5d61-11ea-8468-69b70d4921ab.gif)
