### PR TITLE
[Dialogs] Accessibility frame is larger than displayed text.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -712,6 +712,11 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     contentScrollViewRect.size.height = CGRectGetHeight(self.bounds) -
                                         actionsScrollViewRect.size.height -
                                         contentScrollViewRect.origin.y;
+
+    self.messageLabel.accessibilityFrame = UIAccessibilityConvertFrameToScreenCoordinates(
+        CGRectMake(messageFrame.origin.x, contentScrollViewRect.origin.y, messageFrame.size.width,
+                   MIN(contentScrollViewRect.size.height, messageFrame.size.height)),
+        self);
   }
   self.actionsScrollView.frame = actionsScrollViewRect;
   self.contentScrollView.frame = contentScrollViewRect;


### PR DESCRIPTION
# Description

The content's accessibility frame is matching the size of the message, including when the message is longer than the visible content area, causing the accessibility frame to stretch beyond the visible content size into the actions area (see "Before Screenshot").

## Before

![image](https://user-images.githubusercontent.com/2329102/76152370-f298a780-608c-11ea-9bdc-8003929df737.png)

## Bug Fix

The issue was fixed by setting accessibility frame to match the content area, instead of relying on the default behavior, which matched the message size.

Note: The size of the content area is incorrectly calculated for long messages. For longer messages, it is slightly larger than the visible content area, causing the accessibility frame to bleed into the actions, as seen in the "After Screenshot".  This issue is fixed in PR #9864.

## After

![image](https://user-images.githubusercontent.com/2329102/76152297-e3652a00-608b-11ea-92fe-17cbfc673d22.png)

## Issue

Closes #7637, together with PR: #9864
b/135572756