### PR TITLE
[Ink] Refactor MDCInkView logic for usesLegacyInkLayer, maxRippleRadius, inkStyle Interplay

### DIFF
--- a/components/Ink/src/MDCInkView.h
+++ b/components/Ink/src/MDCInkView.h
@@ -69,9 +69,8 @@ typedef NS_ENUM(NSInteger, MDCInkStyle) {
 
 /**
  Maximum radius of the ink. If the radius <= 0 then half the length of the diagonal of self.bounds
- is used. This value is ignored if @c inkStyle is set to |MDCInkStyleBounded|.
-
- Ignored if updated ink is used.
+ is used. This value is ignored if @c inkStyle is set to MDCInkStyleBounded and @c
+ usesLegacyInkLayer is set to NO.
  */
 @property(nonatomic, assign) CGFloat maxRippleRadius;
 


### PR DESCRIPTION
This PR aims to simplify the logic that grapples with the interplay of usesLegacyInkLayer with properties like maxRippleRadius and inkStyle. I recently merged https://github.com/material-components/material-components-ios/pull/9818 to address this issue, and while I believe it fixes his immediate issue it still leaves other potential issues. Specifically, it does not resolve potential problems related to the ordering of calls to setters for `usesLegacyInkLayer`, `inkStyle`, and `maxRippleRadius` impacting their effectiveness. Hopefully this PR addresses those issues without breaking anything else. I tried to manually test it pretty rigorously by setting all the properties in question in different orders and making sure that everything worked how I expected it to.

Closes #9762.