### PR TITLE
[BottomSheet] fix to allow dismissOnDraggingDownSheet to be set

### DIFF
--- a/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
+++ b/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
@@ -60,7 +60,8 @@
   bottomSheet.scrimAccessibilityLabel = @"Close";
   bottomSheet.trackingScrollView = viewController.collectionView;
   bottomSheet.delegate = self;
-  // The line below is the purpose of this example and is the only delta between this example and the BottomSheetTypicalUseExample.m
+  // The line below is the purpose of this example and is the only delta between this example and
+  // the BottomSheetTypicalUseExample.m
   bottomSheet.dismissOnDraggingDownSheet = NO;
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }

--- a/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
+++ b/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
@@ -1,0 +1,77 @@
+// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+#import "MaterialAppBar+ColorThemer.h"
+#import "MaterialAppBar+TypographyThemer.h"
+#import "MaterialAppBar.h"
+#import "MaterialBottomSheet+ShapeThemer.h"
+#import "MaterialBottomSheet.h"
+#import "supplemental/BottomSheetDummyCollectionViewController.h"
+#import "supplemental/BottomSheetSupplemental.h"
+
+@interface BottomSheetDismissOnDraggingDownExample () <MDCBottomSheetControllerDelegate>
+@property(nonatomic, strong) MDCShapeScheme *shapeScheme;
+@end
+
+@implementation BottomSheetDismissOnDraggingDownExample
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _shapeScheme = [[MDCShapeScheme alloc] init];
+  }
+  return self;
+}
+
+- (void)presentBottomSheet {
+  BottomSheetDummyCollectionViewController *viewController =
+      [[BottomSheetDummyCollectionViewController alloc] initWithNumItems:102];
+  viewController.title = @"Bottom sheet example";
+
+  MDCAppBarContainerViewController *container =
+      [[MDCAppBarContainerViewController alloc] initWithContentViewController:viewController];
+  container.preferredContentSize = CGSizeMake(500, 200);
+  container.appBarViewController.headerView.trackingScrollView = viewController.collectionView;
+  container.topLayoutGuideAdjustmentEnabled = YES;
+
+  [MDCAppBarColorThemer applyColorScheme:self.colorScheme
+                  toAppBarViewController:container.appBarViewController];
+  [MDCAppBarTypographyThemer applyTypographyScheme:self.typographyScheme
+                            toAppBarViewController:container.appBarViewController];
+
+  MDCBottomSheetController *bottomSheet =
+      [[MDCBottomSheetController alloc] initWithContentViewController:container];
+  [MDCBottomSheetControllerShapeThemer applyShapeScheme:self.shapeScheme
+                                toBottomSheetController:bottomSheet];
+  bottomSheet.isScrimAccessibilityElement = YES;
+  bottomSheet.scrimAccessibilityLabel = @"Close";
+  bottomSheet.trackingScrollView = viewController.collectionView;
+  bottomSheet.delegate = self;
+  bottomSheet.dismissOnDraggingDownSheet = NO;
+  [self presentViewController:bottomSheet animated:YES completion:nil];
+}
+
+- (void)bottomSheetControllerDidChangeYOffset:(MDCBottomSheetController *)controller
+                                      yOffset:(CGFloat)yOffset {
+  NSLog(@"bottom sheet Y offset changed: %f", yOffset);
+}
+
+- (void)bottomSheetControllerStateChanged:(MDCBottomSheetController *)controller
+                                    state:(MDCSheetState)state {
+  NSLog(@"bottom sheet state changed to: %lu", (unsigned long)state);
+}
+
+@end

--- a/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
+++ b/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
@@ -1,4 +1,4 @@
-// Copyright 2017-present the Material Components for iOS authors. All Rights Reserved.
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@
   bottomSheet.scrimAccessibilityLabel = @"Close";
   bottomSheet.trackingScrollView = viewController.collectionView;
   bottomSheet.delegate = self;
+  // The line below is the purpose of this example and is the only delta between this example and the BottomSheetTypicalUseExample.m
   bottomSheet.dismissOnDraggingDownSheet = NO;
   [self presentViewController:bottomSheet animated:YES completion:nil];
 }

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.h
@@ -38,5 +38,8 @@
 @interface BottomSheetTypicalUseExample : BottomSheetPresenterViewController
 @end
 
+@interface BottomSheetDismissOnDraggingDownExample : BottomSheetPresenterViewController
+@end
+
 @interface BottomSheetShapedExample : BottomSheetPresenterViewController
 @end

--- a/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetSupplemental.m
@@ -120,6 +120,18 @@
 
 @end
 
