### PR TITLE
[Chips] Do not include insets in MDCChipField placeholder width if there is no placeholder

### DIFF
--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -778,6 +778,11 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
   if (!self.showPlaceholderWithChips && self.chips.count > 0) {
     placeholder = nil;
   }
+
+  if (!placeholder || [placeholder isEqualToString:@""]) {
+    return self.minTextFieldWidth;
+  }
+
   UIFont *placeholderFont = self.textField.placeholderLabel.font;
   CGRect placeholderDesiredRect =
       [placeholder boundingRectWithSize:CGRectStandardize(self.bounds).size

--- a/components/Chips/src/MDCChipField.m
+++ b/components/Chips/src/MDCChipField.m
@@ -779,7 +779,7 @@ static inline UIBezierPath *MDCPathForClearButtonImageFrame(CGRect frame) {
     placeholder = nil;
   }
 
-  if (!placeholder || [placeholder isEqualToString:@""]) {
+  if (placeholder.length == 0) {
     return self.minTextFieldWidth;
   }
 

--- a/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testEmptyPlaceholderSizeDoesNotAccountForContentInsets_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCChipFieldSnapshotTests/testEmptyPlaceholderSizeDoesNotAccountForContentInsets_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45127b8ba417ce603a7d87df53c2a5202e81238f8cfe146e4b62a3f58f0ffdbd
-size 9593
+oid sha256:88faddebb04741992a43fda67f00bbea4134e8616cd5e87f7038c8275b33cc1f
+size 9053


### PR DESCRIPTION
Adds logic to MDCChipField to exit early when calculating placeholder label width if there is no placeholder text. 

Fixes #9846 