### PR TITLE
[BottomSheet] Add flag for enforcing full screen presentation in compact vertical size classes

### DIFF
--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -57,6 +57,14 @@
 @property(nonatomic, assign) BOOL shouldPropagateSafeAreaInsetsToPresentedViewController;
 
 /**
+ When this property is set to @c YES presented sheets will be "full screen", instead of adopting the
+ @c preferredSheetHeight.
+
+ @note Defaults to @c NO.
+ */
+@property(nonatomic, assign) BOOL shouldFullyExtendSheetInCompactVerticalSizeClasses;
+
+/**
  This is used to set a custom height on the sheet view.
 
  @note If a positive value is passed then the sheet view will be that height even if

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -125,6 +125,8 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   self.sheetView.delegate = self;
   self.sheetView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
   self.sheetView.dismissOnDraggingDownSheet = self.dismissOnDraggingDownSheet;
+  self.sheetView.shouldFullyExtendSheetInCompactVerticalSizeClasses =
+      self.shouldFullyExtendSheetInCompactVerticalSizeClasses;
 
   [containerView addSubview:_dimmingView];
   [containerView addSubview:self.sheetView];
@@ -301,6 +303,14 @@ static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewCo
   if (self.sheetView) {
     self.sheetView.dismissOnDraggingDownSheet = dismissOnDraggingDownSheet;
   }
+}
+
+- (void)setShouldFullyExtendSheetInCompactVerticalSizeClasses:
+    (BOOL)shouldFullyExtendSheetInCompactVerticalSizeClasses {
+  _shouldFullyExtendSheetInCompactVerticalSizeClasses =
+      shouldFullyExtendSheetInCompactVerticalSizeClasses;
+  self.sheetView.shouldFullyExtendSheetInCompactVerticalSizeClasses =
+      shouldFullyExtendSheetInCompactVerticalSizeClasses;
 }
 
 #pragma mark - MDCSheetContainerViewDelegate

--- a/components/BottomSheet/src/private/MDCSheetContainerView.h
+++ b/components/BottomSheet/src/private/MDCSheetContainerView.h
@@ -22,6 +22,7 @@
 @property(nonatomic, weak, nullable) id<MDCSheetContainerViewDelegate> delegate;
 @property(nonatomic, readonly) MDCSheetState sheetState;
 @property(nonatomic) CGFloat preferredSheetHeight;
+@property(nonatomic) BOOL shouldFullyExtendSheetInCompactVerticalSizeClasses;
 
 /**
  When set to false, the bottom sheet controller can't be dismissed by dragging the sheet down.


### PR DESCRIPTION
This CL adds a flag for enforcing full screen presentation in compact vertical size classes to address b/144286400. I'm importing this PR so I can look into adding a test. Our project currently does not build for testing via Cocoapods.