+@implementation BottomSheetDismissOnDraggingDownExample (CatalogByConvention)
+
++ (NSDictionary *)catalogMetadata {
+  return @{
+    @"breadcrumbs" : @[ @"Bottom Sheet", @"Bottom Sheet DismissOnDraggingDown" ],
+    @"primaryDemo" : @NO,
+    @"presentable" : @NO,
+  };
+}
+
+@end
+
 @implementation BottomSheetShapedExample (CatalogByConvention)
 
 + (NSDictionary *)catalogMetadata {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -65,17 +65,6 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 @synthesize delegate;
 
-- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
-                       presentingViewController:(UIViewController *)presentingViewController {
-  self = [super initWithPresentedViewController:presentedViewController
-                       presentingViewController:presentingViewController];
-  if (self) {
-    _dismissOnDraggingDownSheet = YES;
-  }
-
-  return self;
-}
-
 - (UIView *)presentedView {
   return self.sheetView;
 }
@@ -114,6 +103,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.accessibilityTraits = _scrimAccessibilityTraits;
   _dimmingView.accessibilityLabel = _scrimAccessibilityLabel;
   _dimmingView.accessibilityHint = _scrimAccessibilityHint;
+
+  _dismissOnDraggingDownSheet = YES;
 
   UIScrollView *scrollView = self.trackingScrollView;
   if (scrollView == nil) {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -65,6 +65,17 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 @synthesize delegate;
 
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController {
+  self = [super initWithPresentedViewController:presentedViewController
+                       presentingViewController:presentingViewController];
+  if (self) {
+    _dismissOnDraggingDownSheet = YES;
+  }
+
+  return self;
+}
+
 - (UIView *)presentedView {
   return self.sheetView;
 }

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -65,6 +65,17 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
 
 @synthesize delegate;
 
+- (instancetype)initWithPresentedViewController:(UIViewController *)presentedViewController
+                       presentingViewController:(UIViewController *)presentingViewController {
+  self = [super initWithPresentedViewController:presentedViewController
+                       presentingViewController:presentingViewController];
+  if (self) {
+    _dismissOnDraggingDownSheet = YES;
+  }
+
+  return self;
+}
+
 - (UIView *)presentedView {
   return self.sheetView;
 }
@@ -103,8 +114,6 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.accessibilityTraits = _scrimAccessibilityTraits;
   _dimmingView.accessibilityLabel = _scrimAccessibilityLabel;
   _dimmingView.accessibilityHint = _scrimAccessibilityHint;
-
-  _dismissOnDraggingDownSheet = YES;
 
   UIScrollView *scrollView = self.trackingScrollView;
   if (scrollView == nil) {

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -115,8 +115,6 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   _dimmingView.accessibilityLabel = _scrimAccessibilityLabel;
   _dimmingView.accessibilityHint = _scrimAccessibilityHint;
 
-  _dismissOnDraggingDownSheet = YES;
-
   UIScrollView *scrollView = self.trackingScrollView;
   if (scrollView == nil) {
     scrollView = MDCBottomSheetGetPrimaryScrollView(self.presentedViewController);

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -388,7 +388,8 @@ static const CGFloat kSheetBounceBuffer = 150;
 - (void)draggableView:(__unused MDCDraggableView *)view
     draggingEndedWithVelocity:(CGPoint)velocity {
   MDCSheetState targetState;
-  MDCSheetState sheetStateClosable = self.dismissOnDraggingDownSheet ? MDCSheetStateClosed : MDCSheetStatePreferred;
+  MDCSheetState sheetStateClosable =
+      self.dismissOnDraggingDownSheet ? MDCSheetStateClosed : MDCSheetStatePreferred;
   if (self.preferredSheetHeight == [self maximumSheetHeight]) {
     // Cannot be extended, only closed.
     targetState = (velocity.y >= 0 ? sheetStateClosable : MDCSheetStatePreferred);

--- a/components/BottomSheet/src/private/MDCSheetContainerView.m
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.m
@@ -360,17 +360,14 @@ static const CGFloat kSheetBounceBuffer = 150;
     shouldBeginDraggingWithVelocity:(CGPoint)velocity {
   [self updateSheetState];
 
-  if (!self.dismissOnDraggingDownSheet) {
-    return NO;
-  }
+  BOOL draggingDown = (velocity.y >= 0);
 
   switch (self.sheetState) {
     case MDCSheetStatePreferred:
-      return YES;
+      return (!draggingDown || self.dismissOnDraggingDownSheet);
     case MDCSheetStateExtended: {
       UIScrollView *scrollView = self.sheet.scrollView;
       if (scrollView) {
-        BOOL draggingDown = (velocity.y >= 0);
         // Only allow dragging down if we are scrolled to the top.
         if (scrollView.contentOffset.y <= -scrollView.contentInset.top && draggingDown) {
           return YES;
@@ -391,15 +388,16 @@ static const CGFloat kSheetBounceBuffer = 150;
 - (void)draggableView:(__unused MDCDraggableView *)view
     draggingEndedWithVelocity:(CGPoint)velocity {
   MDCSheetState targetState;
+  MDCSheetState sheetStateClosable = self.dismissOnDraggingDownSheet ? MDCSheetStateClosed : MDCSheetStatePreferred;
   if (self.preferredSheetHeight == [self maximumSheetHeight]) {
     // Cannot be extended, only closed.
-    targetState = (velocity.y >= 0 ? MDCSheetStateClosed : MDCSheetStatePreferred);
+    targetState = (velocity.y >= 0 ? sheetStateClosable : MDCSheetStatePreferred);
   } else {
     CGFloat currentSheetHeight = CGRectGetMaxY(self.bounds) - CGRectGetMinY(self.sheet.frame);
     if (currentSheetHeight >= self.preferredSheetHeight) {
       targetState = (velocity.y >= 0 ? MDCSheetStatePreferred : MDCSheetStateExtended);
     } else {
-      targetState = (velocity.y >= 0 ? MDCSheetStateClosed : MDCSheetStatePreferred);
+      targetState = (velocity.y >= 0 ? sheetStateClosable : MDCSheetStatePreferred);
     }
   }
   self.isDragging = NO;

--- a/components/BottomSheet/tests/snapshot/MDCBottomSheetControllerSnapshotTests.m
+++ b/components/BottomSheet/tests/snapshot/MDCBottomSheetControllerSnapshotTests.m
@@ -105,4 +105,25 @@
   [self snapshotVerifyViewForIOS13:window];
 }
 
+- (void)testBottomSheetWithDismissOnDraggingDownSheetOff {
+  // Given
+  UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
+  UIViewController *currentViewController = window.rootViewController;
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Bottom sheet is presented"];
+  self.bottomSheet.dismissOnDraggingDownSheet = NO;
+
+  // When
+  [currentViewController presentViewController:self.bottomSheet
+                                      animated:NO
+                                    completion:^{
+    XCTAssertFalse(self.bottomSheet.dismissOnDraggingDownSheet);
+    [expectation fulfill];
+
+                                    }];
+
+  // Then
+  [self waitForExpectations:@[ expectation ] timeout:5];
+}
+
 @end

--- a/components/BottomSheet/tests/snapshot/MDCBottomSheetControllerSnapshotTests.m
+++ b/components/BottomSheet/tests/snapshot/MDCBottomSheetControllerSnapshotTests.m
@@ -117,9 +117,8 @@
   [currentViewController presentViewController:self.bottomSheet
                                       animated:NO
                                     completion:^{
-    XCTAssertFalse(self.bottomSheet.dismissOnDraggingDownSheet);
-    [expectation fulfill];
-
+                                      XCTAssertFalse(self.bottomSheet.dismissOnDraggingDownSheet);
+                                      [expectation fulfill];
                                     }];
 
   // Then

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -352,7 +352,7 @@
   XCTAssertFalse(shouldBeginDragging);
 }
 
--(void)testPresentationControllerDefaults {
+- (void)testPresentationControllerDefaults {
   // Then
   XCTAssertTrue(self.presentationController.dismissOnDraggingDownSheet);
 }

--- a/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
+++ b/components/BottomSheet/tests/unit/MDCBottomSheetPresentationControllerTests.m
@@ -352,4 +352,8 @@
   XCTAssertFalse(shouldBeginDragging);
 }
 
+-(void)testPresentationControllerDefaults {
+  // Then
+  XCTAssertTrue(self.presentationController.dismissOnDraggingDownSheet);
+}
 @end


### PR DESCRIPTION
This change corrected the presentation logic so that the dismissOnDraggingDownSheet would not get reset. 

The flag was being used internally to turn on/off all dragging of the bottom sheet.
Adjustments were made to the logic to allow for upward expand and prefered positions which is what is expected of this external API.


After: [BottomSheet DismissOnDraggingDown.mov.zip](https://github.com/material-components/material-components-ios/files/4325758/BottomSheet.DismissOnDraggingDown.mov.zip)

Information sourced from internal bug:
When using a MDCBottomSheetTransitionController with a custom view controller, setting its dismissOnDraggingDownSheet to false has no effect.

The reason seems to be that MDCBottomSheetPresentationController always sets _dismissOnDraggingDownSheet = YES in |presentationTransitionWillBegin|, before creating the sheetView.

_dismissOnDraggingDownSheet = YES should be moved to the initializer, allowing the value to be overridden before the transition begins

https://github.com/material-components/material-components-ios/issues/9723