### PR TITLE
[TextFields] Replaced strong reference to weak for textInput

### DIFF
--- a/components/TextFields/src/MDCTextInputController.h
+++ b/components/TextFields/src/MDCTextInputController.h
@@ -216,7 +216,7 @@
 @property(class, nonatomic, assign) UIRectCorner roundedCornersDefault;
 
 /** The text input the controller is affecting. */
-@property(nonatomic, nullable, strong) UIView<MDCTextInput> *textInput;
+@property(nonatomic, nullable, weak) UIView<MDCTextInput> *textInput;
 
 /**
  The tintColor applied to the textInput's clear button.


### PR DESCRIPTION
This solves the issue: #9802

```closes #9802```