### PR TITLE
[Dialogs] Allow setting text alignment for alert message text

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -104,7 +104,7 @@
 /** The color applied to the title of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *titleColor;
 
-/** The alignment applied to the title of the Alert Controller.*/
+/** The alignment applied to the title of the Alert. Default to NSTextAlignmentNatural. */
 @property(nonatomic, assign) NSTextAlignment titleAlignment;
 
 /** An optional icon appearing above the title of the Alert Controller.*/
@@ -118,6 +118,9 @@
 
 /** The color applied to the message of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIColor *messageColor;
+
+/** The alignment applied to the message of Alert Controller. Default to NSTextAlignmentNatural. */
+@property(nonatomic, assign) NSTextAlignment messageAlignment;
 
 /**
  The font applied to the button of Alert Controller.

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -122,6 +122,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     _alertTitle = [title copy];
     _message = [message copy];
     _titleAlignment = NSTextAlignmentNatural;
+    _messageAlignment = NSTextAlignmentNatural;
     _actionManager = [[MDCAlertActionManager alloc] init];
     _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
     _shadowColor = UIColor.blackColor;
@@ -326,6 +327,13 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   _titleAlignment = titleAlignment;
   if (self.alertView) {
     self.alertView.titleAlignment = titleAlignment;
+  }
+}
+
+- (void)setMessageAlignment:(NSTextAlignment)messageAlignment {
+  _messageAlignment = messageAlignment;
+  if (self.alertView) {
+    self.alertView.messageAlignment = messageAlignment;
   }
 }
 
@@ -645,6 +653,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     self.alertView.buttonInkColor = self.buttonInkColor;  // b/117717380: Will be deprecated
   }
   self.alertView.titleAlignment = self.titleAlignment;
+  self.alertView.messageAlignment = self.messageAlignment;
   self.alertView.titleIcon = self.titleIcon;
   self.alertView.titleIconTintColor = self.titleIconTintColor;
   self.alertView.titleIconView = self.titleIconView;

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -19,9 +19,10 @@
 @property(nonatomic, strong, nullable) UIFont *titleFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *titleColor UI_APPEARANCE_SELECTOR;
 
-@property(nonatomic, assign) NSTextAlignment titleAlignment;
 @property(nonatomic, strong, nullable) UIImage *titleIcon;
 @property(nonatomic, strong, nullable) UIColor *titleIconTintColor;
+@property(nonatomic, assign) NSTextAlignment titleAlignment;
+@property(nonatomic, assign) NSTextAlignment messageAlignment;
 
 /**
  An optional custom icon view above the title of the alert.

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -52,9 +52,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   BOOL _mdc_adjustsFontForContentSizeCategory;
 }
 
-@dynamic titleAlignment;
-@dynamic titleIcon;
-
 - (instancetype)initWithFrame:(CGRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
@@ -305,6 +302,14 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   _messageColor = messageColor;
 
   _messageLabel.textColor = messageColor;
+}
+
+- (NSTextAlignment)messageAlignment {
+  return self.messageLabel.textAlignment;
+}
+
+- (void)setMessageAlignment:(NSTextAlignment)messageAlignment {
+  self.messageLabel.textAlignment = messageAlignment;
 }
 
 - (void)setAccessoryView:(UIView *)accessoryView {

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerConfigurationsTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerConfigurationsTests.m
@@ -375,4 +375,139 @@ static NSString *const kMessageLongLatin =
   [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
 }
 
+// message alignment: default alignment is natural
+- (void)testMessageDefaultAlignmentIsNatural {
+  // Given
+  self.alertController.message = kMessageLongLatin;
+  // Then
+  [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: center
+- (void)testMessageAlignmentIsCentered {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentCenter;
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: natural
+- (void)testMessageAlignmentIsNatural {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentNatural;
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: natural in RTL
+- (void)testMessageAlignmentIsNaturalInRTL {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentNatural;
+  [self changeToRTL:self.alertController];
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: right
+- (void)testMessageAlignmentIsRight {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentRight;
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: right in RTL
+- (void)testMessageRightAlignmentIsRightInRTL {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentRight;
+  [self changeToRTL:self.alertController];
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: left
+- (void)testMessageAlignmentIsLeft {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentLeft;
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: left in RTL
+- (void)testMessageLeftAlignmentIsLeftInRTL {
+  // Given
+  self.alertController.title = @"A title that is longer than the message";
+  self.alertController.message = kMessageShortLatin;
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentLeft;
+  [self changeToRTL:self.alertController];
+
+  // Then
+  self.alertController.view.bounds = CGRectMake(0.f, 0.f, 300.f, 200.f);
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: left in RTL. long message.
+- (void)testLongMessageLeftAlignmentIsLeftInRTL {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentLeft;
+  [self changeToRTL:self.alertController];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+// message alignment: justified
+- (void)testMessageAlignmentIsJustified {
+  // Given
+  self.alertController.title = kTitleShortLatin;
+  self.alertController.message = kMessageLongLatin;
+
+  // When
+  self.alertController.messageAlignment = NSTextAlignmentJustified;
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForView:self.alertController.view];
+}
+
 @end

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testLongMessageLeftAlignmentIsLeftInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testLongMessageLeftAlignmentIsLeftInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8f090c3ef051b76a02b963d08b20efed170caf95667ae18cc78c00cd9ea909
+size 48394

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsCentered_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsCentered_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c93ecc5f5dc949b9b1b4b8582fd21d38a6dcb2d284532784835207ce807f7d9
+size 42071

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsJustified_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsJustified_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ad976fb002461aea5beb211901e4f48bfc0b913b6bb753b7c841447cb67f4fa
+size 42122

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsLeft_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsLeft_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c851d6bd3cb0cc7f1c543692a160abdead3dfaaca205c68fd2ac6edd6a63ae3
+size 48867

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsNaturalInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsNaturalInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c052bfdd50e394559cc2d51b27d2bac60b72cfcaeea369cf5a90235520b20db1
+size 43305

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsNatural_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsNatural_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c851d6bd3cb0cc7f1c543692a160abdead3dfaaca205c68fd2ac6edd6a63ae3
+size 48867

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsRight_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageAlignmentIsRight_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f051ae7a055e717d1a2066a9f31c998ae8f78a31baddb117189bb39a93497dfb
+size 43294

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageDefaultAlignmentIsNatural_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageDefaultAlignmentIsNatural_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50a2a6d7ee8253391400ae68404aaf88f4d9f37954dfd9ce559238053580d10b
+size 37828

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageLeftAlignmentIsLeftInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageLeftAlignmentIsLeftInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e29b6cb939963b655099935fa8809eb0f9f4aad96dcb79f39d8c5faf07e76af
+size 22542

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageRightAlignmentIsRightInRTL_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerConfigurationsTests/testMessageRightAlignmentIsRightInRTL_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2cf5998f3b1ef3e57211510dae7fb92b4dd737a99a0766ca20f6cc3fd0e9c38
+size 48211


### PR DESCRIPTION
# Description

Using NSTextAlignment to customize alignment of the Material Alert's message.

## Example
Trailing aligned message with a leading aligned message:

![Dialogs - message alignment](https://user-images.githubusercontent.com/2329102/76005569-35198300-5ed9-11ea-9d4d-a2d75469a477.png)

## Issue
Closes #5602 

b/118846596, cl/298994401
