### PR TITLE
[Chips] Resize MDCChipField's textField frame instead of using left insets to align with chips

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -739,8 +739,9 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 // The width of the text input + the clear button.
 - (CGFloat)textInputDesiredWidth {
+  CGFloat placeholderDesiredWidth = [self placeholderDesiredWidth];
   if (!self.textField.text || [self.textField.text isEqualToString:@""]) {
-    return 44;
+    return placeholderDesiredWidth;
   }
 
   UIFont *font = self.textField.placeholderLabel.font;
@@ -751,7 +752,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                   NSFontAttributeName : font,
                 }
                    context:nil];
-  return MAX([self placeholderDesiredWidth],
+  return MAX(placeholderDesiredWidth,
              CGRectGetWidth(desiredRect) + MDCChipFieldHorizontalMargin +
                  self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
 }

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -752,9 +752,9 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                   NSFontAttributeName : font,
                 }
                    context:nil];
-  return MAX(placeholderDesiredWidth,
-             CGRectGetWidth(desiredRect) + MDCChipFieldHorizontalMargin +
-                 self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
+  return MAX(placeholderDesiredWidth, CGRectGetWidth(desiredRect) + MDCChipFieldHorizontalMargin +
+                                          self.contentEdgeInsets.right +
+                                          MDCChipFieldClearImageSquareWidthHeight);
 }
 
 - (CGFloat)placeholderDesiredWidth {

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -31,7 +31,7 @@ static const CGFloat MDCChipFieldClearButtonSquareWidthHeight = 24;
 static const CGFloat MDCChipFieldClearImageSquareWidthHeight = 18;
 static const UIKeyboardType MDCChipFieldDefaultKeyboardType = UIKeyboardTypeEmailAddress;
 
-const CGFloat MDCChipFieldDefaultMinTextFieldWidth = 60;
+const CGFloat MDCChipFieldDefaultMinTextFieldWidth = 44;
 const UIEdgeInsets MDCChipFieldDefaultContentEdgeInsets = {
     MDCChipFieldVerticalInset, MDCChipFieldHorizontalInset, MDCChipFieldVerticalInset,
     MDCChipFieldHorizontalInset};
@@ -734,13 +734,18 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   }
 
   CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
