### PR TITLE
[Navigation Drawer] Updated documentation

### DIFF
--- a/components/NavigationDrawer/README.md
+++ b/components/NavigationDrawer/README.md
@@ -20,7 +20,6 @@ Navigation drawers are recommended for:
   <li class="icon-list-item icon-list-item">Apps with five or more top-level destinations.</li>
   <li class="icon-list-item icon-list-item">Apps with two or more levels of navigation hierarchy.</li>
   <li class="icon-list-item icon-list-item">Quick navigation between unrelated destinations.</li>
-</ul>
 
 ## Design & API documentation
 


### PR DESCRIPTION
The `</ul>` tag is not required to create the list.

When opening the [Navigation Drawer](https://material.io/develop/ios/components/navigation-drawer/) page, the tag was presented when reading the document.
