### PR TITLE
[Slider] Allow thumb to stay filled with discrete value label

### DIFF
--- a/components/Slider/src/MDCSlider.h
+++ b/components/Slider/src/MDCSlider.h
@@ -320,6 +320,14 @@ IB_DESIGNABLE
 @property(nonatomic, assign) BOOL shouldDisplayDiscreteValueLabel;
 
 /**
+ Whether or not to display the thumb when dragging a discrete slider with a value label.
+ This only applies when @c shouldDisplayDiscreteValueLabel is set to @c YES.
+
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldDisplayThumbWithDiscreteValueLabel;
+
+/**
  The color of the discrete value label's text.
 
  Resets to the default color.

--- a/components/Slider/src/MDCSlider.m
+++ b/components/Slider/src/MDCSlider.m
@@ -82,6 +82,7 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
   _trackTickVisibility = MDCSliderTrackTickVisibilityWhenDragging;
   _thumbTrack.discrete = YES;
   _thumbTrack.shouldDisplayDiscreteValueLabel = YES;
+  _thumbTrack.shouldDisplayThumbWithDiscreteValueLabel = NO;
   _thumbTrack.trackOffColor = [[self class] defaultTrackOffColor];
   _thumbTrack.thumbDisabledColor = [[self class] defaultDisabledColor];
   _thumbTrack.trackDisabledColor = [[self class] defaultDisabledColor];
@@ -372,6 +373,14 @@ static inline UIColor *MDCThumbTrackDefaultColor(void) {
 
 - (void)setShouldDisplayDiscreteValueLabel:(BOOL)shouldDisplayDiscreteValueLabel {
   _thumbTrack.shouldDisplayDiscreteValueLabel = shouldDisplayDiscreteValueLabel;
+}
+
+- (BOOL)shouldDisplayThumbWithDiscreteValueLabel {
+  return _thumbTrack.shouldDisplayThumbWithDiscreteValueLabel;
+}
+
+- (void)setShouldDisplayThumbWithDiscreteValueLabel:(BOOL)shouldDisplayThumbWithDiscreteValueLabel {
+  _thumbTrack.shouldDisplayThumbWithDiscreteValueLabel = shouldDisplayThumbWithDiscreteValueLabel;
 }
 
 - (BOOL)isThumbHollowAtStart {

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -770,13 +770,6 @@ static void MoveSliderThumbToRelativePosition(MDCSlider *slider,
       self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
   self.slider.shouldDisplayDiscreteValueLabel = YES;
   self.slider.shouldDisplayThumbWithDiscreteValueLabel = YES;
-  // In Thumbtrack's code, there is a check for verifying that the thumbtrack's width is larger
-  // than 1 point, otherwise it won't go into the main frame adjusting logic. This is to make sure
-  // that the scale transform of the slider's view isn't at its default of 0.001. Therefore this
-  // transform adjustment was made so it can let the logic know we are actually interacting with
-  // the thumb in the test.
-  UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
-  valueLabel.transform = CGAffineTransformIdentity;
   [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
 
   // Then

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -113,7 +113,7 @@ static void MoveSliderThumbToRelativePosition(MDCSlider *slider,
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  //    self.recordMode = YES;
+  //  self.recordMode = YES;
 
   self.slider =
       [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -113,7 +113,7 @@ static void MoveSliderThumbToRelativePosition(MDCSlider *slider,
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-//    self.recordMode = YES;
+  //    self.recordMode = YES;
 
   self.slider =
       [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];

--- a/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
+++ b/components/Slider/tests/snapshot/MDCSliderSnapshotTests.m
@@ -113,7 +113,7 @@ static void MoveSliderThumbToRelativePosition(MDCSlider *slider,
 
   // Uncomment below to recreate all the goldens (or add the following line to the specific
   // test you wish to recreate the golden for).
-  //  self.recordMode = YES;
+//    self.recordMode = YES;
 
   self.slider =
       [[MDCSliderWithCustomTraitCollection alloc] initWithFrame:CGRectMake(0, 0, 120, 48)];
@@ -761,6 +761,28 @@ static void MoveSliderThumbToRelativePosition(MDCSlider *slider,
 
   // Then
   [self generateSnapshotAndVerifyForView:self.slider];
+}
+
+- (void)testDiscreteSliderWithThumbAndValueLabel {
+  // When
+  [self makeSliderDiscrete:self.slider];
+  self.slider.value =
+      self.slider.minimumValue + (self.slider.maximumValue - self.slider.minimumValue) / 2;
+  self.slider.shouldDisplayDiscreteValueLabel = YES;
+  self.slider.shouldDisplayThumbWithDiscreteValueLabel = YES;
+  // In Thumbtrack's code, there is a check for verifying that the thumbtrack's width is larger
+  // than 1 point, otherwise it won't go into the main frame adjusting logic. This is to make sure
+  // that the scale transform of the slider's view isn't at its default of 0.001. Therefore this
+  // transform adjustment was made so it can let the logic know we are actually interacting with
+  // the thumb in the test.
+  UIView *valueLabel = [self.slider.thumbTrack valueForKey:@"_valueLabel"];
+  valueLabel.transform = CGAffineTransformIdentity;
+  [self.slider.thumbTrack setValue:@"YES" forKey:@"_isDraggingThumb"];
+
+  // Then
+  UIView *snapshotView =
+      [self.slider mdc_addToBackgroundViewWithInsets:UIEdgeInsetsMake(30, 0, 0, 0)];
+  [self generateSnapshotAndVerifyForView:snapshotView];
 }
 
 @end

--- a/components/Slider/tests/unit/MDCSliderTests.m
+++ b/components/Slider/tests/unit/MDCSliderTests.m
@@ -1547,7 +1547,6 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
 
   // Then
   XCTAssertTrue(self.slider.thumbTrack.shouldDisplayThumbWithDiscreteValueLabel = YES);
-  
 }
 
 #pragma mark Private test helpers

--- a/components/Slider/tests/unit/MDCSliderTests.m
+++ b/components/Slider/tests/unit/MDCSliderTests.m
@@ -1541,6 +1541,15 @@ static const CGFloat kEpsilonAccuracy = (CGFloat)0.001;
                         [[MDCTypography fontLoader] regularFontOfSize:12]);
 }
 
+- (void)testDisplayingThumbWithValueLabelOnSliderSetsCorrectlyOnThumbtrack {
+  // When
+  self.slider.shouldDisplayThumbWithDiscreteValueLabel = YES;
+
+  // Then
+  XCTAssertTrue(self.slider.thumbTrack.shouldDisplayThumbWithDiscreteValueLabel = YES);
+  
+}
+
 #pragma mark Private test helpers
 
 - (CGFloat)randomNumber {

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -200,7 +200,7 @@ typedef NS_ENUM(NSUInteger, MDCThumbDiscreteDotVisibility) {
 /**
  Whether or not to display the thumb when dragging a discrete slider with a value label.
  This only applies when @c shouldDisplayDiscreteValueLabel is set to @c YES.
- 
+
  Defaults to NO.
  */
 @property(nonatomic, assign) BOOL shouldDisplayThumbWithDiscreteValueLabel;

