### PR TITLE
[AppBar] Add a delegate for customizing accessibilityPerformEscape behavior.

### DIFF
--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -17,7 +17,7 @@
 #import "MaterialNavigationBar.h"
 
 @class MDCAppBarViewController;
-@protocol MDCAppBarViewControllerDelegate;
+@protocol MDCAppBarViewControllerAccessibilityPerformEscapeDelegate;
 
 /**
  MDCAppBarViewController is a flexible header view controller that manages a navigation bar and
@@ -52,8 +52,16 @@
  */
 @property(nonatomic) CGFloat headerStackViewOffset;
 
-/** The safe area delegate can be queried for the correct way to calculate safe areas. */
-@property(nonatomic, weak, nullable) id<MDCAppBarViewControllerDelegate> delegate;
+/**
+ A delegate that, if provided, allows for customization of the default behavior of
+ @c accessibilityPerformEscape.
+
+ If nil, then the default behavior will attempt to dismiss the MDCAppBarViewController's parent
+ view controller and the @c accessibilityPerformEscape will return @c YES.
+ */
+@property(nonatomic, weak, nullable)
+    id<MDCAppBarViewControllerAccessibilityPerformEscapeDelegate>
+    accessibilityPerformEscapeDelegate;
 
 @end
 
@@ -61,14 +69,11 @@
  A delegate that can be implemented in order to respond to events specific to
  MDCAppBarViewController.
  */
-@protocol MDCAppBarViewControllerDelegate <NSObject>
-@optional
+@protocol MDCAppBarViewControllerAccessibilityPerformEscapeDelegate <NSObject>
+@required
 
 /**
  Informs the receiver that the app bar view controller received an accessibilityPerformEscape event.
-
- If this method is not implemented, then the app bar view controller will attempt to dismiss itself
- automatically.
 
  The receiver should return @c YES if the modal view is successfully dismissed; otherwise,
  return @c NO. The value returned by this method is in turn returned to the

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -57,7 +57,7 @@
  @c accessibilityPerformEscape.
 
  If nil, then the default behavior will attempt to dismiss the MDCAppBarViewController's parent
- view controller and the @c accessibilityPerformEscape will return @c YES.
+ view controller and @c accessibilityPerformEscape will return @c YES.
  */
 @property(nonatomic, weak, nullable) id<MDCAppBarViewControllerAccessibilityPerformEscapeDelegate>
     accessibilityPerformEscapeDelegate;

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -59,8 +59,7 @@
  If nil, then the default behavior will attempt to dismiss the MDCAppBarViewController's parent
  view controller and the @c accessibilityPerformEscape will return @c YES.
  */
-@property(nonatomic, weak, nullable)
-    id<MDCAppBarViewControllerAccessibilityPerformEscapeDelegate>
+@property(nonatomic, weak, nullable) id<MDCAppBarViewControllerAccessibilityPerformEscapeDelegate>
     accessibilityPerformEscapeDelegate;
 
 @end

--- a/components/AppBar/src/MDCAppBarViewController.h
+++ b/components/AppBar/src/MDCAppBarViewController.h
@@ -17,6 +17,7 @@
 #import "MaterialNavigationBar.h"
 
 @class MDCAppBarViewController;
+@protocol MDCAppBarViewControllerDelegate;
 
 /**
  MDCAppBarViewController is a flexible header view controller that manages a navigation bar and
@@ -50,6 +51,31 @@
  Defines a downward shift distance for `headerStackView`.
  */
 @property(nonatomic) CGFloat headerStackViewOffset;
