### PR TITLE
[Snackbar] add multi-window guessing support

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -397,6 +397,14 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
     }
   }
 
+  // Check for the key window in the list of windows. This allows to find the correct window
+  // in apps with multi-window support.
+  for (UIWindow *window in [UIApplication mdc_safeSharedApplication].windows) {
+    if (window.isKeyWindow) {
+      return window;
+    }
+  }
+
   // Default to the key window, since we couldn't find anything better.
   return [[UIApplication mdc_safeSharedApplication] keyWindow];
 }


### PR DESCRIPTION
Snackbar has a "best guess window" method that finds which window the snackbar should be added on. In cases where there is multi-window support we shouldn't look at the sharedApplication keyWindow property but rather iterate on the sharedApplication windows property, as Apple states in its API: "KeyWindow should not be used for applications that support multiple scenes as it returns a key window across all connected scenes"

Closes #8397 