### PR TITLE
[Tabs] Add MDCTabBarViewLayoutStyleScrollableCentered

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -31,22 +31,27 @@ typedef NS_ENUM(NSUInteger, MDCTabBarViewLayoutStyle) {
   MDCTabBarViewLayoutStyleScrollable = 1,
 
   /**
+   The same as MDCTabBarViewLayoutStyleScrollable, but the selected tab is centered within the bar
+   if its position in the scrollview's content area permits it.*/
+  MDCTabBarViewLayoutStyleScrollableCentered = 2,
+
+  /**
    Each item's width is as wide as the widest item. The items are arranged in the horizontal center
    of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredCentered = 2,
+  MDCTabBarViewLayoutStyleFixedClusteredCentered = 3,
 
   /**
    Each item's width is as wide as the widest item. The items are arranged horizontally on the
    leading edge of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredLeading = 3,
+  MDCTabBarViewLayoutStyleFixedClusteredLeading = 4,
 
   /**
    Each item's width is as wide as the widest item. The items are arranged horizontally on the
    trailing edge of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredTrailing = 4,
+  MDCTabBarViewLayoutStyleFixedClusteredTrailing = 5,
 };
 
 /**

--- a/components/Tabs/src/TabBarView/MDCTabBarView.h
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.h
@@ -31,27 +31,27 @@ typedef NS_ENUM(NSUInteger, MDCTabBarViewLayoutStyle) {
   MDCTabBarViewLayoutStyleScrollable = 1,
 
   /**
-   The same as MDCTabBarViewLayoutStyleScrollable, but the selected tab is centered within the bar
-   if its position in the scrollview's content area permits it.*/
-  MDCTabBarViewLayoutStyleScrollableCentered = 2,
-
-  /**
    Each item's width is as wide as the widest item. The items are arranged in the horizontal center
    of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredCentered = 3,
+  MDCTabBarViewLayoutStyleFixedClusteredCentered = 2,
 
   /**
    Each item's width is as wide as the widest item. The items are arranged horizontally on the
    leading edge of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredLeading = 4,
+  MDCTabBarViewLayoutStyleFixedClusteredLeading = 3,
 
   /**
    Each item's width is as wide as the widest item. The items are arranged horizontally on the
    trailing edge of the bar.
    */
-  MDCTabBarViewLayoutStyleFixedClusteredTrailing = 5,
+  MDCTabBarViewLayoutStyleFixedClusteredTrailing = 4,
+
+  /**
+   The same as MDCTabBarViewLayoutStyleScrollable, but the selected tab is centered within the bar
+   if its position in the scrollview's content area permits it.*/
+  MDCTabBarViewLayoutStyleScrollableCentered = 5,
 };
 
 /**

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -304,7 +304,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   [self updateTitleColorForAllViews];
   [self updateImageTintColorForAllViews];
   [self updateTitleFontForAllViews];
-  [self scrollRectToVisible:self.itemViews[itemIndex].frame animated:animated];
+  [self scrollToItem:self.items[itemIndex] animated:animated];
   [self didSelectItemAtIndex:itemIndex animateTransition:animated];
 }
 
@@ -604,7 +604,8 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 - (void)layoutSubviews {
   [super layoutSubviews];
 
-  switch ([self effectiveLayoutStyle]) {
+  MDCTabBarViewLayoutStyle layoutStyle = [self effectiveLayoutStyle];
+  switch (layoutStyle) {
     case MDCTabBarViewLayoutStyleFixed: {
       [self layoutSubviewsForJustifiedLayout];
       break;
@@ -612,9 +613,10 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     case MDCTabBarViewLayoutStyleFixedClusteredCentered:
     case MDCTabBarViewLayoutStyleFixedClusteredTrailing:
     case MDCTabBarViewLayoutStyleFixedClusteredLeading: {
-      [self layoutSubviewsForFixedClusteredLayout:[self effectiveLayoutStyle]];
+      [self layoutSubviewsForFixedClusteredLayout:layoutStyle];
       break;
     }
+    case MDCTabBarViewLayoutStyleScrollableCentered:
     case MDCTabBarViewLayoutStyleScrollable: {
       [self layoutSubviewsForScrollableLayout];
       break;
@@ -634,7 +636,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
         self.contentOffset = CGPointMake(self.contentSize.width - viewWidth, self.contentOffset.y);
       }
     }
-    [self scrollUntilSelectedItemIsVisibleWithoutAnimation];
+    [self scrollToItem:self.selectedItem animated:NO];
   }
   // It's possible that after scrolling the minX of bounds could have changed. Positioning it last
   // ensures that its frame matches the displayed content bounds.
@@ -666,6 +668,9 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 
   CGSize availableSize = [self availableSizeForSubviewLayout];
   switch (self.preferredLayoutStyle) {
+    case MDCTabBarViewLayoutStyleScrollableCentered: {
+      return MDCTabBarViewLayoutStyleScrollableCentered;
+    }
     case MDCTabBarViewLayoutStyleScrollable: {
       return MDCTabBarViewLayoutStyleScrollable;
     }
@@ -816,6 +821,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     case MDCTabBarViewLayoutStyleFixed: {
       return [self intrinsicContentSizeForJustifiedLayout];
     }
+    case MDCTabBarViewLayoutStyleScrollableCentered:
     case MDCTabBarViewLayoutStyleScrollable: {
       return [self intrinsicContentSizeForScrollableLayout];
     }
@@ -850,6 +856,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     case MDCTabBarViewLayoutStyleFixedClusteredLeading: {
       return [self availableSizeForSubviewLayout];
     }
+    case MDCTabBarViewLayoutStyleScrollableCentered:
     case MDCTabBarViewLayoutStyleScrollable: {
       return [self intrinsicContentSizeForScrollableLayout];
     }
@@ -909,8 +916,8 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 
 #pragma mark - Helpers
 
-- (void)scrollUntilSelectedItemIsVisibleWithoutAnimation {
-  NSUInteger index = [self.items indexOfObject:self.selectedItem];
+- (void)scrollToItem:(UITabBarItem *)item animated:(BOOL)animated {
+  NSUInteger index = [self.items indexOfObject:item];
   if (index == NSNotFound || index >= self.itemViews.count) {
     index = 0;
   }
@@ -918,8 +925,18 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     return;
   }
 
-  CGRect estimatedItemFrame = [self estimatedFrameForItemAtIndex:index];
-  [self scrollRectToVisible:estimatedItemFrame animated:NO];
+  if ([self effectiveLayoutStyle] == MDCTabBarViewLayoutStyleScrollableCentered) {
+    CGPoint contentOffset = [self contentOffsetNeededToCenterItemView:self.itemViews[index]];
+    NSTimeInterval animationDuration = animated ? self.selectionChangeAnimationDuration : 0;
+    [UIView animateWithDuration:animationDuration
+                     animations:^{
+                       self.contentOffset = contentOffset;
+                     }
+                     completion:nil];
+  } else {
+    CGRect estimatedItemFrame = [self estimatedFrameForItemAtIndex:index];
+    [self scrollRectToVisible:estimatedItemFrame animated:animated];
+  }
 }
 
 - (CGRect)estimatedFrameForItemAtIndex:(NSUInteger)index {
@@ -947,6 +964,15 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   return CGRectMake(viewOriginX, 0, viewSize.width, viewSize.height);
 }
 
+- (CGPoint)contentOffsetNeededToCenterItemView:(UIView *)itemView {
+  CGFloat availableWidth = [self availableSizeForSubviewLayout].width;
+  CGFloat itemViewWidth = CGRectGetWidth(itemView.frame);
+  CGFloat contentOffsetX = CGRectGetMinX(itemView.frame) - (availableWidth - itemViewWidth) / 2.f;
+  contentOffsetX = MAX(contentOffsetX, 0.f);
+  contentOffsetX = MIN(contentOffsetX, self.contentSize.width - availableWidth);
+  return CGPointMake(contentOffsetX, self.contentOffset.y);
+}
+
 - (CGSize)expectedSizeForView:(UIView *)view {
   if (self.itemViews.count == 0) {
     return CGSizeZero;
@@ -965,6 +991,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
     case MDCTabBarViewLayoutStyleFixedClusteredLeading: {
       return [self estimatedItemViewSizeForClusteredFixedLayout];
     }
+    case MDCTabBarViewLayoutStyleScrollableCentered:
     case MDCTabBarViewLayoutStyleScrollable: {
       return [self estimatedIntrinsicSizeForView:view];
     }

--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -969,7 +969,7 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
 - (CGPoint)contentOffsetNeededToCenterItemView:(UIView *)itemView {
   CGFloat availableWidth = [self availableSizeForSubviewLayout].width;
   CGFloat itemViewWidth = CGRectGetWidth(itemView.frame);
-  CGFloat contentOffsetX = CGRectGetMinX(itemView.frame) - (availableWidth - itemViewWidth) / 2.f;
+  CGFloat contentOffsetX = CGRectGetMinX(itemView.frame) - ((availableWidth - itemViewWidth) / 2.f);
   contentOffsetX = MAX(contentOffsetX, 0.f);
   contentOffsetX = MIN(contentOffsetX, self.contentSize.width - availableWidth);
   return CGPointMake(contentOffsetX, self.contentOffset.y);

--- a/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
+++ b/components/Tabs/tests/snapshot/TabBarView/MDCTabBarViewSnapshotTests.m
@@ -369,6 +369,26 @@ static NSString *const kItemTitleLong3Arabic = @"تحت أي قدما وإقام
 
 #pragma mark - Selection
 
+- (void)testSelectionWithScrollableCenteredLayout {
+  // Given
+  self.tabBarView.bounds = CGRectMake(0, 0, 360, kExpectedHeightTitlesAndIcons);
+  UITabBarItem *item1 = [[UITabBarItem alloc] initWithTitle:@"One" image:nil tag:0];
+  UITabBarItem *item2 = [[UITabBarItem alloc] initWithTitle:@"Two" image:nil tag:2];
+  UITabBarItem *item3 = [[UITabBarItem alloc] initWithTitle:@"Three" image:nil tag:5];
+  UITabBarItem *item4 = [[UITabBarItem alloc] initWithTitle:@"Four" image:nil tag:6];
+  UITabBarItem *item5 = [[UITabBarItem alloc] initWithTitle:@"Five" image:nil tag:7];
+  UITabBarItem *item6 = [[UITabBarItem alloc] initWithTitle:@"Six" image:nil tag:8];
+  self.tabBarView.items = @[ item1, item2, item3, item4, item5, item6 ];
+  self.tabBarView.selectionIndicatorStrokeColor = UIColor.redColor;
+  self.tabBarView.preferredLayoutStyle = MDCTabBarViewLayoutStyleScrollableCentered;
+
+  // When
+  [self.tabBarView setSelectedItem:item3 animated:NO];
+
+  // Then
+  [self generateSnapshotAndVerifyForView:self.tabBarView];
+}
+
 - (void)testChangingSelectedItemUsesSelectedImage {
   // Given
   self.tabBarView.bounds = CGRectMake(0, 0, 360, kExpectedHeightTitlesAndIcons);

--- a/snapshot_test_goldens/goldens_64/MDCTabBarViewSnapshotTests/testSelectionWithScrollableCenteredLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCTabBarViewSnapshotTests/testSelectionWithScrollableCenteredLayout_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e3520281d92a526a4690068b1bfcacd7183edfc19dda88016b560dadbc113d6
+size 7466


### PR DESCRIPTION
This is a PR based off of [cl/298786100](http://cl/298786100). I was skeptical about the introduction of the new MDCTabViewAlignment enum in that CL, so I asked Rob (the author of the component) what he thought, and he suggested just extending the existing enum. I wanted to make sure that approach worked before I told the internal contributor about it, so I started tinkering with it, and eventually it just turned into this PR. If we want, we can just merge this PR instead of exporting that CL. I did take some of the code from that CL--this PR definitely would've taken longer to prepare without that code--so I'm wondering if this could still count as a client contribution?

Note: This PR changes the NSInteger values of some of the existing enum cases. I checked internally and none of the few people using this appear to be referring to the old values by their raw values, so I'm thinking this won't be a problem. If someone feels like it will be, I can add the new case to the bottom.

Note: The internal client is happy with this fix.

Here's a before gif:
![before-tabbar](https://user-images.githubusercontent.com/8020010/76020242-0d361980-5ef1-11ea-91b3-8099d2bc06af.gif)

Here's an after gif:
![after-tabbar](https://user-images.githubusercontent.com/8020010/76020231-09a29280-5ef1-11ea-8ec0-532a3f1ceea4.gif)

Closes #9422.