### PR TITLE
[Dialogs] Add support for attributed dialog message text

### DIFF
--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -85,6 +85,23 @@
 + (nonnull instancetype)alertControllerWithTitle:(nullable NSString *)title
                                          message:(nullable NSString *)message;
 
+/**
+ Convenience constructor to create and return a view controller for displaying an alert to the user.
+
+ After creating the alert controller, add actions to the controller by calling -addAction.
+
+ @note Most alerts don't need titles. Use only for high-risk situations.
+ 
+ @note This method receives an @c NSAttributedString for the display message. Use
+       @c alertControllerWithTitle:message: for regular @c NSString support.
+
+ @param title The title of the alert.
+ @param attributedMessage Descriptive text that summarizes a decision in a sentence of two.
+ @return An initialized MDCAlertController object.
+ */
++ (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
+                       attributedMessage:(nullable NSString *)attributedMessage;
+
 /** Alert controllers must be created with alertControllerWithTitle:message: */
 - (nonnull instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
                                  bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -194,8 +194,8 @@
 /** Descriptive text that summarizes a decision in a sentence of two. */
 @property(nonatomic, nullable, copy) NSString *message;
 
-/** 
- Descriptive attributed text that summarizes a decision in a sentence of two. 
+/**
+ Descriptive attributed text that summarizes a decision in a sentence of two.
 
  If provided and non-empty, will be used instead of @c message property.
  */

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -95,7 +95,7 @@
  @note This method receives an @c NSAttributedString for the display message. Use
        @c alertControllerWithTitle:message: for regular @c NSString support.
 
- @note Currently, support for tappable embedded links within attributed strings is not supported.
+ @note Currently tappable embedded links within @c attributedMessage are not supported.
 
  @param alertTitle The title of the alert.
  @param attributedMessage Descriptive text that summarizes a decision in a sentence of two.
@@ -201,8 +201,7 @@
 
  If provided and non-empty, will be used instead of @c message property.
 
- @note Currently, support for tappable embedded links within @c attributedMessage
-       is not supported.
+ @note Currently tappable embedded links within @c attributedMessage are not supported.
  */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedMessage;
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -91,7 +91,7 @@
  After creating the alert controller, add actions to the controller by calling -addAction.
 
  @note Most alerts don't need titles. Use only for high-risk situations.
- 
+
  @note This method receives an @c NSAttributedString for the display message. Use
        @c alertControllerWithTitle:message: for regular @c NSString support.
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -200,7 +200,7 @@
  Descriptive attributed text that summarizes a decision in a sentence of two.
 
  If provided and non-empty, will be used instead of @c message property.
- 
+
  @note Currently, support for tappable embedded links within @c attributedMessage
        is not supported.
  */

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -94,6 +94,8 @@
 
  @note This method receives an @c NSAttributedString for the display message. Use
        @c alertControllerWithTitle:message: for regular @c NSString support.
+ 
+ @note Currently, support for tappable embedded links within attributed strings is not supported.
 
  @param alertTitle The title of the alert.
  @param attributedMessage Descriptive text that summarizes a decision in a sentence of two.
@@ -198,6 +200,9 @@
  Descriptive attributed text that summarizes a decision in a sentence of two.
 
  If provided and non-empty, will be used instead of @c message property.
+ 
+ @note Currently, support for tappable embedded links within @c attributedMessage
+       is not supported.
  */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedMessage;
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -177,6 +177,9 @@
 /** Descriptive text that summarizes a decision in a sentence of two. */
 @property(nonatomic, nullable, copy) NSString *message;
 
+/** Descriptive attributed text that summarizes a decision in a sentence of two. */
+@property(nonatomic, nullable, copy) NSAttributedString *attributedMessage;
+
 /**
  A custom accessibility label for the message.
 

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -102,7 +102,7 @@
  @return An initialized MDCAlertController object.
  */
 + (nonnull instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
-                       attributedMessage:(nullable NSAttributedString *)attributedMessage;
+                               attributedMessage:(nullable NSAttributedString *)attributedMessage;
 
 /** Alert controllers must be created with alertControllerWithTitle:message: */
 - (nonnull instancetype)initWithNibName:(nullable NSString *)nibNameOrNil

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -95,12 +95,12 @@
  @note This method receives an @c NSAttributedString for the display message. Use
        @c alertControllerWithTitle:message: for regular @c NSString support.
 
- @param title The title of the alert.
+ @param alertTitle The title of the alert.
  @param attributedMessage Descriptive text that summarizes a decision in a sentence of two.
  @return An initialized MDCAlertController object.
  */
-+ (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
-                       attributedMessage:(nullable NSString *)attributedMessage;
++ (nonnull instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
+                       attributedMessage:(nullable NSAttributedString *)attributedMessage;
 
 /** Alert controllers must be created with alertControllerWithTitle:message: */
 - (nonnull instancetype)initWithNibName:(nullable NSString *)nibNameOrNil

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -177,7 +177,11 @@
 /** Descriptive text that summarizes a decision in a sentence of two. */
 @property(nonatomic, nullable, copy) NSString *message;
 
-/** Descriptive attributed text that summarizes a decision in a sentence of two. */
+/** 
+ Descriptive attributed text that summarizes a decision in a sentence of two. 
+
+ If provided and non-empty, will be used instead of @c message property.
+ */
 @property(nonatomic, nullable, copy) NSAttributedString *attributedMessage;
 
 /**

--- a/components/Dialogs/src/MDCAlertController.h
+++ b/components/Dialogs/src/MDCAlertController.h
@@ -94,7 +94,7 @@
 
  @note This method receives an @c NSAttributedString for the display message. Use
        @c alertControllerWithTitle:message: for regular @c NSString support.
- 
+
  @note Currently, support for tappable embedded links within attributed strings is not supported.
 
  @param alertTitle The title of the alert.

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -118,7 +118,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 + (nonnull instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
-                       attributedMessage:(nullable NSAttributedString *)attributedMessage {
+                               attributedMessage:(nullable NSAttributedString *)attributedMessage {
   MDCAlertController *alertController =
       [[MDCAlertController alloc] initWithTitle:alertTitle attributedMessage:attributedMessage];
 

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -119,8 +119,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 + (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
                        attributedMessage:(nullable NSString *)attributedMessage {
-  MDCAlertController *alertController = [[MDCAlertController alloc] initWithTitle:alertTitle
-                                                                attributedMessage:attributedMessage];
+  MDCAlertController *alertController =
+      [[MDCAlertController alloc] initWithTitle:alertTitle attributedMessage:attributedMessage];
 
   return alertController;
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -118,7 +118,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 + (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
-                                 attributedMessage:(nullable NSString *)attributedMessage {
+                       attributedMessage:(nullable NSString *)attributedMessage {
   MDCAlertController *alertController = [[MDCAlertController alloc] initWithTitle:alertTitle
                                                                           attributedMessage:attributedMessage];
 
@@ -131,33 +131,28 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
                               message:(nullable NSString *)message {
-  self = [super initWithNibName:nil bundle:nil];
+  self = [self initWithTitle:title];
   if (self) {
-    _transitionController = [[MDCDialogTransitionController alloc] init];
-
-    _alertTitle = [title copy];
     _message = [message copy];
-    _titleAlignment = NSTextAlignmentNatural;
-    _messageAlignment = NSTextAlignmentNatural;
-    _actionManager = [[MDCAlertActionManager alloc] init];
-    _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
-    _shadowColor = UIColor.blackColor;
-    _mdc_overrideBaseElevation = -1;
-
-    super.transitioningDelegate = _transitionController;
-    super.modalPresentationStyle = UIModalPresentationCustom;
   }
   return self;
 }
 
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
-                              attributedMessage:(nullable NSString *)attributedMessage {
+                    attributedMessage:(nullable NSString *)attributedMessage {
+  self = [self initWithTitle:title];
+  if (self) {
+    _attributedMessage = [attributedMessage copy];
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithTitle:(nullable NSString *)title {
   self = [super initWithNibName:nil bundle:nil];
   if (self) {
     _transitionController = [[MDCDialogTransitionController alloc] init];
 
     _alertTitle = [title copy];
-    _attributedMessage = [attributedMessage copy];
     _titleAlignment = NSTextAlignmentNatural;
     _messageAlignment = NSTextAlignmentNatural;
     _actionManager = [[MDCAlertActionManager alloc] init];

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -117,8 +117,8 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   return alertController;
 }
 
-+ (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
-                       attributedMessage:(nullable NSString *)attributedMessage {
++ (nonnull instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
+                       attributedMessage:(nullable NSAttributedString *)attributedMessage {
   MDCAlertController *alertController =
       [[MDCAlertController alloc] initWithTitle:alertTitle attributedMessage:attributedMessage];
 
@@ -139,7 +139,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 }
 
 - (nonnull instancetype)initWithTitle:(nullable NSString *)title
-                    attributedMessage:(nullable NSString *)attributedMessage {
+                    attributedMessage:(nullable NSAttributedString *)attributedMessage {
   self = [self initWithTitle:title];
   if (self) {
     _attributedMessage = [attributedMessage copy];

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -220,19 +220,25 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 - (void)setMessage:(NSString *)message {
   _message = [message copy];
   if (self.alertView) {
-    self.alertView.messageLabel.text = message;
-    self.preferredContentSize =
-        [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
+    [self messageDidChange];
   }
 }
 
 - (void)setAttributedMessage:(NSAttributedString *)attributedMessage {
   _attributedMessage = [attributedMessage copy];
   if (self.alertView) {
-    self.alertView.messageLabel.attributedText = attributedMessage;
-    self.preferredContentSize =
-        [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
+    [self messageDidChange];
   }
+}
+
+- (void)messageDidChange {
+  if (self.attributedMessage.length > 0) {
+    self.alertView.messageLabel.attributedText = self.attributedMessage;
+  } else {
+    self.alertView.messageLabel.text = self.message;
+  }
+  self.preferredContentSize =
+      [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
 }
 
 - (void)setMessageAccessibilityLabel:(NSString *)messageAccessibilityLabel {

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -720,7 +720,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     self.alertView.titleLabel.adjustsFontForContentSizeCategory =
         self.adjustsFontForContentSizeCategory;
   }
-  if (self.attributedMessage.count > 0) {
+  if (self.attributedMessage.length > 0) {
     self.alertView.messageLabel.attributedText = self.attributedMessage;
   } else {
     self.alertView.messageLabel.text = self.message;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -117,6 +117,14 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   return alertController;
 }
 
++ (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
+                                 attributedMessage:(nullable NSString *)attributedMessage {
+  MDCAlertController *alertController = [[MDCAlertController alloc] initWithTitle:alertTitle
+                                                                          attributedMessage:attributedMessage];
+
+  return alertController;
+}
+
 - (instancetype)init {
   return [self initWithTitle:nil message:nil];
 }
@@ -129,6 +137,27 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 
     _alertTitle = [title copy];
     _message = [message copy];
+    _titleAlignment = NSTextAlignmentNatural;
+    _messageAlignment = NSTextAlignmentNatural;
+    _actionManager = [[MDCAlertActionManager alloc] init];
+    _adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable = YES;
+    _shadowColor = UIColor.blackColor;
+    _mdc_overrideBaseElevation = -1;
+
+    super.transitioningDelegate = _transitionController;
+    super.modalPresentationStyle = UIModalPresentationCustom;
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithTitle:(nullable NSString *)title
+                              attributedMessage:(nullable NSString *)attributedMessage {
+  self = [super initWithNibName:nil bundle:nil];
+  if (self) {
+    _transitionController = [[MDCDialogTransitionController alloc] init];
+
+    _alertTitle = [title copy];
+    _attributedMessage = [attributedMessage copy];
     _titleAlignment = NSTextAlignmentNatural;
     _messageAlignment = NSTextAlignmentNatural;
     _actionManager = [[MDCAlertActionManager alloc] init];
@@ -197,6 +226,15 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   _message = [message copy];
   if (self.alertView) {
     self.alertView.messageLabel.text = message;
+    self.preferredContentSize =
+        [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
+  }
+}
+
+- (void)setMessage:(NSAttributedString *)attributedMessage {
+  _attributedMessage = [attributedMessage copy];
+  if (self.alertView) {
+    self.alertView.messageLabel.attributedText = attributedMessage;
     self.preferredContentSize =
         [self.alertView calculatePreferredContentSizeForBounds:CGRectInfinite.size];
   }
@@ -687,7 +725,11 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
     self.alertView.titleLabel.adjustsFontForContentSizeCategory =
         self.adjustsFontForContentSizeCategory;
   }
-  self.alertView.messageLabel.text = self.message;
+  if (self.attributedMessage.count > 0) {
+    self.alertView.messageLabel.attributedText = self.attributedMessage;
+  } else {
+    self.alertView.messageLabel.text = self.message;
+  }
   self.alertView.titleLabel.accessibilityLabel = self.titleAccessibilityLabel ?: self.title;
   self.alertView.messageLabel.accessibilityLabel = self.messageAccessibilityLabel ?: self.message;
   self.alertView.titleIconImageView.accessibilityLabel = self.imageAccessibilityLabel;

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -120,7 +120,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
 + (instancetype)alertControllerWithTitle:(nullable NSString *)alertTitle
                        attributedMessage:(nullable NSString *)attributedMessage {
   MDCAlertController *alertController = [[MDCAlertController alloc] initWithTitle:alertTitle
-                                                                          attributedMessage:attributedMessage];
+                                                                attributedMessage:attributedMessage];
 
   return alertController;
 }

--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -226,7 +226,7 @@ static NSString *const kMaterialDialogsBundle = @"MaterialDialogs.bundle";
   }
 }
 
-- (void)setMessage:(NSAttributedString *)attributedMessage {
+- (void)setAttributedMessage:(NSAttributedString *)attributedMessage {
   _attributedMessage = [attributedMessage copy];
   if (self.alertView) {
     self.alertView.messageLabel.attributedText = attributedMessage;

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -302,7 +302,7 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.attributedAlert.view;
   XCTAssertEqual(view.titleLabel.text, title);
-  XCTAssertEqual(view.messageLabel.text, message);
+  XCTAssertEqualObjects(view.messageLabel.text, message);
 }
 
 - (void)testAlertControllerSetMessageAccessibilityLabelWhenMessageIsSetWhenViewIsNotLoaded {

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -103,9 +103,9 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
 
   self.alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"message"];
 
-  NSAttributedString *attributedStr = [[NSAttributedString alloc] initWithString:"attributed message" 
-                                                                      attributes:@{}];
-  self.attributedAlert = [MDCAlertController alertControllerWithTitle:@"title" 
+  NSAttributedString *attributedStr =
+      [[NSAttributedString alloc] initWithString:"attributed message" attributes:@{}];
+  self.attributedAlert = [MDCAlertController alertControllerWithTitle:@"title"
                                                     attributedMessage:attributedStr];
 }
 

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -116,8 +116,8 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
 }
 
 /**
- Verifies that the message init does call initialize other variables correctly and configures, as per
- the common init, and the message property
+ Verifies that the message init does call initialize other variables correctly and configures, as
+ per the common init, and the message property
  */
 - (void)testMessageInit {
   // Then
@@ -131,8 +131,8 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
 }
 
 /**
- Verifies that the attributedMessage init does call initialize other variables correctly and configures, 
- as per the common init, and the attributedMessage property
+ Verifies that the attributedMessage init does call initialize other variables correctly and
+ configures, as per the common init, and the attributedMessage property
  */
 - (void)testAttributedMessageInit {
   // Then

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -104,7 +104,7 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   self.alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"message"];
 
   NSAttributedString *attributedStr =
-      [[NSAttributedString alloc] initWithString:"attributed message" attributes:@{}];
+      [[NSAttributedString alloc] initWithString:@"attributed message" attributes:@{}];
   self.attributedAlert = [MDCAlertController alertControllerWithTitle:@"title"
                                                     attributedMessage:attributedStr];
 }
@@ -126,8 +126,8 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   XCTAssertTrue(self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
   XCTAssertEqualObjects(self.alert.shadowColor, UIColor.blackColor);
 
-  XCTAssertNotNil(alert.message);
-  XCTAssertNil(alert.attributedMessage);
+  XCTAssertNotNil(self.alert.message);
+  XCTAssertNil(self.alert.attributedMessage);
 }
 
 /**

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -115,21 +115,17 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   [super tearDown];
 }
 
-- (void)testCommonInitializationsFor:(MDCAlertController *)alert {
-  // Then
-  XCTAssertNotNil(alert.actions);
-  XCTAssertNotNil(alert.title);
-  XCTAssertTrue(alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
-  XCTAssertEqualObjects(alert.shadowColor, UIColor.blackColor);
-}
-
 /**
  Verifies that the message init does call initialize other variables correctly and configures, as per
  the common init, and the message property
  */
 - (void)testMessageInit {
   // Then
-  [self testCommonInitializationsFor:self.alert];
+  XCTAssertNotNil(self.alert.actions);
+  XCTAssertNotNil(self.alert.title);
+  XCTAssertTrue(self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
+  XCTAssertEqualObjects(self.alert.shadowColor, UIColor.blackColor);
+
   XCTAssertNotNil(alert.message);
   XCTAssertNil(alert.attributedMessage);
 }
@@ -140,9 +136,13 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
  */
 - (void)testAttributedMessageInit {
   // Then
-  [self testCommonInitializationsFor:self.attributedAlert];
-  XCTAssertNotNil(alert.attributedMessage);
-  XCTAssertNil(alert.message);
+  XCTAssertNotNil(self.attributedAlert.actions);
+  XCTAssertNotNil(self.attributedAlert.title);
+  XCTAssertTrue(self.attributedAlert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
+  XCTAssertEqualObjects(self.attributedAlert.shadowColor, UIColor.blackColor);
+
+  XCTAssertNotNil(self.attributedAlert.attributedMessage);
+  XCTAssertNil(self.attributedAlert.message);
 }
 
 - (void)testAlertControllerWithTitleMessage {

--- a/components/Dialogs/tests/unit/MDCAlertControllerTests.m
+++ b/components/Dialogs/tests/unit/MDCAlertControllerTests.m
@@ -91,8 +91,9 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
 /** Unit tests for @c MDCAlertController. */
 @interface MDCAlertControllerTests : XCTestCase
 
-/** The @c MDCAlertController being tested. */
+/** The @c MDCAlertControllers being tested. */
 @property(nonatomic, nullable) MDCAlertController *alert;
+@property(nonatomic, nullable) MDCAlertController *attributedAlert;
 @end
 
 @implementation MDCAlertControllerTests
@@ -101,6 +102,11 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   [super setUp];
 
   self.alert = [MDCAlertController alertControllerWithTitle:@"title" message:@"message"];
+
+  NSAttributedString *attributedStr = [[NSAttributedString alloc] initWithString:"attributed message" 
+                                                                      attributes:@{}];
+  self.attributedAlert = [MDCAlertController alertControllerWithTitle:@"title" 
+                                                    attributedMessage:attributedStr];
 }
 
 - (void)tearDown {
@@ -109,13 +115,34 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   [super tearDown];
 }
 
-- (void)testInit {
+- (void)testCommonInitializationsFor:(MDCAlertController *)alert {
   // Then
-  XCTAssertNotNil(self.alert.actions);
-  XCTAssertNotNil(self.alert.title);
-  XCTAssertNotNil(self.alert.message);
-  XCTAssertTrue(self.alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
-  XCTAssertEqualObjects(self.alert.shadowColor, UIColor.blackColor);
+  XCTAssertNotNil(alert.actions);
+  XCTAssertNotNil(alert.title);
+  XCTAssertTrue(alert.adjustsFontForContentSizeCategoryWhenScaledFontIsUnavailable);
+  XCTAssertEqualObjects(alert.shadowColor, UIColor.blackColor);
+}
+
+/**
+ Verifies that the message init does call initialize other variables correctly and configures, as per
+ the common init, and the message property
+ */
+- (void)testMessageInit {
+  // Then
+  [self testCommonInitializationsFor:self.alert];
+  XCTAssertNotNil(alert.message);
+  XCTAssertNil(alert.attributedMessage);
+}
+
+/**
+ Verifies that the attributedMessage init does call initialize other variables correctly and configures, 
+ as per the common init, and the attributedMessage property
+ */
+- (void)testAttributedMessageInit {
+  // Then
+  [self testCommonInitializationsFor:self.attributedAlert];
+  XCTAssertNotNil(alert.attributedMessage);
+  XCTAssertNil(alert.message);
 }
 
 - (void)testAlertControllerWithTitleMessage {
@@ -123,6 +150,13 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
   XCTAssertNotNil(self.alert.actions);
   XCTAssertEqualObjects(self.alert.title, @"title");
   XCTAssertEqualObjects(self.alert.message, @"message");
+}
+
+- (void)testAlertControllerWithTitleAttributedMessage {
+  // Then
+  XCTAssertNotNil(self.attributedAlert.actions);
+  XCTAssertEqualObjects(self.attributedAlert.title, @"title");
+  XCTAssertEqualObjects(self.attributedAlert.attributedMessage.string, @"attributed message");
 }
 
 - (void)testAlertControllerTyphography {
@@ -253,6 +287,20 @@ static NSDictionary<UIContentSizeCategory, NSNumber *> *CustomScalingCurve() {
 
   // Then
   MDCAlertControllerView *view = (MDCAlertControllerView *)self.alert.view;
+  XCTAssertEqual(view.titleLabel.text, title);
+  XCTAssertEqual(view.messageLabel.text, message);
+}
+
+- (void)testAlertControllerSettingTitleAndAttributedMessage {
+  // Given
+  NSString *title = @"title";
+  NSString *message = @"attributed message";
+
+  // When
+  self.attributedAlert.titleFont = [UIFont systemFontOfSize:25];
+
+  // Then
+  MDCAlertControllerView *view = (MDCAlertControllerView *)self.attributedAlert.view;
   XCTAssertEqual(view.titleLabel.text, title);
   XCTAssertEqual(view.messageLabel.text, message);
 }


### PR DESCRIPTION
## Description

Adds attributed text support for the message inside dialogs in order to provide further customizability and allow for a more liberal use of the component