--- a/components/private/ThumbTrack/src/MDCThumbTrack.h
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.h
@@ -198,6 +198,14 @@ typedef NS_ENUM(NSUInteger, MDCThumbDiscreteDotVisibility) {
 @property(nonatomic, assign) BOOL shouldDisplayDiscreteValueLabel;
 
 /**
+ Whether or not to display the thumb when dragging a discrete slider with a value label.
+ This only applies when @c shouldDisplayDiscreteValueLabel is set to @c YES.
+ 
+ Defaults to NO.
+ */
+@property(nonatomic, assign) BOOL shouldDisplayThumbWithDiscreteValueLabel;
+
+/**
  Whether or not to show the filled track on the left of the thumb. If NO, the left track will be
  displayed with the same tint color as the right track.
 

--- a/components/private/ThumbTrack/src/MDCThumbTrack.m
+++ b/components/private/ThumbTrack/src/MDCThumbTrack.m
@@ -983,7 +983,8 @@ static inline CGFloat DistanceFromPointToPoint(CGPoint point1, CGPoint point2) {
 
   CGFloat radius;
   if (_isDraggingThumb) {
-    if (_shouldDisplayDiscreteValueLabel && _discrete && _numDiscreteValues > 1) {
+    if (!_shouldDisplayThumbWithDiscreteValueLabel && _discrete &&
+        _shouldDisplayDiscreteValueLabel && _numDiscreteValues > 1) {
       radius = 0;
     } else {
       radius = _thumbRadius + _trackHeight;

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderWithThumbAndValueLabel_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderWithThumbAndValueLabel_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077d4b67b9bfeb8909165a59ad71f7f9f04bae363c81c53a93e9c9701df656e5
+size 5332

--- a/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderWithThumbAndValueLabel_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCSliderSnapshotTests/testDiscreteSliderWithThumbAndValueLabel_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:077d4b67b9bfeb8909165a59ad71f7f9f04bae363c81c53a93e9c9701df656e5
-size 5332
+oid sha256:921d493644533e1d42c25170ea4ea5618e7497c9e25a2d91b633c640cd127467
+size 5376


### PR DESCRIPTION
As per Material Design: https://material.io/components/sliders/#discrete-slider a discrete slider can have it thumb stay even when a value label presents itself.

With the current implementation, when a value label on a discrete slider is displayed, the thumb disappears.

Clients can no opt-in to having the thumb continue to display itself when the value label is shown.

Tested by running catalog example on simulator with the property set to YES, as well as with unit test and snapshot test.

Closes #8986 