### PR TITLE
[Chips] Resize MDCChipField's textField frame instead of using left insets to align with chips

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -698,28 +698,60 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (CGRect)frameForTextFieldForLastChipFrame:(CGRect)lastChipFrame
                               chipFieldSize:(CGSize)chipFieldSize {
-  CGFloat textFieldWidth =
-      chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  CGFloat availableWidth = [self availableWidthForTextInput];
   CGFloat textFieldHeight = [self.textField sizeThatFits:chipFieldSize].height;
   CGFloat originY = lastChipFrame.origin.y + (self.chipHeight - textFieldHeight) / 2;
 
-  // If no chip exists, make the text field the full width minus padding.
+  // If no chip exists, make the text field the full width, adjusted for insets.
   if (CGRectIsEmpty(lastChipFrame)) {
-    // Adjust for the top inset
     originY += self.contentEdgeInsets.top;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    return CGRectMake(self.contentEdgeInsets.left, originY, availableWidth, textFieldHeight);
   }
 
-  CGFloat availableWidth = chipFieldSize.width - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-  CGFloat placeholderDesiredWidth = [self placeholderDesiredWidth];
-  if (availableWidth < placeholderDesiredWidth) {
+  CGFloat originX = 0;
+  CGFloat textFieldWidth = 0;
+  CGFloat desiredTextWidth = [self textInputDesiredWidth];
+  if (availableWidth < desiredTextWidth) {
     // The text field doesn't fit on the line with the last chip.
     originY += self.chipHeight + MDCChipFieldVerticalMargin;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    originX = self.contentEdgeInsets.left;
+    textFieldWidth =
+        chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  } else {
+    // The text field fits on the line with chips
+    originX += CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin;
+    textFieldWidth = availableWidth;
   }
 
-  return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+  return CGRectMake(originX, originY, textFieldWidth, textFieldHeight);
+}
+
+- (CGFloat)availableWidthForTextInput {
+  NSArray *chipFrames = [self chipFramesForSize:self.bounds.size];
+  CGFloat boundsWidth = CGRectGetWidth(CGRectStandardize(self.bounds));
+  if (chipFrames.count == 0) {
+    return boundsWidth - (self.contentEdgeInsets.right + self.contentEdgeInsets.left);
+  }
+
+  CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
+  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
+                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
+  return availableWidth;
+}
+
+// The width of the text input + the clear button.
+- (CGFloat)textInputDesiredWidth {
+  UIFont *font = self.textField.placeholderLabel.font;
+  CGRect placeholderDesiredRect = [self.textField.text
+      boundingRectWithSize:CGSizeMake(UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric)
+                   options:NSStringDrawingUsesLineFragmentOrigin
+                attributes:@{
+                  NSFontAttributeName : font,
+                }
+                   context:nil];
+  return MAX([self placeholderDesiredWidth],
+             CGRectGetWidth(placeholderDesiredRect) + MDCChipFieldHorizontalMargin +
+                 self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
 }
 
 - (CGFloat)placeholderDesiredWidth {
@@ -742,21 +774,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets
     withSizeThatFitsWidthHint:(CGFloat)widthHint {
-  CGRect lastChipFrame = self.chips.lastObject.frame;
-  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    lastChipFrame = MDFRectFlippedHorizontally(lastChipFrame, CGRectGetWidth(self.bounds));
-  }
-
-  CGFloat availableWidth = CGRectGetWidth(self.bounds) - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-
-  CGFloat leftInset = MDCChipFieldIndent;
-  if (!CGRectIsEmpty(lastChipFrame) && availableWidth >= [self placeholderDesiredWidth]) {
-    leftInset +=
-        CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin - self.contentEdgeInsets.left;
-  }
-  defaultInsets.left = leftInset;
-
+  defaultInsets.left = MDCChipFieldIndent;
   return defaultInsets;
 }
 

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -324,18 +324,18 @@ static inline UIImage *TestImage(CGSize size) {
   [field createNewChipFromInput];
   [field layoutIfNeeded];
   CGFloat placeholderWithChipOriginX =
-      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+      CGRectStandardize(field.textField.frame).origin.x;
   MDCChipView *chip = field.chips[0];
   [field removeChip:chip];
   [field layoutIfNeeded];
 
   // Then
   CGFloat finalPlaceholderPositionOriginX =
-      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+      CGRectStandardize(field.textField.frame).origin.x;
   XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
-- (void)testAddChipsManuallyPlaceholderCorrectPosition {
+- (void)testAddChipsManuallyTextFieldCorrectPosition {
   // Given
   MDCChipView *fakeChip = [[MDCChipView alloc] init];
   fakeChip.titleLabel.text = @"Fake chip";
@@ -347,7 +347,7 @@ static inline UIImage *TestImage(CGSize size) {
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
   CGFloat initialPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
+      CGRectStandardize(fakeField.textField.frame).origin.x;
   [fakeField addChip:fakeChip];
   fakeField.textField.placeholder = fakeField.textField.placeholder;
   [fakeField setNeedsLayout];
@@ -355,7 +355,7 @@ static inline UIImage *TestImage(CGSize size) {
 
   // Then
   CGFloat finalPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
+      CGRectStandardize(fakeField.textField.frame).origin.x;
   XCTAssertGreaterThan(finalPlaceholderOriginX, initialPlaceholderOriginX);
 }
 

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -323,15 +323,13 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [field createNewChipFromInput];
   [field layoutIfNeeded];
-  CGFloat placeholderWithChipOriginX =
-      CGRectStandardize(field.textField.frame).origin.x;
+  CGFloat placeholderWithChipOriginX = CGRectStandardize(field.textField.frame).origin.x;
   MDCChipView *chip = field.chips[0];
   [field removeChip:chip];
   [field layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderPositionOriginX =
-      CGRectStandardize(field.textField.frame).origin.x;
+  CGFloat finalPlaceholderPositionOriginX = CGRectStandardize(field.textField.frame).origin.x;
   XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
@@ -346,16 +344,14 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
-  CGFloat initialPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.frame).origin.x;
+  CGFloat initialPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
   [fakeField addChip:fakeChip];
   fakeField.textField.placeholder = fakeField.textField.placeholder;
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.frame).origin.x;
+  CGFloat finalPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
   XCTAssertGreaterThan(finalPlaceholderOriginX, initialPlaceholderOriginX);
 }
 


### PR DESCRIPTION
Updates calculation of text field frame in MDCChipField.

Previously, the text field's frame was always the full width of its parent MDCChipField, with the left inset being provided by textInsets:withSizeThatFitsWidthHint:. This change updates the left inset to be constant, and updates the text field frame's width to fit the available space to the side of the chips if the text field's text is short enough.

Pre-work for #9006