### PR TITLE
[BottomSheet] Anchor movement of the bottom sheet along the y axis.

### DIFF
--- a/components/BottomSheet/src/private/MDCSheetBehavior.m
+++ b/components/BottomSheet/src/private/MDCSheetBehavior.m
@@ -31,6 +31,15 @@
     _attachmentBehavior.frequency = (CGFloat)3.5;
     _attachmentBehavior.damping = (CGFloat)0.4;
     _attachmentBehavior.length = 0;
+
+    // Anchor movement along the y-axis.
+    __weak MDCSheetBehavior *weakSelf = self;
+    _attachmentBehavior.action = ^{
+      MDCSheetBehavior *strongSelf = weakSelf;
+      CGPoint center = item.center;
+      center.x = strongSelf->_targetPoint.x;
+      item.center = center;
+    };
     [self addChildBehavior:_attachmentBehavior];
 
     _itemBehavior = [[UIDynamicItemBehavior alloc] initWithItems:@[ self.item ]];


### PR DESCRIPTION
Prior to this change, it was possible to make the bottom sheet "wobble" on the x-axis if you threw it just right, or if you adjusted the width of the application in a split-screen environment.

This bug was due to the fact that bottom sheet is implemented with UIDynamics and it was using a stock UIAttachmentBehavior to animate the bottom sheet to its destination. UIAttachmentBehavior supports both x and y movement out of the box, but bottom sheet appears to have historically attempted to mitigate this fact by resetting the x velocity to 0 in several places. For example:

https://github.com/material-components/material-components-ios/blob/a42a84cca9e9254ac56da2d4aed0ac03474d335e/components/BottomSheet/src/private/MDCDraggableView.m#L63-L64

and

https://github.com/material-components/material-components-ios/blob/a42a84cca9e9254ac56da2d4aed0ac03474d335e/components/BottomSheet/src/private/MDCDraggableView.m#L87-L88

After this change, the bottom sheet's allowed range of movement will only be along the y axis. This is now enforced through a custom action block that explicitly resets the x position of the behavior's target to _targetPoint.x.

Closes https://github.com/material-components/material-components-ios/issues/9836
Closes https://github.com/material-components/material-components-ios/issues/5330

## Testing

Testing steps:

1. Open MDCDragons on an iPad.
2. Open the "Static content" Bottom Sheet example.
3. Present the bottom sheet.
4. Drag Safari from the dock to the side of the screen to enter split-screen mode.
4. Adjust the split screen divider to adjust the side of the MDCDragons app.

Verify that that bottom sheet is not wobbling on its x-axis.

Similarly, try tossing the bottom sheet up and to the left or up and to the right and verify that it does not wobble on its x-axis.