### PR TITLE
[Material Dialogs] Custom title icon public API: Flip the priority between title icon and title custom view to mirror UIKit convention.

### DIFF
--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -27,9 +27,11 @@
 /**
  An optional custom icon view above the title of the alert.
 
- @note This property is intended to be used to provide a custom implementation of the title icon
- view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
- 'titleIcon' is set, 'titleIconView' is ignored.
+ @discussion This property is intended to be used to provide a custom implementation of the title
+ icon view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
+ this property value is nil, the title icon is displayed above the title view. If you set this
+ property to a custom view, it is displayed instead of the title icon. Custom title views are
+ aligned with the title and may be resized to fit.
  */
 @property(nonatomic, strong, nullable) UIView *titleIconView;
 

--- a/components/Dialogs/src/private/MDCAlertController+Customize.h
+++ b/components/Dialogs/src/private/MDCAlertController+Customize.h
@@ -19,9 +19,11 @@
 /**
  An optional custom icon view above the title of the alert.
 
- @note This property is intended to be used to provide a custom implementation of the title icon
- view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
- 'titleIcon' is set, 'titleIconView' is ignored.
+ @discussion This property is intended to be used to provide a custom implementation of the title
+ icon view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
+ this property value is nil, the title icon is displayed above the title view. If you set this
+ property to a custom view, it is displayed instead of the title icon. Custom title views are
+ aligned with the title and may be resized to fit.
  */
 @property(nonatomic, strong, nullable) UIView *titleIconView;
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -212,11 +212,6 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     return;
   }
 
-  if (self.titleIconView != nil) {
-    [self.titleIconView removeFromSuperview];
-    self.titleIconView = nil;
-  }
-
   if (self.titleIconImageView == nil) {
     self.titleIconImageView = [[UIImageView alloc] initWithImage:titleIcon];
     self.titleIconImageView.contentMode = UIViewContentModeScaleAspectFit;
@@ -238,8 +233,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   if (self.titleIconImageView != nil) {
     NSLog(@"Warning: unintended use of the API. The following APIs are not expected to be used"
            "together: 'setTitleIconView:' and `setTitleIcon:` API. Please set either, but not "
-           "both at the same time. If 'titleIcon' is set, 'titleIconView' is ignored.");
-    return;
+           "both at the same time. If 'titleIconView' is set, 'titleIcon' is ignored.");
+    [self.titleIconImageView removeFromSuperview];
+    self.titleIconImageView = nil;
+    [self setNeedsLayout];
   }
   if (_titleIconView == nil || ![_titleIconView isEqual:titleIconView]) {
     if (_titleIconView != nil) {
@@ -249,7 +246,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     if (_titleIconView != nil) {
       [self.titleScrollView addSubview:_titleIconView];
     }
-    [self.titleScrollView setNeedsLayout];
+    [self setNeedsLayout];
   }
 }
 
@@ -473,10 +470,10 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 - (CGSize)titleIconViewSize {
   CGSize titleIconViewSize = CGSizeZero;
-  if (self.titleIconImageView != nil) {
-    titleIconViewSize = self.titleIconImageView.image.size;
-  } else if (self.titleIconView != nil) {
+  if (self.titleIconView != nil) {
     titleIconViewSize = self.titleIconView.frame.size;
+  } else if (self.titleIconImageView != nil) {
+    titleIconViewSize = self.titleIconImageView.image.size;
   }
   return titleIconViewSize;
 }
@@ -662,11 +659,11 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
       accessoryViewSize.width, accessoryViewSize.height);
 
   CGRect titleIconImageViewRect = [self titleIconFrameWithTitleSize:titleSize];
-  if (self.titleIconImageView != nil) {
+  if (self.titleIconView != nil) {
+    self.titleIconView.frame = titleIconImageViewRect;
+  } else if (self.titleIconImageView != nil) {
     // Match the title icon alignment to the title alignment.
     self.titleIconImageView.frame = titleIconImageViewRect;
-  } else if (self.titleIconView != nil) {
-    self.titleIconView.frame = titleIconImageViewRect;
   }
 
   self.titleLabel.frame = titleFrame;


### PR DESCRIPTION
[Material Dialogs] Custom title icon public API: Flip the priority between title icon and title custom view to mirror UIKit convention.

Custom title icon public API: Flip the priority between title icon and title custom view to mirror UIKit convention.

Issue: b/148428512.
