### PR TITLE
[NavigationDrawer] Support bottom drawer presentation from presenting ViewController that is presented with Page Sheet or Form Sheet modalPresentationStyle.

### DIFF
--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.m
@@ -561,19 +561,22 @@ NSString *const kMDCBottomDrawerScrollViewAccessibilityIdentifier =
 }
 
 - (void)setupLayout {
-  // Layout the clipping view and the scroll view.
-  if (self.currentlyFullscreen) {
-    CGRect scrollViewFrame = self.presentingViewBounds;
-    self.scrollView.frame = scrollViewFrame;
-  } else {
-    CGRect scrollViewFrame = self.presentingViewBounds;
+  // Layout the scroll view.
+  CGRect scrollViewFrame = self.presentingViewBounds;
+  if (!self.currentlyFullscreen) {
     if (self.animatingPresentation) {
       CGFloat heightSurplusForSpringAnimationOvershooting =
           self.presentingViewBounds.size.height / 2;
       scrollViewFrame.size.height += heightSurplusForSpringAnimationOvershooting;
     }
-    self.scrollView.frame = scrollViewFrame;
+
+    // Adjust y-position of origin to account for non-fullscreen presentation styles.
+    CGFloat yOffset = CGRectGetHeight(self.view.frame) - CGRectGetHeight(self.presentingViewBounds);
+    if (yOffset > 0) {
+      scrollViewFrame.origin.y += yOffset;
+    }
   }
+  self.scrollView.frame = scrollViewFrame;
 
   // Layout the top header's bottom shadow.
   [self setUpHeaderBottomShadowIfNeeded];


### PR DESCRIPTION
This closes #9586, which was being caused because the presenting view controller is used to determine the frame of the bottom drawer's scroll view, which caused issues for situations in which the bottom drawer was presented from a modal view controller in the page or form sheet style.

This PR resolves said issue by adding an adjustment for the difference if applicable.

This change is necessary to fully support changes in modal presentation style as of iOS 13 + Xcode 11, which is important for clients because building with SDK 13/Xcode 11 is required for app store submission starting April 2020.

I verified this by testing the solution as it applies to our internal related bug, [b/151091406](https://b.corp.google.com/issues/151091406), as well as by verifying this solution in the example project attached to the original reporting of this bug, [b/148977218](https://b.corp.google.com/issues/148977218), and have added screencasts of this below (also attached to original bug for easier viewing).

BEFORE: [b_148977218 #9586 BEFORE.webm.zip](https://github.com/material-components/material-components-ios/files/4314149/b_148977218.9586.BEFORE.webm.zip)

AFTER: [b_148977218 #9586 AFTER.webm.zip](https://github.com/material-components/material-components-ios/files/4314150/b_148977218.9586.AFTER.webm.zip)

As a sanity check, I also applied these changes to the catalog application and verified that it does not break any of the examples for this component.