### PR TITLE
[Snackbar] Add an opt-in delay to post accessibility notification

### DIFF
--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -244,19 +244,19 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              dispatch_time_t accessibilityPostDelay =
-              dispatch_time(DISPATCH_TIME_NOW, (int64_t)(message.accessibilityPostDelay * NSEC_PER_SEC));
-    dispatch_after(accessibilityPostDelay, dispatch_get_main_queue(), ^(void) {
-                             if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
-                                 ![self isSnackbarTransient:snackbarView]) {
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                                snackbarView);
-              } else {
-                snackbarView.accessibilityElementsHidden = YES;
-                UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
-                                                message.voiceNotificationText);
-              }
-    });
+              dispatch_time_t accessibilityPostDelay = dispatch_time(
+                  DISPATCH_TIME_NOW, (int64_t)(message.accessibilityPostDelay * NSEC_PER_SEC));
+              dispatch_after(accessibilityPostDelay, dispatch_get_main_queue(), ^(void) {
+                if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
+                    ![self isSnackbarTransient:snackbarView]) {
+                  UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
+                                                  snackbarView);
+                } else {
+                  snackbarView.accessibilityElementsHidden = YES;
+                  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
+                                                  message.voiceNotificationText);
+                }
+              });
 
               if ([self isSnackbarTransient:snackbarView] && message.automaticallyDismisses) {
                 __weak MDCSnackbarMessageView *weakSnackbarView = snackbarView;

--- a/components/Snackbar/src/MDCSnackbarManager.m
+++ b/components/Snackbar/src/MDCSnackbarManager.m
@@ -244,8 +244,11 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
       showSnackbarView:snackbarView
               animated:YES
             completion:^{
-              if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
-                  ![self isSnackbarTransient:snackbarView]) {
+              dispatch_time_t accessibilityPostDelay =
+              dispatch_time(DISPATCH_TIME_NOW, (int64_t)(message.accessibilityPostDelay * NSEC_PER_SEC));
+    dispatch_after(accessibilityPostDelay, dispatch_get_main_queue(), ^(void) {
+                             if (snackbarView.accessibilityViewIsModal || message.focusOnShow ||
+                                 ![self isSnackbarTransient:snackbarView]) {
                 UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
                                                 snackbarView);
               } else {
@@ -253,6 +256,7 @@ static NSString *const kAllMessagesCategory = @"$$___ALL_MESSAGES___$$";
                 UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification,
                                                 message.voiceNotificationText);
               }
+    });
 
               if ([self isSnackbarTransient:snackbarView] && message.automaticallyDismisses) {
                 __weak MDCSnackbarMessageView *weakSnackbarView = snackbarView;

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -116,6 +116,13 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, assign) NSTimeInterval duration;
 
 /**
+ How long to delay the accessibility post notification of focusing and/or speaking the Snackbar message.
+
+ Defaults to 0 seconds (post notification is called immediately after the message is shown).
+ */
+@property(nonatomic, assign) NSTimeInterval accessibilityPostDelay;
+
+/**
  Called when a message is finished displaying.
 
  The message completion handler is called regardless of whether or not buttons were tapped and is

--- a/components/Snackbar/src/MDCSnackbarMessage.h
+++ b/components/Snackbar/src/MDCSnackbarMessage.h
@@ -116,7 +116,8 @@ extern NSString *__nonnull const MDCSnackbarMessageBoldAttributeName;
 @property(nonatomic, assign) NSTimeInterval duration;
 
 /**
- How long to delay the accessibility post notification of focusing and/or speaking the Snackbar message.
+ How long to delay the accessibility post notification of focusing and/or speaking the Snackbar
+ message.
 
  Defaults to 0 seconds (post notification is called immediately after the message is shown).
  */

--- a/components/Snackbar/src/MDCSnackbarMessage.m
+++ b/components/Snackbar/src/MDCSnackbarMessage.m
@@ -50,6 +50,7 @@ static BOOL _usesLegacySnackbar = NO;
   self = [super init];
   if (self) {
     _duration = kDefaultDuration;
+    _accessibilityPostDelay = 0;
     _automaticallyDismisses = YES;
   }
   return self;
@@ -63,6 +64,7 @@ static BOOL _usesLegacySnackbar = NO;
   MDCSnackbarMessage *copy = [[[self class] alloc] init];
   copy.attributedText = self.attributedText;
   copy.duration = self.duration;
+  copy.accessibilityPostDelay = self.accessibilityPostDelay;
   copy.category = self.category;
   copy.accessibilityLabel = self.accessibilityLabel;
   copy.accessibilityHint = self.accessibilityHint;

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -547,7 +547,7 @@
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
-- (void)testSnackbarAccessibilityPostNotificationDelay {
+- (void)testSnackbarAccessibilityPostNotificationDelayDoesDelayPost {
   // Given
   self.manager.internalManager.isVoiceOverRunningOverride = YES;
   self.message.accessibilityPostDelay = 3.0;

--- a/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
+++ b/components/Snackbar/tests/unit/MDCSnackbarMessageViewTests.m
@@ -547,4 +547,24 @@
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
+- (void)testSnackbarAccessibilityPostNotificationDelay {
+  // Given
+  self.manager.internalManager.isVoiceOverRunningOverride = YES;
+  self.message.accessibilityPostDelay = 3.0;
+  self.message.duration = 5.0;
+
+  // When
+  [self.manager showMessage:self.message];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completed"];
+  dispatch_time_t popTime =
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)((CGFloat)0.2 * NSEC_PER_SEC));
+  dispatch_after(popTime, dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+
+  // Then
+  XCTAssertFalse(self.manager.internalManager.currentSnackbar.accessibilityElementsHidden);
+}
+
 @end


### PR DESCRIPTION
Clients have been running into issues regarding the Snackbar's accessibility post notification. Specifically they have been witnessing how the Snackbar's accessibility focus is taken away due to a view controller present/dismiss which re-takes accessibility focus. This ends up having the Snackbar start reading its message but then immediately stop and lose focus. Other cases involve not necessarily a present/dismiss but due to other post notifications in the view controller itself. 

This change allows clients to delay the accessibility post notification if they want the Snackbar's focus to happen at a later time.

The default value for the delay property is 0, and hence is an opt-in for clients.

Tested internally with the clients reporting the issue to verify this helps resolve the problem.

Closes #9857 