### PR TITLE
[Tabs] Make ScrollableCentered layout style fall back to FixClusteredCentered in certain situations

### DIFF
--- a/components/Tabs/src/TabBarView/MDCTabBarView.m
+++ b/components/Tabs/src/TabBarView/MDCTabBarView.m
@@ -679,7 +679,12 @@ static NSString *const kAccessibilityTraitsKeyPath = @"accessibilityTraits";
   CGSize availableSize = [self availableSizeForSubviewLayout];
   switch (self.preferredLayoutStyle) {
     case MDCTabBarViewLayoutStyleScrollableCentered: {
-      return MDCTabBarViewLayoutStyleScrollableCentered;
+      if (self.contentSize.width < CGRectGetWidth(self.frame)) {
+        return MDCTabBarViewLayoutStyleFixedClusteredCentered;
+      } else {
+        return MDCTabBarViewLayoutStyleScrollableCentered;
+      }
+      break;
     }
     case MDCTabBarViewLayoutStyleScrollable: {
       return MDCTabBarViewLayoutStyleScrollable;


### PR DESCRIPTION
With this PR the `.scrollableCentered` layout style falls back to the `.fixedClusteredCentered` layout style in situations where the combined width of the item views (equal to the scroll view's `contentSize.width`) is less than the width of the scroll view itself.