### PR TITLE
[Dialogs] Fix vertical calculations for wide actions view

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -417,12 +417,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   NSArray<MDCButton *> *buttons = self.actionManager.buttonsInActionOrder;
   if (0 < buttons.count) {
     size.height = self.actionsInsets.top + self.actionsInsets.bottom;
-    size.width = self.actionsInsets.left + self.actionsInsets.right;
+    CGFloat widthInset = self.actionsInsets.left + self.actionsInsets.right;
     for (UIButton *button in buttons) {
       CGSize buttonSize = [button sizeThatFits:size];
       buttonSize.height = MAX(buttonSize.height, MDCDialogActionButtonMinimumHeight);
       size.height += buttonSize.height;
-      size.width = MAX(size.width, buttonSize.width);
+      size.width = MAX(size.width, buttonSize.width + widthInset);
       if (button != buttons.lastObject) {
         size.height += self.actionsVerticalMargin;
       }

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForCatpitalizedButtonCase_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForCatpitalizedButtonCase_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23d444f47150a75bfb3a7001ba0152a469bf4732cc1bf0bc4f22bdb43217b3f0
-size 23329
+oid sha256:41c9299a623f7522aa878ac1271ef12a8895484c8d2697928e82751ec265baf7
+size 24188

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForExtraLongButtons_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForExtraLongButtons_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e491b6ce672b2d700ca0a4d6528921032763d4f0598707ab8b509dcf80af9cc7
-size 21393
+oid sha256:055c9738ca78595d3ce23252375edf122cb84cb74be6ada672609f14d17f9967
+size 23205


### PR DESCRIPTION
# Description

This issue is specific to alerts with actions that are wider than the title and the message. The width of the alert, which is based on it's widest part (in this case the actions) did not include the insets in the width, causing differences in calculating the final width of the alerts, and cause long actions to be truncated.

## Before
Actions width off, causing the center action to truncate.

![dialog - action-width - BEFORE](https://user-images.githubusercontent.com/2329102/76384098-5c86aa80-6334-11ea-852c-209dc01d57bc.png)

## After

![dialog - action-width - AFTER](https://user-images.githubusercontent.com/2329102/76384099-5c86aa80-6334-11ea-9d62-9b3bf328c999.png)

## Issues
b/137070719, cl/299735845

Addresses part of the issue mentioned in #8434 