### PR TITLE
[TextControls] Update MDCBaseTextField docs to point out that subclassing is unsupported

### DIFF
--- a/components/TextControls/src/BaseTextFields/MDCBaseTextField.h
+++ b/components/TextControls/src/BaseTextFields/MDCBaseTextField.h
@@ -17,8 +17,8 @@
 #import "MaterialTextControls+Enums.h"
 
 /**
- A UITextField subclass that will potentially provide the foundation for Material TextFields in the
- future. This class is under active development and should be used with caution.
+ The superclass of MDCFilledTextField and MDCOutlinedTextField. While not forbidden by the compiler,
+ subclassing this class is not supported and is highly discouraged.
  */
 @interface MDCBaseTextField : UITextField
 


### PR DESCRIPTION
After MDCBaseTextField was done being brought over and ready to use the docs were never updated to indicate that. They still warn against using it. This PR updates them.

This change was prompted by https://github.com/material-components/material-components-ios/issues/9860.

Related to #6945.