### PR TITLE
[FlexibleHeader] Add unit test to reproduce https://github.com/material-components/material-components-ios/issues/9863.

### DIFF
--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
@@ -58,6 +58,42 @@
   XCTAssertNil(fhvc.hairline);
 }
 
+- (void)testFlexibleHeaderViewControllerShowsHairlineTruePersists {
+  // Given
+  MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
+
+  // When
+  fhvc.showsHairline = YES;
+
+  // Then
+  XCTAssertTrue(fhvc.showsHairline);
+}
+
+- (void)testFlexibleHeaderViewControllerShowsHairlineFalsePersists {
+  // Given
+  MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
+
+  // When
+  fhvc.showsHairline = NO;
+
+  // Then
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be NO.
+  XCTAssertTrue(fhvc.showsHairline);
+}
+
+- (void)testFlexibleHeaderViewControllerColorPersists {
+  // Given
+  MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
+  UIColor *color = [UIColor redColor];
+
+  // When
+  fhvc.hairlineColor = color;
+
+  // Then
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be equal to color.
+  XCTAssertNil(fhvc.hairlineColor);
+}
+
 #pragma mark - Visibility
 
 - (void)testAddsHairlineViewToContainerViewWhenMadeVisible {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
@@ -14,7 +14,12 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MaterialFlexibleHeader.h"
 #import "MDCFlexibleHeaderHairline.h"
+
+@interface MDCFlexibleHeaderViewController (UnitTesting)
+@property(nonatomic, strong) MDCFlexibleHeaderHairline *hairline;
+@end
 
 @interface FlexibleHeaderHairlineTests : XCTestCase
 @property(nonatomic, strong) MDCFlexibleHeaderHairline *hairline;
@@ -42,6 +47,15 @@
   XCTAssertEqualObjects(self.hairline.color, [UIColor blackColor]);
   XCTAssertEqual(self.hairline.containerView, self.containerView);
   XCTAssertEqual(self.hairline.containerView.subviews.count, 0);
+}
+
+- (void)testFlexibleHeaderViewControllerDefaults {
+  // Given
+  MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
+
+  // Then
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be non-nil.
+  XCTAssertNil(fhvc.hairline);
 }
 
 #pragma mark - Visibility

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "MaterialFlexibleHeader.h"
 #import "MDCFlexibleHeaderHairline.h"
+#import "MaterialFlexibleHeader.h"
 
 @interface MDCFlexibleHeaderViewController (UnitTesting)
 @property(nonatomic, strong) MDCFlexibleHeaderHairline *hairline;
@@ -54,7 +54,8 @@
   MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be non-nil.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
+  // be non-nil.
   XCTAssertNil(fhvc.hairline);
 }
 
@@ -77,7 +78,8 @@
   fhvc.showsHairline = NO;
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be NO.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
+  // be NO.
   XCTAssertTrue(fhvc.showsHairline);
 }
 
@@ -90,7 +92,8 @@
   fhvc.hairlineColor = color;
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should be equal to color.
+  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
+  // be equal to color.
   XCTAssertNil(fhvc.hairlineColor);
 }
 


### PR DESCRIPTION
The flexible header view controller's hairline object should not be nil after initialization of the controller, but it is.

Pre-work for resolving https://github.com/material-components/material-components-ios/issues/9863.
