### PR TITLE
[Chips] Move MDCChipField text input to a new line if text is too wide

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -616,6 +616,22 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   [self deselectAllChips];
   [self createNewChipWithTextField:self.textField delimiter:MDCChipFieldDelimiterSpace];
 
+  CGRect lastChipFrame = self.chips.lastObject.frame;
+  if (!CGRectIsEmpty(lastChipFrame)) {
+    BOOL isTextTooWide = [self textInputDesiredWidth] >= [self availableWidthForTextInput];
+    BOOL isTextFieldOnSameLineAsChips =
+    CGRectGetMidY(self.textField.frame) == CGRectGetMidY(lastChipFrame);
+    if (isTextTooWide && isTextFieldOnSameLineAsChips) {
+      // The text is on the same line as the chips and doesn't fit
+      // Trigger layout to move the text field down to the next line
+      [self setNeedsLayout];
+    } else if (!isTextTooWide && !isTextFieldOnSameLineAsChips) {
+      // The text is on the line below the chips but can fit on the same line
+      // Trigger layout to move the text field up to the previous line
+      [self setNeedsLayout];
+    }
+  }
+
   if ([self.delegate respondsToSelector:@selector(chipField:didChangeInput:)]) {
     [self.delegate chipField:self didChangeInput:[self.textField.text copy]];
   }

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -620,7 +620,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   if (!CGRectIsEmpty(lastChipFrame)) {
     BOOL isTextTooWide = [self textInputDesiredWidth] >= [self availableWidthForTextInput];
     BOOL isTextFieldOnSameLineAsChips =
-    CGRectGetMidY(self.textField.frame) == CGRectGetMidY(lastChipFrame);
+        CGRectGetMidY(self.textField.frame) == CGRectGetMidY(lastChipFrame);
     if (isTextTooWide && isTextFieldOnSameLineAsChips) {
       // The text is on the same line as the chips and doesn't fit
       // Trigger layout to move the text field down to the next line


### PR DESCRIPTION
Updates MDCChipField to move the internal text field down to a new line if:

1. The textField is on the same line as chips and becomes too long to fit
1. The textField is on the line below chips but can fit on the line with chips

Fixes #9006

This completes the roll-forward of https://github.com/material-components/material-components-ios/pull/9828

Before:
![before 2020-03-03 15_08_50](https://user-images.githubusercontent.com/581764/75815310-2e680000-5d61-11ea-8623-62719a0d0f3a.gif)

After:
![after 2020-03-03 15_10_39](https://user-images.githubusercontent.com/581764/75815323-3031c380-5d61-11ea-8468-69b70d4921ab.gif)