### PR TITLE
[Chips] Account for MDCChipField contentInset in placeholder width calculation

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -770,7 +770,9 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
                                NSFontAttributeName : placeholderFont,
                              }
                                 context:nil];
-  return MAX(CGRectGetWidth(placeholderDesiredRect), self.minTextFieldWidth);
+  CGFloat placeholderDesiredWidth =
+      CGRectGetWidth(placeholderDesiredRect) + self.contentEdgeInsets.right;
+  return MAX(placeholderDesiredWidth, self.minTextFieldWidth);
 }
 
 #pragma mark - MDCTextInputPositioningDelegate

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testPlacholderIsNotTruncated_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testPlacholderIsNotTruncated_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba0cc6b6d0c5d0a7f97abac3b574295dd4f198f35783c670ec311cd979bd3d80
-size 7803
+oid sha256:d0bafa0683e40b8fe56a16ab686e23942eb02ef10afab244902bf9f7411b6c8c
+size 8611


### PR DESCRIPTION
Fixes an issue where MDCChipField's placeholder was being incorrectly truncated instead of being moved to the next line. 

Fixes #9844