-  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-  return availableWidth;
+  return boundsWidth - CGRectGetMaxX(lastChipFrame);
+  //  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
+  //                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
+  //  return availableWidth;
 }
 
 // The width of the text input + the clear button.
 - (CGFloat)textInputDesiredWidth {
+  if (!self.textField.text || [self.textField.text isEqualToString:@""]) {
+    return 44;
+  }
+
   UIFont *font = self.textField.placeholderLabel.font;
   CGRect placeholderDesiredRect = [self.textField.text
       boundingRectWithSize:CGSizeMake(UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric)

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -698,28 +698,60 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (CGRect)frameForTextFieldForLastChipFrame:(CGRect)lastChipFrame
                               chipFieldSize:(CGSize)chipFieldSize {
-  CGFloat textFieldWidth =
-      chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  CGFloat availableWidth = [self availableWidthForTextInput];
   CGFloat textFieldHeight = [self.textField sizeThatFits:chipFieldSize].height;
   CGFloat originY = lastChipFrame.origin.y + (self.chipHeight - textFieldHeight) / 2;
 
-  // If no chip exists, make the text field the full width minus padding.
+  // If no chip exists, make the text field the full width, adjusted for insets.
   if (CGRectIsEmpty(lastChipFrame)) {
-    // Adjust for the top inset
     originY += self.contentEdgeInsets.top;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    return CGRectMake(self.contentEdgeInsets.left, originY, availableWidth, textFieldHeight);
   }
 
-  CGFloat availableWidth = chipFieldSize.width - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-  CGFloat placeholderDesiredWidth = [self placeholderDesiredWidth];
-  if (availableWidth < placeholderDesiredWidth) {
+  CGFloat originX = 0;
+  CGFloat textFieldWidth = 0;
+  CGFloat desiredTextWidth = [self textInputDesiredWidth];
+  if (availableWidth < desiredTextWidth) {
     // The text field doesn't fit on the line with the last chip.
     originY += self.chipHeight + MDCChipFieldVerticalMargin;
-    return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+    originX = self.contentEdgeInsets.left;
+    textFieldWidth =
+        chipFieldSize.width - self.contentEdgeInsets.left - self.contentEdgeInsets.right;
+  } else {
+    // The text field fits on the line with chips
+    originX += CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin;
+    textFieldWidth = availableWidth;
   }
 
-  return CGRectMake(self.contentEdgeInsets.left, originY, textFieldWidth, textFieldHeight);
+  return CGRectMake(originX, originY, textFieldWidth, textFieldHeight);
+}
+
+- (CGFloat)availableWidthForTextInput {
+  NSArray *chipFrames = [self chipFramesForSize:self.bounds.size];
+  CGFloat boundsWidth = CGRectGetWidth(CGRectStandardize(self.bounds));
+  if (chipFrames.count == 0) {
+    return boundsWidth - (self.contentEdgeInsets.right + self.contentEdgeInsets.left);
+  }
+
+  CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
+  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
+                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
+  return availableWidth;
+}
+
+// The width of the text input + the clear button.
+- (CGFloat)textInputDesiredWidth {
+  UIFont *font = self.textField.placeholderLabel.font;
+  CGRect placeholderDesiredRect = [self.textField.text
+      boundingRectWithSize:CGSizeMake(UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric)
+                   options:NSStringDrawingUsesLineFragmentOrigin
+                attributes:@{
+                  NSFontAttributeName : font,
+                }
+                   context:nil];
+  return MAX([self placeholderDesiredWidth],
+             CGRectGetWidth(placeholderDesiredRect) + MDCChipFieldHorizontalMargin +
+                 self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
 }
 
 - (CGFloat)placeholderDesiredWidth {
@@ -742,21 +774,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
 - (UIEdgeInsets)textInsets:(UIEdgeInsets)defaultInsets
     withSizeThatFitsWidthHint:(CGFloat)widthHint {
-  CGRect lastChipFrame = self.chips.lastObject.frame;
-  if (self.mdf_effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-    lastChipFrame = MDFRectFlippedHorizontally(lastChipFrame, CGRectGetWidth(self.bounds));
-  }
-
-  CGFloat availableWidth = CGRectGetWidth(self.bounds) - self.contentEdgeInsets.right -
-                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-
-  CGFloat leftInset = MDCChipFieldIndent;
-  if (!CGRectIsEmpty(lastChipFrame) && availableWidth >= [self placeholderDesiredWidth]) {
-    leftInset +=
-        CGRectGetMaxX(lastChipFrame) + MDCChipFieldHorizontalMargin - self.contentEdgeInsets.left;
-  }
-  defaultInsets.left = leftInset;
-
+  defaultInsets.left = MDCChipFieldIndent;
   return defaultInsets;
 }
 

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -735,9 +735,6 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
 
   CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
   return boundsWidth - CGRectGetMaxX(lastChipFrame);
-  //  CGFloat availableWidth = boundsWidth - self.contentEdgeInsets.right -
-  //                           CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalMargin;
-  //  return availableWidth;
 }
 
 // The width of the text input + the clear button.

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -744,7 +744,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   }
 
   UIFont *font = self.textField.placeholderLabel.font;
-  CGRect placeholderDesiredRect = [self.textField.text
+  CGRect desiredRect = [self.textField.text
       boundingRectWithSize:CGSizeMake(UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric)
                    options:NSStringDrawingUsesLineFragmentOrigin
                 attributes:@{
@@ -752,7 +752,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                 }
                    context:nil];
   return MAX([self placeholderDesiredWidth],
-             CGRectGetWidth(placeholderDesiredRect) + MDCChipFieldHorizontalMargin +
+             CGRectGetWidth(desiredRect) + MDCChipFieldHorizontalMargin +
                  self.contentEdgeInsets.right + MDCChipFieldClearImageSquareWidthHeight);
 }
 

--- a/components/Chips/tests/unit/ChipsTests.m
+++ b/components/Chips/tests/unit/ChipsTests.m
@@ -323,19 +323,17 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [field createNewChipFromInput];
   [field layoutIfNeeded];
-  CGFloat placeholderWithChipOriginX =
-      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+  CGFloat placeholderWithChipOriginX = CGRectStandardize(field.textField.frame).origin.x;
   MDCChipView *chip = field.chips[0];
   [field removeChip:chip];
   [field layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderPositionOriginX =
-      CGRectStandardize(field.textField.placeholderLabel.frame).origin.x;
+  CGFloat finalPlaceholderPositionOriginX = CGRectStandardize(field.textField.frame).origin.x;
   XCTAssertGreaterThan(placeholderWithChipOriginX, finalPlaceholderPositionOriginX);
 }
 
-- (void)testAddChipsManuallyPlaceholderCorrectPosition {
+- (void)testAddChipsManuallyTextFieldCorrectPosition {
   // Given
   MDCChipView *fakeChip = [[MDCChipView alloc] init];
   fakeChip.titleLabel.text = @"Fake chip";
@@ -346,16 +344,14 @@ static inline UIImage *TestImage(CGSize size) {
   // When
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
-  CGFloat initialPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
+  CGFloat initialPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
   [fakeField addChip:fakeChip];
   fakeField.textField.placeholder = fakeField.textField.placeholder;
   [fakeField setNeedsLayout];
   [fakeField layoutIfNeeded];
 
   // Then
-  CGFloat finalPlaceholderOriginX =
-      CGRectStandardize(fakeField.textField.placeholderLabel.frame).origin.x;
+  CGFloat finalPlaceholderOriginX = CGRectStandardize(fakeField.textField.frame).origin.x;
   XCTAssertGreaterThan(finalPlaceholderOriginX, initialPlaceholderOriginX);
 }
 

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnLineBelowWideChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnLineBelowWideChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:190bbf91431b62e4d2e001e2806770647260c333a44547d8b4041b6b4fa51473
-size 27193
+oid sha256:e3e081674ef0be7a591f8fbbf45a8f7484a6dcfca4ae365cf7e197e34b156c7b
+size 26081

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d85d77ede51c0ed40b1ee930f9d7d065d151a9bf6028d72bc95aac6f887f6e6
-size 6225
+oid sha256:4d34c24525d06510d6eb63b2f3ee56277e80ac20e2eb88583fbd8bbf19e83b5f
+size 5881

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbba24afacac68bae450f7b8c3b2a42d4156dfb25112a0e3d306c7c572cdbddd
-size 5991
+oid sha256:7d85d77ede51c0ed40b1ee930f9d7d065d151a9bf6028d72bc95aac6f887f6e6
+size 6225

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fc17e0c9aa5392a287eaf4e56c60f23dae71499e9e2d97c2d7366036b2e5915
-size 26367
+oid sha256:e3e081674ef0be7a591f8fbbf45a8f7484a6dcfca4ae365cf7e197e34b156c7b
+size 26081

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d22fa49b0c4393cb4ae35a16c04a4904f9e4b28bf16d0d1e32a3c59ff2c9b3ed
-size 26002
+oid sha256:6fc17e0c9aa5392a287eaf4e56c60f23dae71499e9e2d97c2d7366036b2e5915
+size 26367


### PR DESCRIPTION
Updates calculation of text field frame in MDCChipField.

Previously, the text field's frame was always the full width of its parent MDCChipField, with the left inset being provided by textInsets:withSizeThatFitsWidthHint:. This change updates the left inset to be constant, and updates the text field frame's width to fit the available space to the side of the chips if the text field's text is short enough.

This is a partial roll-forward of https://github.com/material-components/material-components-ios/pull/9828. The primary change is that the default minimum text field width has been updated to match the minimum HIG-recommended touch target size.

Pre-work for #9006 