### PR TITLE
[Catalog] Remove traitCollection overrides from examples

### DIFF
--- a/components/Cards/examples/CardExampleViewController.swift
+++ b/components/Cards/examples/CardExampleViewController.swift
@@ -54,14 +54,6 @@ class CardExampleViewController: UIViewController {
       imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
     }
   }
-
-  override public var traitCollection: UITraitCollection {
-    if UIDevice.current.userInterfaceIdiom == .pad && UIDevice.current.orientation.isPortrait {
-      return UITraitCollection(traitsFrom:[UITraitCollection(horizontalSizeClass: .compact),
-                                           UITraitCollection(verticalSizeClass: .regular)])
-    }
-    return super.traitCollection
-  }
 }
 
 extension CardExampleViewController {

--- a/components/Cards/examples/ShapedCardViewController.swift
+++ b/components/Cards/examples/ShapedCardViewController.swift
@@ -162,14 +162,6 @@ class ShapedCardViewController: UIViewController {
     }
   }
 
-  override public var traitCollection: UITraitCollection {
-    if UIDevice.current.userInterfaceIdiom == .pad && UIDevice.current.orientation.isPortrait {
-      return UITraitCollection(traitsFrom:[UITraitCollection(horizontalSizeClass: .compact),
-                                           UITraitCollection(verticalSizeClass: .regular)])
-    }
-    return super.traitCollection
-  }
-
   @objc func changeShape() {
     primarySlider.isHidden = true
     secondarySlider.isHidden = true

--- a/components/Ripple/examples/CardWithRippleExample.swift
+++ b/components/Ripple/examples/CardWithRippleExample.swift
@@ -70,14 +70,6 @@ class CardWithRippleExample: UIViewController {
     card.accessibilityTraits = .button
     card.accessibilityLabel = "Card with button"
   }
-
-  override public var traitCollection: UITraitCollection {
-    if UIDevice.current.userInterfaceIdiom == .pad && UIDevice.current.orientation.isPortrait {
-      return UITraitCollection(traitsFrom:[UITraitCollection(horizontalSizeClass: .compact),
-                                           UITraitCollection(verticalSizeClass: .regular)])
-    }
-    return super.traitCollection
-  }
 }
 
 extension CardWithRippleExample {


### PR DESCRIPTION
It's not clear to me why these existed – I can't see any visual difference before vs. after on an iPad in portrait orientation.

Fixes #7683