### PR TITLE
[FlexibleHeader] Fix bug where hairline configuration would not persist.

### DIFF
--- a/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
+++ b/components/FlexibleHeader/src/MDCFlexibleHeaderViewController.m
@@ -133,12 +133,12 @@ static char *const kKVOContextMDCFlexibleHeaderViewController =
   headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   headerView.delegate = self;
   _headerView = headerView;
+
+  self.hairline = [[MDCFlexibleHeaderHairline alloc] initWithContainerView:_headerView];
 }
 
 - (void)loadView {
   self.view = self.headerView;
-
-  self.hairline = [[MDCFlexibleHeaderHairline alloc] initWithContainerView:self.headerView];
 }
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {

--- a/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
+++ b/components/FlexibleHeader/tests/unit/FlexibleHeaderHairlineTests.m
@@ -54,9 +54,7 @@
   MDCFlexibleHeaderViewController *fhvc = [[MDCFlexibleHeaderViewController alloc] init];
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
-  // be non-nil.
-  XCTAssertNil(fhvc.hairline);
+  XCTAssertNotNil(fhvc.hairline);
 }
 
 - (void)testFlexibleHeaderViewControllerShowsHairlineTruePersists {
@@ -78,9 +76,7 @@
   fhvc.showsHairline = NO;
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
-  // be NO.
-  XCTAssertTrue(fhvc.showsHairline);
+  XCTAssertFalse(fhvc.showsHairline);
 }
 
 - (void)testFlexibleHeaderViewControllerColorPersists {
@@ -92,9 +88,7 @@
   fhvc.hairlineColor = color;
 
   // Then
-  // TODO(https://github.com/material-components/material-components-ios/issues/9863): This should
-  // be equal to color.
-  XCTAssertNil(fhvc.hairlineColor);
+  XCTAssertEqual(fhvc.hairlineColor, color);
 }
 
 #pragma mark - Visibility


### PR DESCRIPTION
Prior to this change, the FlexibleHeader's hairline APIs were not backed by storage until the FlexibleHeader's view was loaded. This meant that settings on these properties would effectively get lost.

After this change, the FlexibleHeader initializes the hairline storage immediately on initialization so that the public hairline properties are consistently backed by storage.

Closes https://github.com/material-components/material-components-ios/issues/9863