+
+/** The safe area delegate can be queried for the correct way to calculate safe areas. */
+@property(nonatomic, weak, nullable) id<MDCAppBarViewControllerDelegate> delegate;
+
+@end
+
+/**
+ A delegate that can be implemented in order to respond to events specific to
+ MDCAppBarViewController.
+ */
+@protocol MDCAppBarViewControllerDelegate <NSObject>
+@optional
+
+/**
+ Informs the receiver that the app bar view controller received an accessibilityPerformEscape event.
+
+ If this method is not implemented, then the app bar view controller will attempt to dismiss itself
+ automatically.
+
+ The receiver should return @c YES if the modal view is successfully dismissed; otherwise,
+ return @c NO. The value returned by this method is in turn returned to the
+ @c accessibilityPerformEscape event.
+ */
+- (BOOL)appBarViewControllerAccessibilityPerformEscape:
+    (nonnull MDCAppBarViewController *)appBarViewController;
 
 @end
 

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -276,6 +276,12 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 #pragma mark - UIAccessibility
 
 - (BOOL)accessibilityPerformEscape {
+  if ([self.delegate respondsToSelector:
+          @selector(appBarViewControllerAccessibilityPerformEscape:)]) {
+    return [self.delegate appBarViewControllerAccessibilityPerformEscape:self];
+  }
+
+  // Fall-back behavior.
   [self dismissSelf];
   return YES;
 }

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -276,9 +276,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 #pragma mark - UIAccessibility
 
 - (BOOL)accessibilityPerformEscape {
-  if ([self.delegate
-          respondsToSelector:@selector(appBarViewControllerAccessibilityPerformEscape:)]) {
-    return [self.delegate appBarViewControllerAccessibilityPerformEscape:self];
+  if (self.accessibilityPerformEscapeDelegate) {
+    return [self.accessibilityPerformEscapeDelegate appBarViewControllerAccessibilityPerformEscape:self];
   }
 
   // Fall-back behavior.

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -277,7 +277,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 
 - (BOOL)accessibilityPerformEscape {
   if (self.accessibilityPerformEscapeDelegate) {
-    return [self.accessibilityPerformEscapeDelegate appBarViewControllerAccessibilityPerformEscape:self];
+    return [self.accessibilityPerformEscapeDelegate
+        appBarViewControllerAccessibilityPerformEscape:self];
   }
 
   // Fall-back behavior.

--- a/components/AppBar/src/MDCAppBarViewController.m
+++ b/components/AppBar/src/MDCAppBarViewController.m
@@ -276,8 +276,8 @@ static NSString *const kMaterialAppBarBundle = @"MaterialAppBar.bundle";
 #pragma mark - UIAccessibility
 
 - (BOOL)accessibilityPerformEscape {
-  if ([self.delegate respondsToSelector:
-          @selector(appBarViewControllerAccessibilityPerformEscape:)]) {
+  if ([self.delegate
+          respondsToSelector:@selector(appBarViewControllerAccessibilityPerformEscape:)]) {
     return [self.delegate appBarViewControllerAccessibilityPerformEscape:self];
   }
 

--- a/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
+++ b/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
@@ -49,7 +49,7 @@ class AppBarDelegateAccessibilityPerformEscapeTests: XCTestCase {
     // Given
     let delegate = FakeDelegate()
     delegate.accessibilityPerformEscapeResult = true
-    appBarViewController.delegate = accessibilityPerformEscapeDelegate
+    appBarViewController.accessibilityPerformEscapeDelegate = delegate
 
     // When
     let result = appBarViewController.accessibilityPerformEscape()
@@ -63,7 +63,7 @@ class AppBarDelegateAccessibilityPerformEscapeTests: XCTestCase {
     // Given
     let delegate = FakeDelegate()
     delegate.accessibilityPerformEscapeResult = false
-    appBarViewController.delegate = accessibilityPerformEscapeDelegate
+    appBarViewController.accessibilityPerformEscapeDelegate = delegate
 
     // When
     let result = appBarViewController.accessibilityPerformEscape()

--- a/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
+++ b/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import MaterialComponents.MaterialAppBar
+
+private class FakeDelegate: NSObject, MDCAppBarViewControllerDelegate {
+  var accessibilityPerformEscapeResult = false
+  var didInvokeAppBarViewControllerAccessibilityPerformEscape = false
+
+  func appBarViewControllerAccessibilityPerformEscape(_ appBarViewController: MDCAppBarViewController) -> Bool {
+    didInvokeAppBarViewControllerAccessibilityPerformEscape = true
+    return accessibilityPerformEscapeResult
+  }
+}
+
+class AppBarDelegateAccessibilityPerformEscapeTests: XCTestCase {
+
+  var appBarViewController: MDCAppBarViewController!
+
+  override func setUp() {
+    super.setUp()
+
+    appBarViewController = MDCAppBarViewController()
+  }
+
+  override func tearDown() {
+    appBarViewController = nil
+
+    super.tearDown()
+  }
+
+  func testDefaults() {
+    XCTAssertNil(appBarViewController.delegate)
+  }
+
+  func testInvokesDelegateAndReturnsTrueValue() {
+    // Given
+    let delegate = FakeDelegate()
+    delegate.accessibilityPerformEscapeResult = true
+    appBarViewController.delegate = delegate
+
+    // When
+    let result = appBarViewController.accessibilityPerformEscape()
+
+    // Then
+    XCTAssertTrue(delegate.didInvokeAppBarViewControllerAccessibilityPerformEscape)
+    XCTAssertTrue(result)
+  }
+
+  func testInvokesDelegateAndReturnsFalseValue() {
+    // Given
+    let delegate = FakeDelegate()
+    delegate.accessibilityPerformEscapeResult = false
+    appBarViewController.delegate = delegate
+
+    // When
+    let result = appBarViewController.accessibilityPerformEscape()
+
+    // Then
+    XCTAssertTrue(delegate.didInvokeAppBarViewControllerAccessibilityPerformEscape)
+    XCTAssertFalse(result)
+  }
+}

--- a/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
+++ b/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
@@ -42,14 +42,14 @@ class AppBarDelegateAccessibilityPerformEscapeTests: XCTestCase {
   }
 
   func testDefaults() {
-    XCTAssertNil(appBarViewController.delegate)
+    XCTAssertNil(appBarViewController.accessibilityPerformEscapeDelegate)
   }
 
   func testInvokesDelegateAndReturnsTrueValue() {
     // Given
     let delegate = FakeDelegate()
     delegate.accessibilityPerformEscapeResult = true
-    appBarViewController.delegate = delegate
+    appBarViewController.delegate = accessibilityPerformEscapeDelegate
 
     // When
     let result = appBarViewController.accessibilityPerformEscape()
@@ -63,7 +63,7 @@ class AppBarDelegateAccessibilityPerformEscapeTests: XCTestCase {
     // Given
     let delegate = FakeDelegate()
     delegate.accessibilityPerformEscapeResult = false
-    appBarViewController.delegate = delegate
+    appBarViewController.delegate = accessibilityPerformEscapeDelegate
 
     // When
     let result = appBarViewController.accessibilityPerformEscape()

--- a/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
+++ b/components/AppBar/tests/unit/AppBarDelegateAccessibilityPerformEscapeTests.swift
@@ -15,7 +15,7 @@
 import XCTest
 import MaterialComponents.MaterialAppBar
 
-private class FakeDelegate: NSObject, MDCAppBarViewControllerDelegate {
+private class FakeDelegate: NSObject, MDCAppBarViewControllerAccessibilityPerformEscapeDelegate {
   var accessibilityPerformEscapeResult = false
   var didInvokeAppBarViewControllerAccessibilityPerformEscape = false
 


### PR DESCRIPTION
MDCAppBarViewController has a new delegate property with an optional method, `-appBarViewControllerAccessibilityPerformEscape:`. This method can be implemented to override the default behavior of MDCAppBarViewController when an accessibilityPerformEscape event is received.

Closes https://github.com/material-components/material-components-ios/issues/9576