### PR TITLE
[Dialogs] Fix actions order for center and justified actions alignment.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -748,26 +748,24 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
                            (self.actionsInsets.left + self.actionsInsets.right);
   CGPoint buttonOrigin = CGPointZero;
   CGFloat buttonWidth = 0.f;
-  CGFloat multiplier = 1.f;
-  if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentTrailing) {
-    buttonOrigin.x = self.actionsScrollView.contentSize.width - self.actionsInsets.right;
-    multiplier = -1.f;
+  CGFloat multiplier =
+      self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentLeading ? 1.f : -1.f;
+  if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentLeading) {
+    buttonOrigin.x = self.actionsInsets.left;
   } else if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentCenter) {
     CGFloat actionWidthNoInsets =
         actionSize.width - self.actionsInsets.left - self.actionsInsets.right;
-    buttonOrigin.x = (self.actionsScrollView.contentSize.width - actionWidthNoInsets) / 2.f;
-  } else {  // leading or fill
-    buttonOrigin.x = self.actionsInsets.left;
+    buttonOrigin.x = ((self.actionsScrollView.contentSize.width - actionWidthNoInsets) / 2.f) +
+                     actionWidthNoInsets;
+  } else {  // trailing or justified
+    buttonOrigin.x = self.actionsScrollView.contentSize.width - self.actionsInsets.right;
   }
   buttonOrigin.y = self.actionsInsets.top;
   for (UIButton *button in buttons) {
     CGRect buttonRect = button.frame;
 
     buttonWidth = buttonRect.size.width;
-
-    if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentTrailing) {
-      buttonOrigin.x -= buttonRect.size.width;
-    } else if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentJustified) {
+    if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentJustified) {
       if (buttons.count > 1) {
         CGFloat totalMargin = self.actionsHorizontalMargin * (buttons.count - 1);
         buttonWidth = (maxButtonWidth - totalMargin) / buttons.count;
@@ -775,16 +773,21 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
         buttonWidth = maxButtonWidth;
       }
     }
+
+    if (self.actionsHorizontalAlignment != MDCContentHorizontalAlignmentLeading) {
+      buttonOrigin.x += multiplier * buttonWidth;
+    }
+
     buttonRect.origin = buttonOrigin;
     buttonRect.size.width = buttonWidth;
 
     button.frame = buttonRect;
 
     if (button != buttons.lastObject) {
-      if (self.actionsHorizontalAlignment != MDCContentHorizontalAlignmentTrailing) {
-        buttonOrigin.x += buttonRect.size.width + self.actionsHorizontalMargin;
+      if (self.actionsHorizontalAlignment == MDCContentHorizontalAlignmentLeading) {
+        buttonOrigin.x += multiplier * (buttonWidth + self.actionsHorizontalMargin);
       } else {
-        buttonOrigin.x -= self.actionsHorizontalMargin;
+        buttonOrigin.x += multiplier * self.actionsHorizontalMargin;
       }
     }
   }

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreCenteredInHorizontalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreCenteredInHorizontalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0247c7bf55403d09666f70bcda7e7df0bc2d3ab353c6e15aa8a01f345a5e6ee
-size 49392
+oid sha256:874a6b9acdbbb2ea1b43d1eed5a916e1171a50017632758cb29e35a0598a9b9b
+size 49372

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreJustifiedInHorizontalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testLowEmphasisActionsAreJustifiedInHorizontalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df4d0dd0f8d4c38a3e17656f1460876aa23cf53bfa088e93ac3441697fdd3f59
-size 49437
+oid sha256:aa7922f304ffe9be3834685bd0534be13ff94ab4537833ee2d47bf0e2aa34343
+size 49406

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreCenteredInHorizontalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreCenteredInHorizontalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ca2ee04001c56fc2193bd89c20065800204b1b59e8594f7abe28ffed416d121
-size 50613
+oid sha256:62fd9827ba93c1943a524e4a8025dbc016904073c0edf383cb28f6050845d6fd
+size 50623

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreJustifiedInHorizontalLayout_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testMediumEmphasisActionsAreJustifiedInHorizontalLayout_11_2@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85bd2f29cfae8c264b1e3dbd510a7cddfcf1d52b4d5b3809ad0806a844cf750b
-size 50395
+oid sha256:7a6ec5268203b9f8128ad5b22498f5d2111ed0885ec5c8b6f169851173236cd1
+size 50377


### PR DESCRIPTION
# Description

Actions are ordered consistently in all action alignment modes, except for leading alignment.

When adding actions, the first added action appears on the trailing side for these actionsAlignment enums: trailing, centered and justified alignments.
The first added action appears on the leading side in Leading alignment.

The actions order for centered and justified actions were fixed in this PR.

## Centered Actions
![2020-03-12-dialog-centered-actions](https://user-images.githubusercontent.com/2329102/76544315-31987580-645e-11ea-84d9-9de8a524ff4a.png)

## Justified Actions
![2020-03-12-dialog-justified-actions](https://user-images.githubusercontent.com/2329102/76544317-31987580-645e-11ea-90ed-8e4103e88ccb.png)

## Issues
Closes: #9890.
b/151317453, cl/300541039
