### PR TITLE
[Dialogs] Rename titleIcon to titleImage

### DIFF
--- a/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
+++ b/components/Dialogs/examples/DialogsAlertCustomizationExampleViewController.swift
@@ -80,7 +80,7 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
     case 3:
       return performRightTitleWithResizedIcon()
     case 4:
-      return performTintedTitleIconNoTitle()
+      return performTintedTitleImageNoTitle()
     case 5:
       return performScrimColor()
     case 6:
@@ -119,7 +119,7 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
 
   func performCenteredTitleWithIcon() -> MDCAlertController {
     let alert = createMDCAlertController(title: "Center Aligned Title")
-    alert.titleIcon = sampleIcon()
+    alert.titleImage = sampleIcon()
     alert.titleAlignment = .center
     alert.applyTheme(withScheme: containerScheme)
     return alert
@@ -127,26 +127,26 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
 
   func performNaturalTitleWithIcon() -> MDCAlertController {
     let alert = createMDCAlertController(title: "Default (Natural) Title Alignment")
-    alert.titleIcon = sampleIcon()
+    alert.titleImage = sampleIcon()
     alert.applyTheme(withScheme: containerScheme)
     return alert
   }
 
   func performRightTitleWithResizedIcon() -> MDCAlertController {
     let alert = createMDCAlertController(title: "Right Aligned Title")
-    alert.titleIcon = sampleIcon(isStandardSize: false)
+    alert.titleImage = sampleIcon(isStandardSize: false)
     alert.titleAlignment = .right
     alert.applyTheme(withScheme: containerScheme)
     return alert
   }
 
-  func performTintedTitleIconNoTitle() -> MDCAlertController {
+  func performTintedTitleImageNoTitle() -> MDCAlertController {
     let alert = createMDCAlertController(title: nil)
-    alert.titleIcon = sampleIcon()
+    alert.titleImage = sampleIcon()
     alert.applyTheme(withScheme: containerScheme)
 
-    // Theming override: set the titleIconTintColor after the color scheme has been applied
-    alert.titleIconTintColor = .red
+    // Theming override: set the titleImageTintColor after the color scheme has been applied
+    alert.titleImageTintColor = .red
 
     return alert
   }
@@ -207,7 +207,7 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
   func performCustomButtonTheming() -> MDCAlertController {
     let alert = MDCAlertController(title: "Custom Button Theming",
                                    message: "Custom styling of High, Medium & Low Emphasis")
-    alert.titleIcon = sampleIcon()
+    alert.titleImage = sampleIcon()
 
     // Use .low emphasis for styling buttons as text buttons
     alert.addAction(MDCAlertAction(title:"High", emphasis: .high, handler: handler))
@@ -227,7 +227,7 @@ class DialogsAlertCustomizationExampleViewController: MDCCollectionViewControlle
   func performDarkTheming() -> MDCAlertController {
     let alert = MDCAlertController(title: "Dark Theme",
                                    message: "Lorem ipsum dolor sit amet, consectetur adipiscing")
-    alert.titleIcon = sampleIcon()
+    alert.titleImage = sampleIcon()
 
     alert.addAction(MDCAlertAction(title:"All Right", emphasis: .high, handler: handler))
     alert.addAction(MDCAlertAction(title:"Not Now", emphasis: .medium, handler: handler))

--- a/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
+++ b/components/Dialogs/src/ColorThemer/MDCAlertColorThemer.m
@@ -27,7 +27,7 @@
                toAlertController:(nonnull MDCAlertController *)alertController {
   alertController.titleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
   alertController.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  alertController.titleIconTintColor = colorScheme.primaryColor;
+  alertController.titleImageTintColor = colorScheme.primaryColor;
   alertController.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
   alertController.backgroundColor = colorScheme.surfaceColor;
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -107,11 +107,15 @@
 /** The alignment applied to the title of the Alert. Default to NSTextAlignmentNatural. */
 @property(nonatomic, assign) NSTextAlignment titleAlignment;
 
-/** An optional icon appearing above the title of the Alert Controller.*/
-@property(nonatomic, strong, nullable) UIImage *titleIcon;
+/** An optional image or icon appearing above the title of the Alert Controller.*/
+@property(nonatomic, strong, nullable) UIImage *titleImage;
+//@property(nonatomic, strong, nullable) UIImage *titleIcon __deprecated_msg("Please use
+//`titleImage` instead.");
 
-/** The tint color applied to the titleIcon. Leave empty to preserve original image color(s).*/
-@property(nonatomic, strong, nullable) UIColor *titleIconTintColor;
+/** The tint color applied to the titleImage. Leave empty to preserve original image color(s).*/
+@property(nonatomic, strong, nullable) UIColor *titleImageTintColor;
+//@property(nonatomic, strong, nullable) UIColor *titleIconTintColor __deprecated_msg("Please use
+//`titleImageTintColor` instead.");
 
 /** The font applied to the message of Alert Controller.*/
 @property(nonatomic, strong, nullable) UIFont *messageFont;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -75,7 +75,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @end
 
 @interface MDCAlertControllerView (Accessibility)
-@property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
+@property(nonatomic, nullable, strong) UIImageView *titleImageImageView;
 @end
 
 @interface MDCAlertController ()
@@ -83,7 +83,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @property(nonatomic, nullable, weak) MDCAlertControllerView *alertView;
 @property(nonatomic, strong) MDCDialogTransitionController *transitionController;
 @property(nonatomic, nonnull, strong) MDCAlertActionManager *actionManager;
-@property(nonatomic, nullable, strong) UIView *titleIconView;
+@property(nonatomic, nullable, strong) UIView *titleImageView;
 
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message;
@@ -102,7 +102,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 @synthesize mdc_overrideBaseElevation = _mdc_overrideBaseElevation;
 @synthesize mdc_elevationDidChangeBlock = _mdc_elevationDidChangeBlock;
 @synthesize adjustsFontForContentSizeCategory = _adjustsFontForContentSizeCategory;
-@synthesize titleIconView = _titleIconView;
+@synthesize titleImageView = _titleImageView;
 @synthesize actionsHorizontalAlignment = _actionsHorizontalAlignment;
 @synthesize actionsHorizontalAlignmentInVerticalLayout =
     _actionsHorizontalAlignmentInVerticalLayout;
@@ -216,8 +216,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   _imageAccessibilityLabel = [imageAccessibilityLabel copy];
 
   if (self.alertView) {
-    self.alertView.titleIconImageView.accessibilityLabel = _imageAccessibilityLabel;
-    self.alertView.titleIconView.accessibilityLabel = _imageAccessibilityLabel;
+    self.alertView.titleImageImageView.accessibilityLabel = _imageAccessibilityLabel;
+    self.alertView.titleImageView.accessibilityLabel = _imageAccessibilityLabel;
   }
 }
 
@@ -228,9 +228,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   if (!self.alertView) {
     return nil;
   }
-  return (self.alertView.titleIconImageView != nil)
-             ? self.alertView.titleIconImageView.accessibilityLabel
-             : self.alertView.titleIconView.accessibilityLabel;
+  return (self.alertView.titleImageImageView != nil)
+             ? self.alertView.titleImageImageView.accessibilityLabel
+             : self.alertView.titleImageView.accessibilityLabel;
 }
 
 - (void)setAccessoryView:(UIView *)accessoryView {
@@ -393,24 +393,24 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
-- (void)setTitleIcon:(UIImage *)titleIcon {
-  _titleIcon = titleIcon;
+- (void)setTitleImage:(UIImage *)titleImage {
+  _titleImage = titleImage;
   if (self.alertView) {
-    self.alertView.titleIcon = titleIcon;
+    self.alertView.titleImage = titleImage;
   }
 }
 
-- (void)setTitleIconView:(UIView *)titleIconView {
-  _titleIconView = titleIconView;
+- (void)setTitleImageView:(UIView *)titleImageView {
+  _titleImageView = titleImageView;
   if (self.alertView) {
-    self.alertView.titleIconView = titleIconView;
+    self.alertView.titleImageView = titleImageView;
   }
 }
 
-- (void)setTitleIconTintColor:(UIColor *)titleIconTintColor {
-  _titleIconTintColor = titleIconTintColor;
+- (void)setTitleImageTintColor:(UIColor *)titleImageTintColor {
+  _titleImageTintColor = titleImageTintColor;
   if (self.alertView) {
-    self.alertView.titleIconTintColor = titleIconTintColor;
+    self.alertView.titleImageTintColor = titleImageTintColor;
   }
 }
 
@@ -686,8 +686,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   self.alertView.messageLabel.text = self.message;
   self.alertView.titleLabel.accessibilityLabel = self.titleAccessibilityLabel ?: self.title;
   self.alertView.messageLabel.accessibilityLabel = self.messageAccessibilityLabel ?: self.message;
-  self.alertView.titleIconImageView.accessibilityLabel = self.imageAccessibilityLabel;
-  self.alertView.titleIconView.accessibilityLabel = self.imageAccessibilityLabel;
+  self.alertView.titleImageImageView.accessibilityLabel = self.imageAccessibilityLabel;
+  self.alertView.titleImageView.accessibilityLabel = self.imageAccessibilityLabel;
 
   // TODO(https://github.com/material-components/material-components-ios/issues/8671): Update
   // adjustsFontForContentSizeCategory for messageLabel
@@ -713,9 +713,9 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
   self.alertView.titleAlignment = self.titleAlignment;
   self.alertView.messageAlignment = self.messageAlignment;
-  self.alertView.titleIcon = self.titleIcon;
-  self.alertView.titleIconTintColor = self.titleIconTintColor;
-  self.alertView.titleIconView = self.titleIconView;
+  self.alertView.titleImage = self.titleImage;
+  self.alertView.titleImageTintColor = self.titleImageTintColor;
+  self.alertView.titleImageView = self.titleImageView;
   self.alertView.cornerRadius = self.cornerRadius;
   self.alertView.enableRippleBehavior = self.enableRippleBehavior;
   self.orderVerticalActionsByEmphasis = NO;

--- a/components/Dialogs/src/MDCAlertControllerView.h
+++ b/components/Dialogs/src/MDCAlertControllerView.h
@@ -19,8 +19,8 @@
 @property(nonatomic, strong, nullable) UIFont *titleFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *titleColor UI_APPEARANCE_SELECTOR;
 
-@property(nonatomic, strong, nullable) UIImage *titleIcon;
-@property(nonatomic, strong, nullable) UIColor *titleIconTintColor;
+@property(nonatomic, strong, nullable) UIImage *titleImage;
+@property(nonatomic, strong, nullable) UIColor *titleImageTintColor;
 @property(nonatomic, assign) NSTextAlignment titleAlignment;
 @property(nonatomic, assign) NSTextAlignment messageAlignment;
 
@@ -28,10 +28,10 @@
  An optional custom icon view above the title of the alert.
 
  @note This property is intended to be used to provide a custom implementation of the title icon
- view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
- 'titleIcon' is set, 'titleIconView' is ignored.
+ view. If the intention is to just display a `UIImage`, use `setTitleImage:` API instead. If
+ 'titleImage' is set, 'titleImageView' is ignored.
  */
-@property(nonatomic, strong, nullable) UIView *titleIconView;
+@property(nonatomic, strong, nullable) UIView *titleImageView;
 
 @property(nonatomic, strong, nullable) UIFont *messageFont UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, nullable) UIColor *messageColor UI_APPEARANCE_SELECTOR;

--- a/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
+++ b/components/Dialogs/src/Theming/MDCAlertController+MaterialTheming.m
@@ -74,7 +74,7 @@ static const CGFloat kCornerRadius = 4;
 
   self.titleColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.87];
   self.messageColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.60];
-  self.titleIconTintColor = colorScheme.primaryColor;
+  self.titleImageTintColor = colorScheme.primaryColor;
   self.scrimColor = [colorScheme.onSurfaceColor colorWithAlphaComponent:(CGFloat)0.32];
   self.backgroundColor = colorScheme.surfaceColor;
 }

--- a/components/Dialogs/src/private/MDCAlertController+Customize.h
+++ b/components/Dialogs/src/private/MDCAlertController+Customize.h
@@ -20,9 +20,9 @@
  An optional custom icon view above the title of the alert.
 
  @note This property is intended to be used to provide a custom implementation of the title icon
- view. If the intention is to just display a `UIImage`, use `setTitleIcon:` API instead. If
- 'titleIcon' is set, 'titleIconView' is ignored.
+ view. If the intention is to just display a `UIImage`, use `setTitleImage:` API instead. If
+ 'titleImage' is set, 'titleImageView' is ignored.
  */
-@property(nonatomic, strong, nullable) UIView *titleIconView;
+@property(nonatomic, strong, nullable) UIView *titleImageView;
 
 @end

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.h
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.h
@@ -67,16 +67,16 @@
 
 /**
  The edge insets around the title icon or title icon view against the dialog edges (top, leading,
- trailing) and the title (bottom). Note that `titleIconInsets.bottom` takes precedence over
+ trailing) and the title (bottom). Note that `titleImageInsets.bottom` takes precedence over
  `titleInsets.top`.
 
  Default value is UIEdgeInsets(top: 24, leading: 24, bottom: 12, trailing: 24).
  */
-@property(nonatomic, assign) UIEdgeInsets titleIconInsets;
+@property(nonatomic, assign) UIEdgeInsets titleImageInsets;
 
 /**
  The edge insets around the title against the dialog edges or its neighbor elements. If either the
- title icon or title icon view is present, then `titleIconInsets.bottom` takes precedence over
+ titleImage or titleImageView is present, then `titleImageInsets.bottom` takes precedence over
  `titleInsets.top`. If there is no message, `titleInsets.bottom` is ignored.
 
 

--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -37,7 +37,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 @interface MDCAlertControllerView ()
 
 @property(nonatomic, getter=isVerticalActionsLayout) BOOL verticalActionsLayout;
-@property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
+@property(nonatomic, nullable, strong) UIImageView *titleImageImageView;
 
 @end
 
@@ -55,7 +55,7 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.actionsHorizontalAlignment = MDCContentHorizontalAlignmentTrailing;
     self.actionsHorizontalAlignmentInVerticalLayout = MDCContentHorizontalAlignmentCenter;
 
-    self.titleIconInsets = UIEdgeInsetsMake(24.0f, 24.0f, 12.0f, 24.0f);
+    self.titleImageInsets = UIEdgeInsetsMake(24.0f, 24.0f, 12.0f, 24.0f);
     self.titleInsets = UIEdgeInsetsMake(24.0f, 24.0f, 20.0f, 24.0f);
     self.contentInsets = UIEdgeInsetsMake(24.0f, 24.0f, 24.0f, 24.0f);
     self.actionsInsets = UIEdgeInsetsMake(8.0f, 8.0f, 8.0f, 8.0f);
@@ -200,54 +200,54 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   self.titleLabel.textAlignment = titleAlignment;
 }
 
-- (UIImage *)titleIcon {
-  return self.titleIconImageView.image;
+- (UIImage *)titleImage {
+  return self.titleImageImageView.image;
 }
 
-- (void)setTitleIcon:(UIImage *)titleIcon {
-  if (titleIcon == nil) {
-    [self.titleIconImageView removeFromSuperview];
-    self.titleIconImageView = nil;
+- (void)setTitleImage:(UIImage *)titleImage {
+  if (titleImage == nil) {
+    [self.titleImageImageView removeFromSuperview];
+    self.titleImageImageView = nil;
     [self setNeedsLayout];
     return;
   }
 
-  if (self.titleIconView != nil) {
-    [self.titleIconView removeFromSuperview];
-    self.titleIconView = nil;
+  if (self.titleImageView != nil) {
+    [self.titleImageView removeFromSuperview];
+    self.titleImageView = nil;
   }
 
-  if (self.titleIconImageView == nil) {
-    self.titleIconImageView = [[UIImageView alloc] initWithImage:titleIcon];
-    self.titleIconImageView.contentMode = UIViewContentModeScaleAspectFit;
-    [self.titleScrollView addSubview:self.titleIconImageView];
+  if (self.titleImageImageView == nil) {
+    self.titleImageImageView = [[UIImageView alloc] initWithImage:titleImage];
+    self.titleImageImageView.contentMode = UIViewContentModeScaleAspectFit;
+    [self.titleScrollView addSubview:self.titleImageImageView];
   } else {
-    self.titleIconImageView.image = titleIcon;
+    self.titleImageImageView.image = titleImage;
   }
 
-  self.titleIconImageView.tintColor = self.titleIconTintColor;
+  self.titleImageImageView.tintColor = self.titleImageTintColor;
   [self setNeedsLayout];
 }
 
-- (void)setTitleIconTintColor:(UIColor *)titleIconTintColor {
-  _titleIconTintColor = titleIconTintColor;
-  self.titleIconImageView.tintColor = titleIconTintColor;
+- (void)setTitleImageTintColor:(UIColor *)titleImageTintColor {
+  _titleImageTintColor = titleImageTintColor;
+  self.titleImageImageView.tintColor = titleImageTintColor;
 }
 
-- (void)setTitleIconView:(UIView *)titleIconView {
-  if (self.titleIconImageView != nil) {
+- (void)setTitleImageView:(UIView *)titleImageView {
+  if (self.titleImageImageView != nil) {
     NSLog(@"Warning: unintended use of the API. The following APIs are not expected to be used"
-           "together: 'setTitleIconView:' and `setTitleIcon:` API. Please set either, but not "
-           "both at the same time. If 'titleIcon' is set, 'titleIconView' is ignored.");
+           "together: 'setTitleImageView:' and `setTitleImage:` API. Please set either, but not "
+           "both at the same time. If 'titleImage' is set, 'titleImageView' is ignored.");
     return;
   }
-  if (_titleIconView == nil || ![_titleIconView isEqual:titleIconView]) {
-    if (_titleIconView != nil) {
-      [_titleIconView removeFromSuperview];
+  if (_titleImageView == nil || ![_titleImageView isEqual:titleImageView]) {
+    if (_titleImageView != nil) {
+      [_titleImageView removeFromSuperview];
     }
-    _titleIconView = titleIconView;
-    if (_titleIconView != nil) {
-      [self.titleScrollView addSubview:_titleIconView];
+    _titleImageView = titleImageView;
+    if (_titleImageView != nil) {
+      [self.titleScrollView addSubview:_titleImageView];
     }
     [self.titleScrollView setNeedsLayout];
   }
@@ -432,8 +432,8 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return size;
 }
 
-- (BOOL)hasTitleIconOrImage {
-  return self.titleIconImageView.image.size.height > 0.0f || self.titleIconView != nil;
+- (BOOL)hasTitleImageOrImage {
+  return self.titleImageImageView.image.size.height > 0.0f || self.titleImageView != nil;
 }
 
 - (BOOL)hasTitle {
@@ -449,18 +449,18 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return accessoryViewSize.height > 0.0f;
 }
 
-- (CGFloat)titleIconInsetBottom {
-  return [self hasTitleIconOrImage] && [self hasTitle] ? self.titleIconInsets.bottom : 0.0f;
+- (CGFloat)titleImageInsetBottom {
+  return [self hasTitleImageOrImage] && [self hasTitle] ? self.titleImageInsets.bottom : 0.0f;
 }
 
 - (CGFloat)titleInsetTop {
-  return [self hasTitleIconOrImage] ? self.titleIconInsets.top : self.titleInsets.top;
+  return [self hasTitleImageOrImage] ? self.titleImageInsets.top : self.titleInsets.top;
 }
 
 - (CGFloat)titleInsetBottom {
   if (![self hasMessage] && ![self hasAccessoryView]) {
     return 0.0f;
-  } else if ([self hasTitle] || [self hasTitleIconOrImage]) {
+  } else if ([self hasTitle] || [self hasTitleImageOrImage]) {
     return self.titleInsets.bottom;
   } else {
     return 0.0f;
@@ -471,20 +471,20 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return ([self hasMessage] && [self hasAccessoryView]) ? self.accessoryViewVerticalInset : 0.0f;
 }
 
-- (CGSize)titleIconViewSize {
-  CGSize titleIconViewSize = CGSizeZero;
-  if (self.titleIconImageView != nil) {
-    titleIconViewSize = self.titleIconImageView.image.size;
-  } else if (self.titleIconView != nil) {
-    titleIconViewSize = self.titleIconView.frame.size;
+- (CGSize)titleImageViewSize {
+  CGSize titleImageViewSize = CGSizeZero;
+  if (self.titleImageImageView != nil) {
+    titleImageViewSize = self.titleImageImageView.image.size;
+  } else if (self.titleImageView != nil) {
+    titleImageViewSize = self.titleImageView.frame.size;
   }
-  return titleIconViewSize;
+  return titleImageViewSize;
 }
 
 - (CGRect)titleFrameWithTitleSize:(CGSize)titleSize {
   CGFloat leftInset = self.titleInsets.left;
   CGFloat titleTop =
-      [self titleIconViewSize].height + [self titleInsetTop] + [self titleIconInsetBottom];
+      [self titleImageViewSize].height + [self titleInsetTop] + [self titleImageInsetBottom];
   return CGRectMake(leftInset, titleTop, titleSize.width, titleSize.height);
 }
 
@@ -492,23 +492,23 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   return CGRectMake(self.contentInsets.left, 0.0f, messageSize.width, messageSize.height);
 }
 
-- (CGRect)titleIconFrameWithTitleSize:(CGSize)titleSize {
-  CGSize titleIconViewSize = [self titleIconViewSize];
+- (CGRect)titleImageFrameWithTitleSize:(CGSize)titleSize {
+  CGSize titleImageViewSize = [self titleImageViewSize];
   CGRect titleFrame = [self titleFrameWithTitleSize:titleSize];
 
-  // match the titleIcon alignment to the title alignment
-  CGFloat leftInset = self.titleIconInsets.left;
-  CGFloat topInset = self.titleIconInsets.top;
+  // match the titleImage alignment to the title alignment
+  CGFloat leftInset = self.titleImageInsets.left;
+  CGFloat topInset = self.titleImageInsets.top;
   if (self.titleAlignment == NSTextAlignmentCenter) {
     leftInset =
-        CGRectGetMinX(titleFrame) + (CGRectGetWidth(titleFrame) - titleIconViewSize.width) / 2.0f;
+        CGRectGetMinX(titleFrame) + (CGRectGetWidth(titleFrame) - titleImageViewSize.width) / 2.0f;
   } else if (self.titleAlignment == NSTextAlignmentRight ||
              (self.titleAlignment == NSTextAlignmentNatural &&
               [self mdf_effectiveUserInterfaceLayoutDirection] ==
                   UIUserInterfaceLayoutDirectionRightToLeft)) {
-    leftInset = CGRectGetMaxX(titleFrame) - titleIconViewSize.width;
+    leftInset = CGRectGetMaxX(titleFrame) - titleImageViewSize.width;
   }
-  return CGRectMake(leftInset, topInset, titleIconViewSize.width, titleIconViewSize.height);
+  return CGRectMake(leftInset, topInset, titleImageViewSize.width, titleImageViewSize.height);
 }
 
 // @param boundsSize should not include any internal margins or padding
@@ -532,9 +532,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 // @param boundingWidth should not include any internal margins or padding
 - (CGSize)calculateContentSizeThatFitsWidth:(CGFloat)boundingWidth {
   CGFloat leftInset =
-      MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left);
+      MAX(MAX(self.titleInsets.left, self.titleImageInsets.left), self.contentInsets.left);
   CGFloat rightInset =
-      MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right);
+      MAX(MAX(self.titleInsets.right, self.titleImageInsets.right), self.contentInsets.right);
 
   CGSize boundsSize = CGRectInfinite.size;
   boundsSize.width = boundingWidth - leftInset - rightInset;
@@ -560,9 +560,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 */
 - (CGSize)calculateTitleViewSizeThatFitsWidth:(CGFloat)boundingWidth {
   CGFloat leftInset =
-      MAX(MAX(self.titleInsets.left, self.titleIconInsets.left), self.contentInsets.left);
+      MAX(MAX(self.titleInsets.left, self.titleImageInsets.left), self.contentInsets.left);
   CGFloat rightInset =
-      MAX(MAX(self.titleInsets.right, self.titleIconInsets.right), self.contentInsets.right);
+      MAX(MAX(self.titleInsets.right, self.titleImageInsets.right), self.contentInsets.right);
 
   CGSize boundsSize = CGRectInfinite.size;
   boundsSize.width = boundingWidth - leftInset - rightInset;
@@ -572,9 +572,9 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   CGSize accessoryViewSize = [self.accessoryView systemLayoutSizeFittingSize:boundsSize];
   CGFloat titleWidth = MAX(MAX(titleSize.width, messageSize.width), accessoryViewSize.width) +
                        leftInset + rightInset;
-  CGFloat totalElementsHeight = [self titleIconViewSize].height + titleSize.height;
+  CGFloat totalElementsHeight = [self titleImageViewSize].height + titleSize.height;
 
-  CGFloat titleHeight = totalElementsHeight + [self titleInsetTop] + [self titleIconInsetBottom] +
+  CGFloat titleHeight = totalElementsHeight + [self titleInsetTop] + [self titleImageInsetBottom] +
                         [self titleInsetBottom];
   return CGSizeMake((CGFloat)ceil(titleWidth), (CGFloat)ceil(titleHeight));
 }
@@ -661,12 +661,12 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
       self.contentInsets.left, CGRectGetMaxY(messageFrame) + [self accessoryVerticalInset],
       accessoryViewSize.width, accessoryViewSize.height);
 
-  CGRect titleIconImageViewRect = [self titleIconFrameWithTitleSize:titleSize];
-  if (self.titleIconImageView != nil) {
+  CGRect titleImageImageViewRect = [self titleImageFrameWithTitleSize:titleSize];
+  if (self.titleImageImageView != nil) {
     // Match the title icon alignment to the title alignment.
-    self.titleIconImageView.frame = titleIconImageViewRect;
-  } else if (self.titleIconView != nil) {
-    self.titleIconView.frame = titleIconImageViewRect;
+    self.titleImageImageView.frame = titleImageImageViewRect;
+  } else if (self.titleImageView != nil) {
+    self.titleImageView.frame = titleImageImageViewRect;
   }
 
   self.titleLabel.frame = titleFrame;

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerConfigurationsTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerConfigurationsTests.m
@@ -120,7 +120,7 @@ static NSString *const kMessageLongLatin =
 // title-icon + actions
 - (void)testAlertHasTitleIcon {
   // Given
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
 
   // When
   [self.alertController applyThemeWithScheme:self.containerScheme2019];
@@ -133,7 +133,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleImage {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
 
   // When
   [self.alertController applyThemeWithScheme:self.containerScheme2019];
@@ -171,7 +171,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleIconAndMessage {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.message = kMessageShortLatin;
 
   // When
@@ -185,7 +185,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleImageAndMessage {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
   self.alertController.message = kMessageLongLatin;
 
   // When
@@ -198,7 +198,7 @@ static NSString *const kMessageLongLatin =
 // title-icon + accessory-view + actions
 - (void)testAlertHasTitleIconAndAccessoryView {
   // Given
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.accessoryView = self.accessoryView;
 
   // When
@@ -212,7 +212,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleImageAndAccessoryView {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
   self.alertController.accessoryView = self.accessoryView;
 
   // When
@@ -252,7 +252,7 @@ static NSString *const kMessageLongLatin =
 // title + title-icon + accessory-view + actions
 - (void)testAlertHasTitleAndTitleIconAndAccessoryView {
   // Given
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.title = kTitleShortLatin;
   self.alertController.accessoryView = self.accessoryView;
 
@@ -267,7 +267,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleAndTitleImageAndAccessoryView {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
   self.alertController.title = kTitleShortLatin;
   self.alertController.message = kMessageShortLatin;
   self.alertController.accessoryView = self.accessoryView;
@@ -283,7 +283,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleAndTitleIconAndMessageAndAccessoryView {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.title = kTitleShortLatin;
   self.alertController.message = kMessageLongLatin;
   self.alertController.accessoryView = self.accessoryView;
@@ -298,7 +298,7 @@ static NSString *const kMessageLongLatin =
 // title + title-image + message + accessory-view + actions
 - (void)testAlertHasTitleAndTitleImageAndMessageAndAccessoryView {
   // Given
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
   self.alertController.title = kTitleShortLatin;
   self.alertController.message = kMessageLongLatin;
   self.alertController.accessoryView = self.accessoryView;
@@ -314,7 +314,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleImageAndVerticalButtons {
   // Given
   [self addOutlinedActionWithTitle:@"Verticallly Aligned Buttons"];
-  self.alertController.titleIcon = self.titleImage;
+  self.alertController.titleImage = self.titleImage;
 
   // When
   [self.alertController applyThemeWithScheme:self.containerScheme2019];
@@ -330,7 +330,7 @@ static NSString *const kMessageLongLatin =
   [self addOutlinedActionWithTitle:@"Buttons?"];
   [self addOutlinedActionWithTitle:@"Vertical"];
   [self addOutlinedActionWithTitle:@"Four"];
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.message = kMessageShortLatin;
   self.alertController.accessoryView = self.accessoryView;
 
@@ -362,7 +362,7 @@ static NSString *const kMessageLongLatin =
 - (void)testAlertHasTitleAndTitleIconAndMessageAndAccessoryViewInRTL {
   // Given
   [self addOutlinedActionWithTitle:@"Cancel"];
-  self.alertController.titleIcon = self.titleIcon;
+  self.alertController.titleImage = self.titleIcon;
   self.alertController.title = kTitleShortLatin;
   self.alertController.message = kMessageLongLatin;
   self.alertController.accessoryView = self.accessoryView;

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
@@ -80,7 +80,7 @@ static NSString *const kActionLowUrdu = @"کم";
 - (void)testPreferredContentSizeWithNotoNastaliqUrdu {
   // When
   self.alertController.title = kTitleUrdu;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageUrdu;
   NSString *urduFontName = @"NotoNastaliqUrdu";
   UIFont *dialogBodyFont = [UIFont systemFontOfSize:20.0];

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerSnapshotTests.m
@@ -157,7 +157,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultAppearanceWithSmallIconShortMessageLatin {
   // When
-  self.alertController.titleIcon = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+  self.alertController.titleImage = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
       imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   self.alertController.message = kMessageShortLatin;
 
@@ -167,7 +167,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultAppearanceWithSmallIconShortMessageArabic {
   // When
-  self.alertController.titleIcon = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
+  self.alertController.titleImage = [[UIImage mdc_testImageOfSize:CGSizeMake(24, 24)]
       imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   self.alertController.message = kMessageShortArabic;
   [self changeToRTL:self.alertController];
@@ -178,7 +178,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultAppearanceWithLargeIconLongMessageLatin {
   // When
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // Then
@@ -187,7 +187,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultAppearanceWithLargeIconLongMessageArabic {
   // When
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 
@@ -198,7 +198,7 @@ static NSString *const kMessageLongArabic =
 - (void)testDefaultAppearanceWithLargeIconLongTitleLongMessageLatin {
   // When
   self.alertController.title = kTitleLongLatin;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // Then
@@ -208,7 +208,7 @@ static NSString *const kMessageLongArabic =
 - (void)testDefaultAppearanceWithLargeIconLongTitleLongMessageArabic {
   // When
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 
@@ -227,7 +227,7 @@ static NSString *const kMessageLongArabic =
 - (void)testPreferredContentSizeWithLargeIconLongTitleLongMessageLatin {
   // When
   self.alertController.title = kTitleLongLatin;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
   CGSize preferredContentSize = self.alertController.preferredContentSize;
   self.alertController.view.bounds =
@@ -240,7 +240,7 @@ static NSString *const kMessageLongArabic =
 - (void)testPreferredContentSizeWithLargeIconLongTitleLongMessageArabic {
   // When
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
   CGSize preferredContentSize = self.alertController.preferredContentSize;
@@ -265,7 +265,7 @@ static NSString *const kMessageLongArabic =
 - (void)testPreferredContentSizeWithLargeIconLongTitleLongMessageArabicAccessoryView {
   // When
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
   [self.alertController setAccessoryView:self.accessoryView];
@@ -280,7 +280,7 @@ static NSString *const kMessageLongArabic =
 - (void)testSizeToFitWithLargeIconLongTitleLongMessageLatin {
   // When
   self.alertController.title = kTitleLongLatin;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
   [self.alertController.view sizeToFit];
 
@@ -291,7 +291,7 @@ static NSString *const kMessageLongArabic =
 - (void)testSizeToFitWithLargeIconLongTitleLongMessageArabic {
   // When
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
   [self.alertController.view sizeToFit];

--- a/components/Dialogs/tests/snapshot/MDCAlertController_ThemingSnapshotTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertController_ThemingSnapshotTests.m
@@ -226,7 +226,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultThemeWithLargeIconLongMessageLatin {
   // Given
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // When
@@ -238,7 +238,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testDefaultThemeWithLargeIconLongMessageArabic {
   // Given
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 
@@ -251,7 +251,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testCustomThemeWithLargeIconLongMessageLatin {
   // Given
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // When
@@ -263,7 +263,7 @@ static NSString *const kMessageLongArabic =
 
 - (void)testCustomThemeWithLargeIconLongMessageArabic {
   // Given
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 
@@ -277,7 +277,7 @@ static NSString *const kMessageLongArabic =
 - (void)testDefaultThemeWithLargeIconLongTitleLongMessageLatin {
   // Given
   self.alertController.title = kTitleLongLatin;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // When
@@ -290,7 +290,7 @@ static NSString *const kMessageLongArabic =
 - (void)testDefaultThemeWithLargeIconLongTitleLongMessageArabic {
   // Given
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 
@@ -304,7 +304,7 @@ static NSString *const kMessageLongArabic =
 - (void)testCustomThemeWithLargeIconLongTitleLongMessageLatin {
   // Given
   self.alertController.title = kTitleLongLatin;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongLatin;
 
   // When
@@ -317,7 +317,7 @@ static NSString *const kMessageLongArabic =
 - (void)testCustomThemeWithLargeIconLongTitleLongMessageArabic {
   // Given
   self.alertController.title = kTitleLongArabic;
-  self.alertController.titleIcon = self.iconImage;
+  self.alertController.titleImage = self.iconImage;
   self.alertController.message = kMessageLongArabic;
   [self changeToRTL:self.alertController];
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerCustomizationTests.m
@@ -20,7 +20,7 @@
 #import <XCTest/XCTest.h>
 
 @interface MDCAlertControllerView (Testing)
-@property(nonatomic, nullable, strong) UIImageView *titleIconImageView;
+@property(nonatomic, nullable, strong) UIImageView *titleImageImageView;
 @end
 
 @interface MDCAlertControllerCustomizationTests : XCTestCase
@@ -64,12 +64,12 @@
   UIImage *icon = TestImage(CGSizeMake(24, 24));
 
   // When
-  self.alert.titleIcon = icon;
+  self.alert.titleImage = icon;
 
   // Then
-  XCTAssertNotNil(self.alert.titleIcon);
-  XCTAssertEqual(self.alertView.titleIcon, icon);
-  XCTAssertEqual(self.alertView.titleIconImageView.image, icon);
+  XCTAssertNotNil(self.alert.titleImage);
+  XCTAssertEqual(self.alertView.titleImage, icon);
+  XCTAssertEqual(self.alertView.titleImageImageView.image, icon);
 }
 
 - (void)testApplyingTintToTitleIcon {
@@ -78,14 +78,14 @@
   UIColor *tintColor = UIColor.orangeColor;
 
   // When
-  self.alert.titleIcon = icon;
-  self.alert.titleIconTintColor = tintColor;
+  self.alert.titleImage = icon;
+  self.alert.titleImageTintColor = tintColor;
 
   // Then
-  XCTAssertNotNil(self.alert.titleIcon);
-  XCTAssertEqualObjects(self.alertView.titleIcon, icon);
-  XCTAssertEqualObjects(self.alertView.titleIconTintColor, tintColor);
-  XCTAssertEqualObjects(self.alertView.titleIconImageView.tintColor, tintColor);
+  XCTAssertNotNil(self.alert.titleImage);
+  XCTAssertEqualObjects(self.alertView.titleImage, icon);
+  XCTAssertEqualObjects(self.alertView.titleImageTintColor, tintColor);
+  XCTAssertEqualObjects(self.alertView.titleImageImageView.tintColor, tintColor);
 }
 
 - (void)testApplyingTintToTitleIconInAnyOrder {
@@ -94,14 +94,14 @@
   UIColor *tintColor = UIColor.orangeColor;
 
   // When
-  self.alert.titleIconTintColor = tintColor;
-  self.alert.titleIcon = icon;
+  self.alert.titleImageTintColor = tintColor;
+  self.alert.titleImage = icon;
 
   // Then
-  XCTAssertNotNil(self.alert.titleIcon);
-  XCTAssertEqualObjects(self.alertView.titleIcon, icon);
-  XCTAssertEqualObjects(self.alertView.titleIconTintColor, tintColor);
-  XCTAssertEqualObjects(self.alertView.titleIconImageView.tintColor, tintColor);
+  XCTAssertNotNil(self.alert.titleImage);
+  XCTAssertEqualObjects(self.alertView.titleImage, icon);
+  XCTAssertEqualObjects(self.alertView.titleImageTintColor, tintColor);
+  XCTAssertEqualObjects(self.alertView.titleImageImageView.tintColor, tintColor);
 }
 
 - (void)testApplyingScrimColorToPresentationController {

--- a/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
+++ b/components/Dialogs/tests/unit/Theming/DialogsMaterialThemingTests.swift
@@ -47,7 +47,7 @@ class DialogsMaterialThemingTests: XCTestCase {
     // Color
     XCTAssertEqual(alert.titleColor, colorScheme.onSurfaceColor.withAlphaComponent(0.87))
     XCTAssertEqual(alert.messageColor, colorScheme.onSurfaceColor.withAlphaComponent(0.60))
-    XCTAssertEqual(alert.titleIconTintColor, colorScheme.primaryColor)
+    XCTAssertEqual(alert.titleImageTintColor, colorScheme.primaryColor)
     XCTAssertEqual(alert.scrimColor, colorScheme.onSurfaceColor.withAlphaComponent(0.32))
     XCTAssertEqual(alert.backgroundColor, colorScheme.surfaceColor);
 
@@ -164,7 +164,7 @@ class DialogsMaterialThemingTests: XCTestCase {
     XCTAssertEqual(presentationController.scrimColor,
                    colorScheme.onSurfaceColor.withAlphaComponent(0.32))
 
-    XCTAssertEqual(alertView.titleIconTintColor, colorScheme.primaryColor)
+    XCTAssertEqual(alertView.titleImageTintColor, colorScheme.primaryColor)
     XCTAssertEqual(button.backgroundColor(for: .normal), colorScheme.primaryColor)
 
     XCTAssertEqual(button.titleColor(for: .normal), colorScheme.onPrimaryColor)


### PR DESCRIPTION
# Description

Rename all titleIcon API to titleImage, to keep API naming consistency with titleImageView:
* titleIcon and titleIconTintColor were renamed to titleImage and titleImageTintColor
  in MDCAlertController.h and MDCAlertControllerView.h.
* Similarly, all other "titleIcon" APIs were also renamed, like: titleIconInsets.
* Internal property/variable names were also renamed.
* The rest of the changes are a change & replace of "titleIcon" with "titleImage"

Tested: cl/300977244