### PR TITLE
[Dialogs] Add a snapshot test for extra long buttons

### DIFF
--- a/components/Dialogs/tests/snapshot/MDCAlertControllerActionsTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerActionsTests.m
@@ -65,6 +65,14 @@ static NSString *const kSecondLongAction = @"Second Long Long Action";
   [super tearDown];
 }
 
+- (void)sizeTofitContent {
+  // Ensure snapshot view size matches actual runtime size of alert
+  MDCAlertControllerView *alertView = (MDCAlertControllerView *)self.alertController.view;
+  CGSize preferredContentSize = self.alertController.preferredContentSize;
+  CGSize bounds = [alertView calculatePreferredContentSizeForBounds:preferredContentSize];
+  self.alertController.view.bounds = CGRectMake(0.f, 0.f, bounds.width, bounds.height);
+}
+
 - (void)generateSnapshotAndVerifyForView:(UIView *)view {
   [view layoutIfNeeded];
 
@@ -221,11 +229,22 @@ static NSString *const kSecondLongAction = @"Second Long Long Action";
   }
 
   // Then
-  // Ensure snapshot view size matches actual runtime size of alert
-  CGSize preferredContentSize = self.alertController.preferredContentSize;
-  MDCAlertControllerView *alertView = (MDCAlertControllerView *)self.alertController.view;
-  CGSize bounds = [alertView calculatePreferredContentSizeForBounds:preferredContentSize];
-  self.alertController.view.bounds = CGRectMake(0.f, 0.f, bounds.width, bounds.height);
+  [self sizeTofitContent];
+  [self generateSnapshotAndVerifyForView:self.alertController.view];
+}
+
+- (void)testActionsLayoutHorizontallyForExtraLongButtons {
+  // Given
+  self.alertController.title = @"Recurring actions";
+  self.alertController.message = nil;
+  [self addLowEmphasisAction:@"This and all following events"];
+  [self addLowEmphasisAction:@"This and all following events"];
+
+  // When
+  [self.alertController applyThemeWithScheme:self.containerScheme2019];
+
+  // Then
+  [self sizeTofitContent];
   [self generateSnapshotAndVerifyForView:self.alertController.view];
 }
 

--- a/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForExtraLongButtons_11_2@2x.png
+++ b/snapshot_test_goldens/goldens_64/MDCAlertControllerActionsTests/testActionsLayoutHorizontallyForExtraLongButtons_11_2@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e491b6ce672b2d700ca0a4d6528921032763d4f0598707ab8b509dcf80af9cc7
+size 21393


### PR DESCRIPTION
# Description

Adding a snapshot test to demonstrate the truncation of extra long buttons (buttons that are longer than the title).

This issue is fixed in PR #9878.

![image](https://user-images.githubusercontent.com/2329102/76674303-3a836700-6584-11ea-87f7-040fcf12bc82.png)

## Issues
Closes #8434.
b/137070719, cl/299735845
