### PR TITLE
[FlexibleHeader] Fix jumping effect in a table view with dynamic cell heights.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderView.m
@@ -1322,9 +1322,10 @@ static inline MDCFlexibleHeaderShiftBehavior ShiftBehaviorForCurrentAppContext(
       CAAnimation *boundsAnimation =
           [self.trackingScrollView.layer animationForKey:@"bounds.origin"];
       if (boundsAnimation) {
-        [UIView animateWithDuration:boundsAnimation.duration animations:^{
-          updateTransform();
-        }];
+        [UIView animateWithDuration:boundsAnimation.duration
+                         animations:^{
+                           updateTransform();
+                         }];
       } else {
         updateTransform();
       }


### PR DESCRIPTION
## Context

1. FlexibleHeader is added to a UITableView.
2. That table view has cells that, when tapped, expand.
3. When the selected cell expands, the previously selected cell collapses.

## Reproduction steps

1. Open AppBarWithExpandableCells.
2. Tap a cell to expand it.
3. Scroll the cell above the top of the FlexibleHeader
4. Tap another cell to expand it and collapse the off-screen cell.

## Impact of this change

Prior to this change, the FlexibleHeader would "jump" off-screen momentarily and then appear to animate back on-screen. This was happening even though the FlexibleHeader's shift behavior was disabled.

After this change, the FlexibleHeader will stay on-screen when these repro steps occur.

## Root cause analysis

To identify the root cause of this, I started by putting a log statement in fhv_commitAccumulatorToFrame just before self.center is called in https://github.com/material-components/material-components-ios/blob/6326cd055aef43882257c9cd4264376b7be4523a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m#L1241-L1244, because fhv_commitAccumulatorToFrame is the method that adjusts the offset of the header when shifting. As I went through the repro steps I saw that the position of the header view never changed, but I did still see the header jumping off-screen momentarily.

The only other way the FlexibleHeader's position can be adjusted is if it is a subview of the tracking scroll view, in which case the FlexibleHeader will offset its frame's position using an inverse translation transform on the view: https://github.com/material-components/material-components-ios/blob/6326cd055aef43882257c9cd4264376b7be4523a/components/FlexibleHeader/src/MDCFlexibleHeaderView.m#L1298-L1315. This most commonly comes in to play when the FlexibleHeader is added as a subview of a UITableViewController's .view, which is the .tableView.

The root cause of this issue appears to be that UITableView will animate its bounds to account for the change in cell height. This animation happens while the scroll view's content offset is being adjusted which results in the scroll view appearing to stay visually in place.

Because this animation happens on the tracking scroll view, which is itself a parent of the FlexibleHeader's view, the FlexibleHeader appears to "shift" off-screen momentarily as part of this animation because its transform is updated immediately and is therefor out of sync with the scroll view's position for the course of the scroll view bounds animation.

Closes https://github.com/material-components/material-components-ios/issues/9853