### PR TITLE
[Chips] Revert "Resize MDCChipField's textField frame instead of using left insets to align with chips"

### DIFF
--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -323,17 +323,19 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [field createNewChipFromInput];
   [field layoutIfNeeded];
-  CGFloat placeholderWithChipOriginX = CGRectStandardize(field.textField.frame).origin.x;
+  CGFloat placeholderWithChipOriginX =
+      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
   MDCChipView *chip = field.chips[0];
   [field removeChip:chip];
   [field layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderPositionOriginX = CGRectStandardize(field.textField.frame).origin.x;
+  CGFloat finalPlaceholderPositionOriginX =
+      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
   XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
-- (void)testAddChipsManuallyTextFieldCorrectPosition {
+- (void)testAddChipsManuallyPlaceholderCorrectPosition {
   // Given
   MDCChipView *fakeChip = [[MDCChipView alloc] init];
   fakeChip.titleLabel.text = @"Fake chip";
@@ -344,14 +346,16 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
-  CGFloat initialPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
+  CGFloat initialPlaceholderOriginX =
+      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
   [fakeField addChip:fakeChip];
   fakeField.textField.placeholder = fakeField.textField.placeholder;
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
+  CGFloat finalPlaceholderOriginX =
+      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
   XCTAssertGreaterThan(finalPlaceholderOriginX, initialPlaceholderOriginX);
 }
 


### PR DESCRIPTION
Reverts 04567ba1653cb61927117160c3e8fd37e186d4b9 and 8b7c2b696c1f1ea212817f38b75d47825f3deb39

This change is getting rolled back because, when adding chips programatically, the MDCChipField grows taller than it should. After rollback, I'll add snapshot and/or unit tests to capture the current behavior and attempt to fix the issue then. 

Reopens #9006