### PR TITLE
[Chips] In MDCChipField, account for horizontal padding when calculating available width for text field

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -734,7 +734,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   }
 
   CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
-  return boundsWidth - CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalInset;
+  return boundsWidth - CGRectGetMaxX(lastChipFrame) - self.contentEdgeInsets.right;
 }
 
 // The width of the text input + the clear button.

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -734,7 +734,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   }
 
   CGRect lastChipFrame = [chipFrames.lastObject CGRectValue];
-  return boundsWidth - CGRectGetMaxX(lastChipFrame);
+  return boundsWidth - CGRectGetMaxX(lastChipFrame) - MDCChipFieldHorizontalInset;
 }
 
 // The width of the text input + the clear button.

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnLineBelowWideChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnLineBelowWideChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e081674ef0be7a591f8fbbf45a8f7484a6dcfca4ae365cf7e197e34b156c7b
-size 26081
+oid sha256:a88f0d51cc7ba9ed2aea3ea51e8a06dfac55329701b6337122ca13cb18d765e0
+size 26427

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldIsOnTheSameLineAsNarrowChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d34c24525d06510d6eb63b2f3ee56277e80ac20e2eb88583fbd8bbf19e83b5f
-size 5881
+oid sha256:b65a6b0c371f202f51c28206c50b101c8dda503c37a5d59df59458e38218a880
+size 6227

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testTextFieldWithZeroMinimumWidthIsOnSameLineAsWideChips_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e081674ef0be7a591f8fbbf45a8f7484a6dcfca4ae365cf7e197e34b156c7b
-size 26081
+oid sha256:a88f0d51cc7ba9ed2aea3ea51e8a06dfac55329701b6337122ca13cb18d765e0
+size 26427


### PR DESCRIPTION
This change addresses an issue introduced in https://github.com/material-components/material-components-ios/pull/9837, where the calculation of available width for the text field did not take into account the chip field's horizontal insets. 