### PR TITLE
Disable BottomSheet and ActionSheet on macCatalyst builds

### DIFF
--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UIKit
-
 import CatalogByConvention
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialAppBar_ColorThemer
@@ -21,6 +19,7 @@ import MaterialComponents.MaterialAppBar_TypographyThemer
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialCollections
 import MaterialComponents.MaterialIcons_ic_more_horiz
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationControllerDelegate {
@@ -32,8 +31,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
   let navigationController = MDCAppBarNavigationController()
   var tree: CBCNode?
 
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions
-                   launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
     self.window = MDCCatalogWindow(frame: UIScreen.main.bounds)
 
     // The navigation tree will only take examples that implement
@@ -81,13 +82,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MDCAppBarNavigationContro
 
   // MARK: MDCAppBarNavigationControllerInjectorDelegate
 
-  func appBarNavigationController(_ navigationController: MDCAppBarNavigationController,
-                                  willAdd appBarViewController: MDCAppBarViewController,
-                                  asChildOf viewController: UIViewController) {
-    MDCAppBarColorThemer.applyColorScheme(AppTheme.containerScheme.colorScheme,
-                                                        to: appBarViewController)
-    MDCAppBarTypographyThemer.applyTypographyScheme(AppTheme.containerScheme.typographyScheme,
-                                                    to: appBarViewController)
+  func appBarNavigationController(
+    _ navigationController: MDCAppBarNavigationController,
+    willAdd appBarViewController: MDCAppBarViewController,
+    asChildOf viewController: UIViewController
+  ) {
+    MDCAppBarColorThemer.applyColorScheme(
+      AppTheme.containerScheme.colorScheme,
+      to: appBarViewController)
+    MDCAppBarTypographyThemer.applyTypographyScheme(
+      AppTheme.containerScheme.typographyScheme,
+      to: appBarViewController)
 
     if let injectee = viewController as? CatalogAppBarInjectee {
       injectee.appBarNavigationControllerInjector(willAdd: appBarViewController)
@@ -116,10 +121,11 @@ extension UINavigationController {
   @available(macCatalyst, unavailable)
   func setMenuBarButton(for viewController: UIViewController) {
     let dotsImage = MDCIcons.imageFor_ic_more_horiz()?.withRenderingMode(.alwaysTemplate)
-    let menuItem = UIBarButtonItem(image: dotsImage,
-                                   style: .plain,
-                                   target: self,
-                                   action: #selector(presentMenu))
+    let menuItem = UIBarButtonItem(
+      image: dotsImage,
+      style: .plain,
+      target: self,
+      action: #selector(presentMenu))
     menuItem.accessibilityLabel = "Menu"
     menuItem.accessibilityHint = "Opens catalog configuration options."
     viewController.navigationItem.rightBarButtonItem = menuItem

--- a/catalog/MDCCatalog/AppDelegate.swift
+++ b/catalog/MDCCatalog/AppDelegate.swift
@@ -106,12 +106,14 @@ protocol CatalogAppBarInjectee {
 }
 
 extension UINavigationController {
+  @available(macCatalyst, unavailable)
   @objc func presentMenu() {
     let menuViewController = MDCMenuViewController(style: .plain)
     let bottomSheet = MDCBottomSheetController(contentViewController: menuViewController)
     self.present(bottomSheet, animated: true, completion: nil)
   }
 
+  @available(macCatalyst, unavailable)
   func setMenuBarButton(for viewController: UIViewController) {
     let dotsImage = MDCIcons.imageFor_ic_more_horiz()?.withRenderingMode(.alwaysTemplate)
     let menuItem = UIBarButtonItem(image: dotsImage,

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UIKit
 import CatalogByConvention
 import MaterialCatalog
 import MaterialComponents.MaterialFlexibleHeader
+import MaterialComponents.MaterialIcons_ic_arrow_back
 import MaterialComponents.MaterialLibraryInfo
 import MaterialComponents.MaterialRipple
 import MaterialComponents.MaterialShadowElevations
 import MaterialComponents.MaterialShadowLayer
 import MaterialComponents.MaterialThemes
 import MaterialComponents.MaterialTypography
-import MaterialComponents.MaterialIcons_ic_arrow_back
+import UIKit
 
 class MDCCatalogComponentsController: UICollectionViewController,
   UICollectionViewDelegateFlowLayout, MDCRippleTouchControllerDelegate
@@ -65,15 +65,14 @@ class MDCCatalogComponentsController: UICollectionViewController,
     //   "Use of undeclared type 'UIPointerInteractionDelegate'"
     // Ideally, we would be able to tie this to an iOS version rather than a compiler version, but
     // such a solution does not seem to be available for Swift.
-#if compiler(>=5.2)
+    #if compiler(>=5.2)
       if #available(iOS 13.4, *) {
         let interaction = UIPointerInteraction(delegate: self)
         button.addInteraction(interaction)
       }
-#endif
+    #endif
     return button
   }()
-
 
   private let node: CBCNode
   private lazy var titleLabel: UILabel = {
@@ -92,10 +91,11 @@ class MDCCatalogComponentsController: UICollectionViewController,
 
     let layout = UICollectionViewFlowLayout()
     let sectionInset: CGFloat = Constants.spacing
-    layout.sectionInset = UIEdgeInsets(top: sectionInset,
-                                       left: sectionInset,
-                                       bottom: sectionInset,
-                                       right: sectionInset)
+    layout.sectionInset = UIEdgeInsets(
+      top: sectionInset,
+      left: sectionInset,
+      bottom: sectionInset,
+      right: sectionInset)
     layout.minimumInteritemSpacing = Constants.spacing
     layout.minimumLineSpacing = Constants.spacing
 
@@ -111,7 +111,8 @@ class MDCCatalogComponentsController: UICollectionViewController,
     headerViewController.headerView.maximumHeight = 128
     headerViewController.headerView.minimumHeight = 56
 
-    collectionView?.register(MDCCatalogCollectionViewCell.self,
+    collectionView?.register(
+      MDCCatalogCollectionViewCell.self,
       forCellWithReuseIdentifier: "MDCCatalogCollectionViewCell")
     collectionView?.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
 
@@ -157,10 +158,11 @@ class MDCCatalogComponentsController: UICollectionViewController,
     titleLabel.font = AppTheme.containerScheme.typographyScheme.headline6
     titleLabel.sizeToFit()
 
-    let titleInsets = UIEdgeInsets(top: 0,
-                                   left: Constants.inset,
-                                   bottom: Constants.inset,
-                                   right: Constants.inset)
+    let titleInsets = UIEdgeInsets(
+      top: 0,
+      left: Constants.inset,
+      bottom: Constants.inset,
+      right: Constants.inset)
     let titleSize = titleLabel.sizeThatFits(containerView.bounds.size)
 
     containerView.addSubview(titleLabel)
@@ -172,27 +174,31 @@ class MDCCatalogComponentsController: UICollectionViewController,
 
     let colorScheme = AppTheme.containerScheme.colorScheme
 
-    let image = MDCDrawImage(CGRect(x:0,
-                                    y:0,
-                                    width: Constants.logoWidthHeight,
-                                    height: Constants.logoWidthHeight),
-                             { MDCCatalogDrawMDCLogoLight($0, $1) },
-                             colorScheme)
+    let image = MDCDrawImage(
+      CGRect(
+        x: 0,
+        y: 0,
+        width: Constants.logoWidthHeight,
+        height: Constants.logoWidthHeight),
+      { MDCCatalogDrawMDCLogoLight($0, $1) },
+      colorScheme)
     logo.image = image
 
     #if !targetEnvironment(macCatalyst)
-    menuButton.addTarget(self.navigationController,
-                         action: #selector(navigationController?.presentMenu),
-                         for: .touchUpInside)
-    menuButton.tintColor = colorScheme.onPrimaryColor
-    containerView.addSubview(menuButton)
+      menuButton.addTarget(
+        self.navigationController,
+        action: #selector(navigationController?.presentMenu),
+        for: .touchUpInside)
+      menuButton.tintColor = colorScheme.onPrimaryColor
+      containerView.addSubview(menuButton)
     #endif
 
     setupFlexibleHeaderContentConstraints()
-    constrainLabel(label: titleLabel,
-                   containerView: containerView,
-                   insets: titleInsets,
-                   height: titleSize.height)
+    constrainLabel(
+      label: titleLabel,
+      containerView: containerView,
+      insets: titleInsets,
+      height: titleSize.height)
 
     headerViewController.headerView.backgroundColor = colorScheme.primaryColor
 
@@ -222,7 +228,8 @@ class MDCCatalogComponentsController: UICollectionViewController,
   }
 
   override func willAnimateRotation(
-    to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval) {
+    to toInterfaceOrientation: UIInterfaceOrientation, duration: TimeInterval
+  ) {
     collectionView?.collectionViewLayout.invalidateLayout()
   }
 
@@ -244,71 +251,84 @@ class MDCCatalogComponentsController: UICollectionViewController,
 
   func setupFlexibleHeaderContentConstraints() {
 
-    logoLeftPaddingConstraint = NSLayoutConstraint(item: logo,
-                                                   attribute: .leading,
-                                                   relatedBy: .equal,
-                                                   toItem: logo.superview,
-                                                   attribute: .leading,
-                                                   multiplier: 1,
-                                                   constant: Constants.inset)
+    logoLeftPaddingConstraint = NSLayoutConstraint(
+      item: logo,
+      attribute: .leading,
+      relatedBy: .equal,
+      toItem: logo.superview,
+      attribute: .leading,
+      multiplier: 1,
+      constant: Constants.inset)
     logoLeftPaddingConstraint?.isActive = true
 
     #if !targetEnvironment(macCatalyst)
-    menuButtonRightPaddingConstraint = NSLayoutConstraint(item: menuButton,
-                                                          attribute: .trailing,
-                                                          relatedBy: .equal,
-                                                          toItem: menuButton.superview,
-                                                          attribute: .trailing,
-                                                          multiplier: 1,
-                                                          constant: -1 * Constants.inset)
-    menuButtonRightPaddingConstraint?.isActive = true
+      menuButtonRightPaddingConstraint = NSLayoutConstraint(
+        item: menuButton,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: menuButton.superview,
+        attribute: .trailing,
+        multiplier: 1,
+        constant: -1 * Constants.inset)
+      menuButtonRightPaddingConstraint?.isActive = true
 
-    menuTopPaddingConstraint = NSLayoutConstraint(item: menuButton,
-                                                  attribute: .top,
-                                                  relatedBy: .equal,
-                                                  toItem: menuButton.superview,
-                                                  attribute: .top,
-                                                  multiplier: 1,
-                                                  constant: Constants.menuTopVerticalSpacing)
-    menuTopPaddingConstraint?.isActive = true
+      menuTopPaddingConstraint = NSLayoutConstraint(
+        item: menuButton,
+        attribute: .top,
+        relatedBy: .equal,
+        toItem: menuButton.superview,
+        attribute: .top,
+        multiplier: 1,
+        constant: Constants.menuTopVerticalSpacing)
+      menuTopPaddingConstraint?.isActive = true
 
-    NSLayoutConstraint(item: logo,
-                       attribute: .centerY,
-                       relatedBy: .equal,
-                       toItem: menuButton,
-                       attribute: .centerY,
-                       multiplier: 1,
-                       constant: 0).isActive = true
-    NSLayoutConstraint(item: menuButton,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: menuButton,
-                       attribute: .height,
-                       multiplier: 1,
-                       constant: 0).isActive = true
-    NSLayoutConstraint(item: menuButton,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1,
-                       constant: Constants.menuButtonWidthHeight).isActive = true
+      NSLayoutConstraint(
+        item: logo,
+        attribute: .centerY,
+        relatedBy: .equal,
+        toItem: menuButton,
+        attribute: .centerY,
+        multiplier: 1,
+        constant: 0
+      ).isActive = true
+      NSLayoutConstraint(
+        item: menuButton,
+        attribute: .width,
+        relatedBy: .equal,
+        toItem: menuButton,
+        attribute: .height,
+        multiplier: 1,
+        constant: 0
+      ).isActive = true
+      NSLayoutConstraint(
+        item: menuButton,
+        attribute: .width,
+        relatedBy: .equal,
+        toItem: nil,
+        attribute: .notAnAttribute,
+        multiplier: 1,
+        constant: Constants.menuButtonWidthHeight
+      ).isActive = true
     #endif
 
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: logo,
-                       attribute: .height,
-                       multiplier: 1,
-                       constant: 0).isActive = true
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1,
-                       constant: Constants.logoWidthHeight).isActive = true
+    NSLayoutConstraint(
+      item: logo,
+      attribute: .width,
+      relatedBy: .equal,
+      toItem: logo,
+      attribute: .height,
+      multiplier: 1,
+      constant: 0
+    ).isActive = true
+    NSLayoutConstraint(
+      item: logo,
+      attribute: .width,
+      relatedBy: .equal,
+      toItem: nil,
+      attribute: .notAnAttribute,
+      multiplier: 1,
+      constant: Constants.logoWidthHeight
+    ).isActive = true
   }
 
   // MARK: UICollectionViewDataSource
@@ -317,8 +337,10 @@ class MDCCatalogComponentsController: UICollectionViewController,
     return 1
   }
 
-  override func collectionView(_ collectionView: UICollectionView,
-                               numberOfItemsInSection section: Int) -> Int {
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
     return node.children.count
   }
 
@@ -344,11 +366,14 @@ class MDCCatalogComponentsController: UICollectionViewController,
 
   // MARK: UICollectionViewDelegate
 
-  override func collectionView(_ collectionView: UICollectionView,
-                               cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
     let cell =
-      collectionView.dequeueReusableCell(withReuseIdentifier: "MDCCatalogCollectionViewCell",
-                                         for: indexPath)
+      collectionView.dequeueReusableCell(
+        withReuseIdentifier: "MDCCatalogCollectionViewCell",
+        for: indexPath)
     cell.backgroundColor = AppTheme.containerScheme.colorScheme.backgroundColor
 
     let componentName = node.children[indexPath.row].title
@@ -362,9 +387,11 @@ class MDCCatalogComponentsController: UICollectionViewController,
     return cell
   }
 
-  func collectionView(_ collectionView: UICollectionView,
-                      layout collectionViewLayout: UICollectionViewLayout,
-                      sizeForItemAt indexPath: IndexPath) -> CGSize {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
     let dividerWidth: CGFloat = 1
     var safeInsets: CGFloat = 0
     if #available(iOS 11, *) {
@@ -385,8 +412,10 @@ class MDCCatalogComponentsController: UICollectionViewController,
     return CGSize(width: cellWidthHeight, height: cellWidthHeight)
   }
 
-  override func collectionView(_ collectionView: UICollectionView,
-                               didSelectItemAt indexPath: IndexPath) {
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
     let node = self.node.children[indexPath.row]
     var vc: UIViewController
     if node.isExample() {
@@ -395,50 +424,60 @@ class MDCCatalogComponentsController: UICollectionViewController,
       vc = MDCNodeListViewController(node: node)
     }
     #if !targetEnvironment(macCatalyst)
-    self.navigationController?.setMenuBarButton(for: vc)
+      self.navigationController?.setMenuBarButton(for: vc)
     #endif
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
   // MARK: Private
-  func constrainLabel(label: UILabel,
-                      containerView: UIView,
-                      insets: UIEdgeInsets,
-                      height: CGFloat) {
+  func constrainLabel(
+    label: UILabel,
+    containerView: UIView,
+    insets: UIEdgeInsets,
+    height: CGFloat
+  ) {
 
-    NSLayoutConstraint(item: label,
-                       attribute: .leading,
-                       relatedBy: .equal,
-                       toItem: logo,
-                       attribute: .trailing,
-                       multiplier: 1.0,
-                       constant: insets.left).isActive = true
+    NSLayoutConstraint(
+      item: label,
+      attribute: .leading,
+      relatedBy: .equal,
+      toItem: logo,
+      attribute: .trailing,
+      multiplier: 1.0,
+      constant: insets.left
+    ).isActive = true
 
     #if !targetEnvironment(macCatalyst)
-    NSLayoutConstraint(item: label,
-                       attribute: .trailing,
-                       relatedBy: .equal,
-                       toItem: menuButton,
-                       attribute: .leading,
-                       multiplier: 1.0,
-                       constant: -insets.right).isActive = true
+      NSLayoutConstraint(
+        item: label,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: menuButton,
+        attribute: .leading,
+        multiplier: 1.0,
+        constant: -insets.right
+      ).isActive = true
     #endif
 
-    NSLayoutConstraint(item: label,
-                       attribute: .bottom,
-                       relatedBy: .equal,
-                       toItem: containerView,
-                       attribute: .bottom,
-                       multiplier: 1.0,
-                       constant: -insets.bottom).isActive = true
+    NSLayoutConstraint(
+      item: label,
+      attribute: .bottom,
+      relatedBy: .equal,
+      toItem: containerView,
+      attribute: .bottom,
+      multiplier: 1.0,
+      constant: -insets.bottom
+    ).isActive = true
 
-    NSLayoutConstraint(item: label,
-                       attribute: .height,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1.0,
-                       constant: height).isActive = true
+    NSLayoutConstraint(
+      item: label,
+      attribute: .height,
+      relatedBy: .equal,
+      toItem: nil,
+      attribute: .notAnAttribute,
+      multiplier: 1.0,
+      constant: height
+    ).isActive = true
   }
 }
 
@@ -447,19 +486,21 @@ class MDCCatalogComponentsController: UICollectionViewController,
 // Ideally, we would be able to tie this to an iOS version rather than a compiler version, but such
 // a solution does not seem to be available for Swift.
 #if compiler(>=5.2)
-@available(iOS 13.4, *)
-extension MDCCatalogComponentsController: UIPointerInteractionDelegate {
   @available(iOS 13.4, *)
-  func pointerInteraction(_ interaction: UIPointerInteraction,
-                          styleFor region: UIPointerRegion) -> UIPointerStyle? {
-    guard let interactionView = interaction.view else {
-      return nil
+  extension MDCCatalogComponentsController: UIPointerInteractionDelegate {
+    @available(iOS 13.4, *)
+    func pointerInteraction(
+      _ interaction: UIPointerInteraction,
+      styleFor region: UIPointerRegion
+    ) -> UIPointerStyle? {
+      guard let interactionView = interaction.view else {
+        return nil
+      }
+      let targetedPreview = UITargetedPreview(view: interactionView)
+      let pointerStyle = UIPointerStyle(effect: .highlight(targetedPreview))
+      return pointerStyle
     }
-    let targetedPreview = UITargetedPreview(view: interactionView)
-    let pointerStyle = UIPointerStyle(effect: .highlight(targetedPreview))
-    return pointerStyle
   }
-}
 #endif
 
 // UIScrollViewDelegate
@@ -472,8 +513,9 @@ extension MDCCatalogComponentsController {
   }
 
   override func scrollViewDidEndDragging(
-      _ scrollView: UIScrollView,
-      willDecelerate decelerate: Bool) {
+    _ scrollView: UIScrollView,
+    willDecelerate decelerate: Bool
+  ) {
     let headerView = headerViewController.headerView
     if scrollView == headerView.trackingScrollView {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
@@ -487,9 +529,10 @@ extension MDCCatalogComponentsController {
   }
 
   override func scrollViewWillEndDragging(
-      _ scrollView: UIScrollView,
-      withVelocity velocity: CGPoint,
-      targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
     let headerView = headerViewController.headerView
     if scrollView == headerView.trackingScrollView {
       headerView.trackingScrollWillEndDragging(

--- a/catalog/MDCCatalog/MDCCatalogComponentsController.swift
+++ b/catalog/MDCCatalog/MDCCatalogComponentsController.swift
@@ -180,11 +180,13 @@ class MDCCatalogComponentsController: UICollectionViewController,
                              colorScheme)
     logo.image = image
 
+    #if !targetEnvironment(macCatalyst)
     menuButton.addTarget(self.navigationController,
                          action: #selector(navigationController?.presentMenu),
                          for: .touchUpInside)
     menuButton.tintColor = colorScheme.onPrimaryColor
     containerView.addSubview(menuButton)
+    #endif
 
     setupFlexibleHeaderContentConstraints()
     constrainLabel(label: titleLabel,
@@ -251,6 +253,7 @@ class MDCCatalogComponentsController: UICollectionViewController,
                                                    constant: Constants.inset)
     logoLeftPaddingConstraint?.isActive = true
 
+    #if !targetEnvironment(macCatalyst)
     menuButtonRightPaddingConstraint = NSLayoutConstraint(item: menuButton,
                                                           attribute: .trailing,
                                                           relatedBy: .equal,
@@ -276,21 +279,6 @@ class MDCCatalogComponentsController: UICollectionViewController,
                        attribute: .centerY,
                        multiplier: 1,
                        constant: 0).isActive = true
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: logo,
-                       attribute: .height,
-                       multiplier: 1,
-                       constant: 0).isActive = true
-    NSLayoutConstraint(item: logo,
-                       attribute: .width,
-                       relatedBy: .equal,
-                       toItem: nil,
-                       attribute: .notAnAttribute,
-                       multiplier: 1,
-                       constant: Constants.logoWidthHeight).isActive = true
-
     NSLayoutConstraint(item: menuButton,
                        attribute: .width,
                        relatedBy: .equal,
@@ -305,6 +293,22 @@ class MDCCatalogComponentsController: UICollectionViewController,
                        attribute: .notAnAttribute,
                        multiplier: 1,
                        constant: Constants.menuButtonWidthHeight).isActive = true
+    #endif
+
+    NSLayoutConstraint(item: logo,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: logo,
+                       attribute: .height,
+                       multiplier: 1,
+                       constant: 0).isActive = true
+    NSLayoutConstraint(item: logo,
+                       attribute: .width,
+                       relatedBy: .equal,
+                       toItem: nil,
+                       attribute: .notAnAttribute,
+                       multiplier: 1,
+                       constant: Constants.logoWidthHeight).isActive = true
   }
 
   // MARK: UICollectionViewDataSource
@@ -390,7 +394,9 @@ class MDCCatalogComponentsController: UICollectionViewController,
     } else {
       vc = MDCNodeListViewController(node: node)
     }
+    #if !targetEnvironment(macCatalyst)
     self.navigationController?.setMenuBarButton(for: vc)
+    #endif
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
@@ -408,6 +414,7 @@ class MDCCatalogComponentsController: UICollectionViewController,
                        multiplier: 1.0,
                        constant: insets.left).isActive = true
 
+    #if !targetEnvironment(macCatalyst)
     NSLayoutConstraint(item: label,
                        attribute: .trailing,
                        relatedBy: .equal,
@@ -415,6 +422,7 @@ class MDCCatalogComponentsController: UICollectionViewController,
                        attribute: .leading,
                        multiplier: 1.0,
                        constant: -insets.right).isActive = true
+    #endif
 
     NSLayoutConstraint(item: label,
                        attribute: .bottom,

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import UIKit
-
 import CatalogByConvention
-
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialAppBar_ColorThemer
 import MaterialComponents.MaterialAppBar_TypographyThemer
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
+import MaterialComponents.MaterialButtons_Theming
 import MaterialComponents.MaterialCollections
 import MaterialComponents.MaterialTypography
-import MaterialComponents.MaterialButtons_Theming
+import UIKit
 
 class NodeViewTableViewDemoCell: UITableViewCell {
 
@@ -50,7 +48,8 @@ class NodeViewTableViewDemoCell: UITableViewCell {
       toItem: nil,
       attribute: .notAnAttribute,
       multiplier: 1.0,
-      constant: 1).isActive = true
+      constant: 1
+    ).isActive = true
 
     // Line divider to section view
     NSLayoutConstraint(
@@ -60,7 +59,8 @@ class NodeViewTableViewDemoCell: UITableViewCell {
       toItem: lineDivider,
       attribute: .leading,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: self,
       attribute: .trailing,
@@ -68,7 +68,8 @@ class NodeViewTableViewDemoCell: UITableViewCell {
       toItem: lineDivider,
       attribute: .trailing,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: self,
       attribute: .bottom,
@@ -76,7 +77,8 @@ class NodeViewTableViewDemoCell: UITableViewCell {
       toItem: lineDivider,
       attribute: .bottom,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
   }
 
   required init(coder: NSCoder) {
@@ -107,49 +109,55 @@ class NodeViewTableViewPrimaryDemoCell: UITableViewCell {
   func setupContainedButton() {
     containedButton.setTitle("Start Demo", for: .normal)
     containedButton.translatesAutoresizingMaskIntoConstraints = false
-    containedButton.accessibilityIdentifier = "start.demo";
+    containedButton.accessibilityIdentifier = "start.demo"
     contentView.addSubview(containedButton)
 
     // constraints
-    NSLayoutConstraint(item: contentView,
-                       attribute: .left,
-                       relatedBy: .equal,
-                       toItem: containedButton,
-                       attribute: .left,
-                       multiplier: 1,
-                       constant: -16).isActive = true
-    NSLayoutConstraint(item: contentView,
-                       attribute: .right,
-                       relatedBy: .equal,
-                       toItem: containedButton,
-                       attribute: .right,
-                       multiplier: 1,
-                       constant: 16).isActive = true
-    NSLayoutConstraint(item: contentView,
-                       attribute: .top,
-                       relatedBy: .equal,
-                       toItem: containedButton,
-                       attribute: .top,
-                       multiplier: 1,
-                       constant: -10).isActive = true
-    NSLayoutConstraint(item: contentView,
-                       attribute: .bottom,
-                       relatedBy: .equal,
-                       toItem: containedButton,
-                       attribute: .bottom,
-                       multiplier: 1,
-                       constant: 6).isActive = true
+    NSLayoutConstraint(
+      item: contentView,
+      attribute: .left,
+      relatedBy: .equal,
+      toItem: containedButton,
+      attribute: .left,
+      multiplier: 1,
+      constant: -16
+    ).isActive = true
+    NSLayoutConstraint(
+      item: contentView,
+      attribute: .right,
+      relatedBy: .equal,
+      toItem: containedButton,
+      attribute: .right,
+      multiplier: 1,
+      constant: 16
+    ).isActive = true
+    NSLayoutConstraint(
+      item: contentView,
+      attribute: .top,
+      relatedBy: .equal,
+      toItem: containedButton,
+      attribute: .top,
+      multiplier: 1,
+      constant: -10
+    ).isActive = true
+    NSLayoutConstraint(
+      item: contentView,
+      attribute: .bottom,
+      relatedBy: .equal,
+      toItem: containedButton,
+      attribute: .bottom,
+      multiplier: 1,
+      constant: 6
+    ).isActive = true
   }
 
 }
 
-
-
 class MDCNodeListViewController: CBCNodeListViewController {
-  var mainSectionHeader : UIView?
-  var mainSectionHeaderTitleLabel : UILabel?
-  var mainSectionHeaderDescriptionLabel : UILabel?
-  var additionalExamplesSectionHeader : UIView?
+  var mainSectionHeader: UIView?
+  var mainSectionHeaderTitleLabel: UILabel?
+  var mainSectionHeaderDescriptionLabel: UILabel?
+  var additionalExamplesSectionHeader: UIView?
   let sectionNames = ["Description", "Additional Examples"]
   let estimadedDescriptionSectionHeight = CGFloat(100)
   let estimadedAdditionalExamplesSectionHeight = CGFloat(50)
@@ -168,9 +176,10 @@ class MDCNodeListViewController: CBCNodeListViewController {
   }
 
   deinit {
-    NotificationCenter.default.removeObserver(self,
-                                              name: AppTheme.didChangeGlobalThemeNotificationName,
-                                              object: nil)
+    NotificationCenter.default.removeObserver(
+      self,
+      name: AppTheme.didChangeGlobalThemeNotificationName,
+      object: nil)
   }
 
   override init(node: CBCNode) {
@@ -180,7 +189,8 @@ class MDCNodeListViewController: CBCNodeListViewController {
 
     // Make sure that primary demo appears first
     if let primaryDemoNodeIndex = childrenNodes.index(where: { $0.isPrimaryDemo() }),
-        primaryDemoNodeIndex != 0 {
+      primaryDemoNodeIndex != 0
+    {
       let primaryDemoNode = childrenNodes[primaryDemoNodeIndex]
       childrenNodes.remove(at: primaryDemoNodeIndex)
       childrenNodes.insert(primaryDemoNode, at: 0)
@@ -222,10 +232,12 @@ class MDCNodeListViewController: CBCNodeListViewController {
       self.tableView.accessibilityIdentifier = "DemoTableList"
     }
 
-    self.tableView.register(NodeViewTableViewPrimaryDemoCell.self,
-                            forCellReuseIdentifier: "NodeViewTableViewPrimaryDemoCell")
-    self.tableView.register(NodeViewTableViewDemoCell.self,
-                            forCellReuseIdentifier: "NodeViewTableViewDemoCell")
+    self.tableView.register(
+      NodeViewTableViewPrimaryDemoCell.self,
+      forCellReuseIdentifier: "NodeViewTableViewPrimaryDemoCell")
+    self.tableView.register(
+      NodeViewTableViewDemoCell.self,
+      forCellReuseIdentifier: "NodeViewTableViewDemoCell")
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -250,31 +262,39 @@ extension MDCNodeListViewController {
     return sectionNames.count
   }
 
-  override func tableView(_ tableView: UITableView,
-                          titleForHeaderInSection section: Int) -> String? {
+  override func tableView(
+    _ tableView: UITableView,
+    titleForHeaderInSection section: Int
+  ) -> String? {
     return sectionNames[section]
   }
-  override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+  override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat
+  {
     if indexPath.section == Section.description.rawValue {
       return demoButtonRowHeight
     }
     return additionalDemoRowHeight
   }
 
-  override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+  override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int)
+    -> CGFloat
+  {
     if let mainSectionHeader = mainSectionHeader, section == Section.description.rawValue {
       let labelPreferredMaxLayoutWidth = tableView.frame.size.width - (2 * padding)
       mainSectionHeaderDescriptionLabel?.preferredMaxLayoutWidth = labelPreferredMaxLayoutWidth
       mainSectionHeaderTitleLabel?.preferredMaxLayoutWidth = labelPreferredMaxLayoutWidth
-      let targetSize = CGSize(width: tableView.frame.size.width,
-                              height: estimadedDescriptionSectionHeight)
+      let targetSize = CGSize(
+        width: tableView.frame.size.width,
+        height: estimadedDescriptionSectionHeight)
       return mainSectionHeader.systemLayoutSizeFitting(targetSize).height
     }
     return estimadedAdditionalExamplesSectionHeight
   }
   // swiftlint:disable function_body_length
-  override func tableView(_ tableView: UITableView,
-                          viewForHeaderInSection section: Int) -> UIView? {
+  override func tableView(
+    _ tableView: UITableView,
+    viewForHeaderInSection section: Int
+  ) -> UIView? {
     if section == 0 {
       return mainSectionHeader
     }
@@ -306,7 +326,8 @@ extension MDCNodeListViewController {
       toItem: nil,
       attribute: .notAnAttribute,
       multiplier: 1.0,
-      constant: 1).isActive = true
+      constant: 1
+    ).isActive = true
 
     // Line divider to section view
     NSLayoutConstraint(
@@ -316,7 +337,8 @@ extension MDCNodeListViewController {
       toItem: lineDivider,
       attribute: .leading,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: sectionView,
       attribute: .trailing,
@@ -324,7 +346,8 @@ extension MDCNodeListViewController {
       toItem: lineDivider,
       attribute: .trailing,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: sectionView,
       attribute: .top,
@@ -332,7 +355,8 @@ extension MDCNodeListViewController {
       toItem: lineDivider,
       attribute: .top,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
 
     // Line divider to Title Label
     NSLayoutConstraint(
@@ -342,7 +366,8 @@ extension MDCNodeListViewController {
       toItem: sectionTitleLabel,
       attribute: .top,
       multiplier: 1.0,
-      constant: -padding).isActive = true
+      constant: -padding
+    ).isActive = true
 
     let preiOS11Behavior = {
       NSLayoutConstraint(
@@ -352,7 +377,8 @@ extension MDCNodeListViewController {
         toItem: sectionTitleLabel,
         attribute: .leading,
         multiplier: 1.0,
-        constant: -self.padding).isActive = true
+        constant: -self.padding
+      ).isActive = true
       NSLayoutConstraint(
         item: sectionView,
         attribute: .trailing,
@@ -360,29 +386,35 @@ extension MDCNodeListViewController {
         toItem: sectionTitleLabel,
         attribute: .trailing,
         multiplier: 1.0,
-        constant: self.padding).isActive = true
+        constant: self.padding
+      ).isActive = true
     }
     // Title Label to Section View
     if #available(iOS 11.0, *) {
       // Align to the safe area insets.
       sectionTitleLabel.leadingAnchor
-        .constraint(equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
-                    constant: padding).isActive = true
+        .constraint(
+          equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
+          constant: padding
+        ).isActive = true
       sectionTitleLabel.trailingAnchor
-        .constraint(equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -padding).isActive = true
+        .constraint(
+          equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
+          constant: -padding
+        ).isActive = true
     } else {
       preiOS11Behavior()
     }
 
-     NSLayoutConstraint(
+    NSLayoutConstraint(
       item: sectionView,
       attribute: .bottom,
       relatedBy: .equal,
       toItem: sectionTitleLabel,
       attribute: .bottom,
       multiplier: 1.0,
-      constant: padding).isActive = true
+      constant: padding
+    ).isActive = true
 
     return sectionView
   }
@@ -407,7 +439,7 @@ extension MDCNodeListViewController {
     let attrs = [NSAttributedString.Key.paragraphStyle: paragraphStyle]
 
     descriptionLabel.attributedText =
-        NSAttributedString(string:componentDescription, attributes:attrs)
+      NSAttributedString(string: componentDescription, attributes: attrs)
     descriptionLabel.alpha = MDCTypography.body1FontOpacity()
     descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
     descriptionLabel.numberOfLines = 0
@@ -426,7 +458,8 @@ extension MDCNodeListViewController {
         toItem: sectionTitleLabel,
         attribute: .leading,
         multiplier: 1.0,
-        constant: -self.padding).isActive = true
+        constant: -self.padding
+      ).isActive = true
       NSLayoutConstraint(
         item: sectionView,
         attribute: .trailing,
@@ -434,16 +467,21 @@ extension MDCNodeListViewController {
         toItem: sectionTitleLabel,
         attribute: .trailing,
         multiplier: 1.0,
-        constant: self.padding).isActive = true
+        constant: self.padding
+      ).isActive = true
     }
     if #available(iOS 11.0, *) {
       // Align to the safe area insets.
       sectionTitleLabel.leadingAnchor
-        .constraint(equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
-                    constant: padding).isActive = true
+        .constraint(
+          equalTo: sectionView.safeAreaLayoutGuide.leadingAnchor,
+          constant: padding
+        ).isActive = true
       sectionTitleLabel.trailingAnchor
-        .constraint(equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
-                    constant: -padding).isActive = true
+        .constraint(
+          equalTo: sectionView.safeAreaLayoutGuide.trailingAnchor,
+          constant: -padding
+        ).isActive = true
     } else {
       preiOS11Behavior()
     }
@@ -455,7 +493,8 @@ extension MDCNodeListViewController {
       toItem: sectionView,
       attribute: .top,
       multiplier: 1.0,
-      constant: titleMaxY).isActive = true
+      constant: titleMaxY
+    ).isActive = true
 
     // descriptionLabel to sectionTitleLabel
     NSLayoutConstraint(
@@ -465,7 +504,8 @@ extension MDCNodeListViewController {
       toItem: descriptionLabel,
       attribute: .leading,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: sectionTitleLabel,
       attribute: .trailing,
@@ -473,7 +513,8 @@ extension MDCNodeListViewController {
       toItem: descriptionLabel,
       attribute: .trailing,
       multiplier: 1.0,
-      constant: 0).isActive = true
+      constant: 0
+    ).isActive = true
     NSLayoutConstraint(
       item: sectionTitleLabel,
       attribute: .lastBaseline,
@@ -481,7 +522,8 @@ extension MDCNodeListViewController {
       toItem: descriptionLabel,
       attribute: .firstBaseline,
       multiplier: 1.0,
-      constant: -titleDescriptionMargin).isActive = true
+      constant: -titleDescriptionMargin
+    ).isActive = true
 
     // descriptionLabel to SectionView
     NSLayoutConstraint(
@@ -491,11 +533,11 @@ extension MDCNodeListViewController {
       toItem: descriptionLabel,
       attribute: .bottom,
       multiplier: 1.0,
-      constant: 10).isActive = true
+      constant: 10
+    ).isActive = true
 
     return sectionView
   }
-
 
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     if section == Section.description.rawValue {
@@ -504,9 +546,11 @@ extension MDCNodeListViewController {
     return node.children.count - 1
   }
 
-  override func tableView(_ tableView: UITableView,
-                          cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    var cell : UITableViewCell?
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath
+  ) -> UITableViewCell {
+    var cell: UITableViewCell?
     if indexPath.section == Section.description.rawValue {
       cell = tableView.dequeueReusableCell(withIdentifier: "NodeViewTableViewPrimaryDemoCell")
       cell?.selectionStyle = .none
@@ -542,7 +586,7 @@ extension MDCNodeListViewController {
     return true
   }
 
-  @objc func primaryDemoButtonClicked () {
+  @objc func primaryDemoButtonClicked() {
     let indexPath = IndexPath(row: 0, section: Section.description.rawValue)
     self.tableView(self.tableView, didSelectRowAt: indexPath)
   }
@@ -571,17 +615,17 @@ extension MDCNodeListViewController {
     let contentVC = node.createExampleViewController()
     themeExample(vc: contentVC)
     #if !targetEnvironment(macCatalyst)
-    self.navigationController?.setMenuBarButton(for: contentVC)
+      self.navigationController?.setMenuBarButton(for: contentVC)
     #endif
     return contentVC
   }
 
   func themeExample(vc: UIViewController) {
-    let colorSel = NSSelectorFromString("setColorScheme:");
+    let colorSel = NSSelectorFromString("setColorScheme:")
     if vc.responds(to: colorSel) {
       vc.perform(colorSel, with: AppTheme.containerScheme.colorScheme)
     }
-    let typoSel = NSSelectorFromString("setTypographyScheme:");
+    let typoSel = NSSelectorFromString("setTypographyScheme:")
     if vc.responds(to: typoSel) {
       vc.perform(typoSel, with: AppTheme.containerScheme.typographyScheme)
     }

--- a/catalog/MDCCatalog/MDCNodeListViewController.swift
+++ b/catalog/MDCCatalog/MDCNodeListViewController.swift
@@ -570,7 +570,9 @@ extension MDCNodeListViewController {
   func createViewController(from node: CBCNode) -> UIViewController {
     let contentVC = node.createExampleViewController()
     themeExample(vc: contentVC)
+    #if !targetEnvironment(macCatalyst)
     self.navigationController?.setMenuBarButton(for: contentVC)
+    #endif
     return contentVC
   }
 

--- a/components/ActionSheet/examples/ActionSheetComparisonExample.m
+++ b/components/ActionSheet/examples/ActionSheetComparisonExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "MaterialActionSheet+Theming.h"
 #import "MaterialActionSheet.h"
 #import "MaterialButtons+Theming.h"
@@ -146,3 +148,5 @@
 }
 
 @end
+
+#endif

--- a/components/ActionSheet/examples/ActionSheetTypalUseSwiftExample.swift
+++ b/components/ActionSheet/examples/ActionSheetTypalUseSwiftExample.swift
@@ -14,6 +14,8 @@
 
 import UIKit
 
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialContainerScheme
@@ -107,7 +109,6 @@ extension ActionSheetTypicalUseSwiftExampleViewController {
       "presentable": false,
     ]
   }
-
 }
 
 extension ActionSheetTypicalUseSwiftExampleViewController : UITableViewDelegate {
@@ -232,5 +233,6 @@ extension ActionSheetTypicalUseSwiftExampleViewController {
     }
     return actionSheet
   }
-
 }
+
+#endif

--- a/components/ActionSheet/examples/ActionSheetTypalUseSwiftExample.swift
+++ b/components/ActionSheet/examples/ActionSheetTypalUseSwiftExample.swift
@@ -16,223 +16,242 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialContainerScheme
-import MaterialComponents.MaterialTypographyScheme
+  import MaterialComponents.MaterialAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialContainerScheme
+  import MaterialComponents.MaterialTypographyScheme
 
-import MaterialComponents.MaterialActionSheet
-import MaterialComponents.MaterialActionSheet_Theming
+  import MaterialComponents.MaterialActionSheet
+  import MaterialComponents.MaterialActionSheet_Theming
 
-class ActionSheetTypicalUseSwiftExampleViewController: UIViewController {
+  class ActionSheetTypicalUseSwiftExampleViewController: UIViewController {
 
-  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
-  
-  let tableView = UITableView()
-  enum ActionSheetExampleType {
-    case typical, title, message, noIcons, titleAndMessage, dynamicType, delayed, thirtyOptions
-  }
-  typealias ExamplesTuple = (label: String, type: ActionSheetExampleType)
-  let data: [ExamplesTuple] = [
-    ("Typical Use", .typical),
-    ("Title only", .title),
-    ("Message only", .message),
-    ("No Icons", .noIcons),
-    ("With Title and Message", .titleAndMessage),
-    ("Dynamic Type Enabled", .dynamicType),
-    ("Delayed", .delayed),
-    ("Thirty Options", .thirtyOptions)
-  ]
-  let cellIdentifier = "BaseCell"
+    @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    view.backgroundColor = containerScheme.colorScheme.backgroundColor
-    if let appBarContainer = parent as? MDCAppBarContainerViewController {
-      appBarContainer.appBarViewController.headerView.trackingScrollView = tableView
+    let tableView = UITableView()
+    enum ActionSheetExampleType {
+      case typical, title, message, noIcons, titleAndMessage, dynamicType, delayed, thirtyOptions
     }
-    tableView.delegate = self
-    tableView.dataSource = self
-    tableView.frame = view.bounds
-    tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    tableView.rowHeight = UITableView.automaticDimension
-    tableView.estimatedRowHeight = 56
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
-    view.addSubview(tableView)
-  }
-
-  func showActionSheet(_ type: ActionSheetExampleType) {
-    let actionSheet: MDCActionSheetController
-    switch type {
-    case .typical:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.typical()
-    case .title:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.title()
-    case .message:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.message()
-    case .noIcons:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.noIcons()
-    case .titleAndMessage:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.titleAndMessage()
-    case .dynamicType:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.dynamic()
-    case .delayed:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.titleAndMessage()
-      let action = MDCActionSheetAction(title: "Home", image: UIImage(named: "ic_home")) { _ in
-        print("Second home action")
-      }
-      DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-        actionSheet.title = "New title"
-        actionSheet.message = "New Message"
-        actionSheet.addAction(action)
-        actionSheet.addAction(action)
-        actionSheet.addAction(action)
-        actionSheet.backgroundColor = .green
-        actionSheet.contentEdgeInsets = UIEdgeInsets(top: -10, left: 0, bottom: -10, right: 0)
-      }
-    case .thirtyOptions:
-      actionSheet = ActionSheetTypicalUseSwiftExampleViewController.thirtyOptions()
-    }
-    actionSheet.applyTheme(withScheme: containerScheme)
-    present(actionSheet, animated: true, completion: nil)
-  }
-}
-
-// MARK: Catalog by Convensions
-extension ActionSheetTypicalUseSwiftExampleViewController {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Action Sheet", "Action Sheet (Swift)"],
-      "primaryDemo": false,
-      "presentable": false,
+    typealias ExamplesTuple = (label: String, type: ActionSheetExampleType)
+    let data: [ExamplesTuple] = [
+      ("Typical Use", .typical),
+      ("Title only", .title),
+      ("Message only", .message),
+      ("No Icons", .noIcons),
+      ("With Title and Message", .titleAndMessage),
+      ("Dynamic Type Enabled", .dynamicType),
+      ("Delayed", .delayed),
+      ("Thirty Options", .thirtyOptions),
     ]
-  }
-}
+    let cellIdentifier = "BaseCell"
 
-extension ActionSheetTypicalUseSwiftExampleViewController : UITableViewDelegate {
-  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    showActionSheet(data[indexPath.row].type)
-  }
-}
+    override func viewDidLoad() {
+      super.viewDidLoad()
 
-extension ActionSheetTypicalUseSwiftExampleViewController : UITableViewDataSource {
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-    cell.textLabel?.text = data[indexPath.row].label
-    return cell
-  }
-
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return data.count
-  }
-}
-
-extension ActionSheetTypicalUseSwiftExampleViewController {
-  static var actionOne: MDCActionSheetAction {
-    let image = UIImage(named: "ic_home") ?? UIImage()
-    return MDCActionSheetAction(title: "Home",
-                                image: image) { (_) in
-                                  print("Home action") }
-  }
-
-  static var actionTwo: MDCActionSheetAction {
-    let image = UIImage(named: "ic_favorite") ?? UIImage()
-    return MDCActionSheetAction(title: "Favorite",
-                                image: image) { (_) in
-                                  print("Favorite action") }
-  }
-
-  static var actionThree: MDCActionSheetAction {
-    let image = UIImage(named: "ic_email") ?? UIImage()
-    return MDCActionSheetAction(title: "Email",
-                                image: image) { (_) in
-                                  print("Email action") }
-  }
-
-  static var messageString: String {
-    return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ultricies diam " +
-      "libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risusnmaximus tempus. " +
-      "Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, quis eleifend nisi " +
-    "eros dictum mi. In finibus vulputate eros, in luctus diam auctor in."
-  }
-
-  static func typical() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController()
-    actionSheet.addAction(actionOne)
-    actionSheet.addAction(actionTwo)
-    actionSheet.addAction(actionThree)
-    return actionSheet
-  }
-
-  static func title() -> MDCActionSheetController {
-    let actionSheet: MDCActionSheetController = MDCActionSheetController(title: "Action Sheet")
-    actionSheet.addAction(actionOne)
-    actionSheet.addAction(actionTwo)
-    actionSheet.addAction(actionThree)
-    return actionSheet
-  }
-
-  static func message() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController(title: nil,
-                                               message: messageString)
-    actionSheet.addAction(actionOne)
-    actionSheet.addAction(actionTwo)
-    actionSheet.addAction(actionThree)
-    return actionSheet
-  }
-
-  static func titleAndMessage() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController(title: "Action Sheet",
-                                               message: messageString)
-    actionSheet.addAction(actionOne)
-    actionSheet.addAction(actionTwo)
-    actionSheet.addAction(actionThree)
-    return actionSheet
-  }
-
-  static func noIcons() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController(title: "Action Sheet", message: messageString)
-    let action1 = MDCActionSheetAction(title: "Home", image: nil, handler: { _ in
-      print("Home action")
-    })
-    let action2 = MDCActionSheetAction(title: "Favorite", image: nil, handler: { _ in
-      print("Favorite action")
-    })
-    let action3 = MDCActionSheetAction(title: "Email", image: nil, handler: { _ in
-      print("Email action")
-    })
-    actionSheet.addAction(action1)
-    actionSheet.addAction(action2)
-    actionSheet.addAction(action3)
-    return actionSheet
-  }
-
-  static func dynamic() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController(title: "Action sheet", message: messageString)
-    actionSheet.mdc_adjustsFontForContentSizeCategory = true
-    let image = UIImage(named: "ic_email") ?? UIImage()
-    let actionThree = MDCActionSheetAction(title: "Email",
-                                           image: image,
-                                           handler: nil)
-    actionSheet.addAction(actionOne)
-    actionSheet.addAction(actionTwo)
-    actionSheet.addAction(actionThree)
-    return actionSheet
-  }
-
-  static func thirtyOptions() -> MDCActionSheetController {
-    let actionSheet = MDCActionSheetController(title: "Action sheet", message: messageString)
-
-    for i in 1...30 {
-      let action = MDCActionSheetAction(title: "Action \(i)",
-                                        image: UIImage(named: "ic_home"),
-                                        handler: nil)
-      actionSheet.addAction(action)
+      view.backgroundColor = containerScheme.colorScheme.backgroundColor
+      if let appBarContainer = parent as? MDCAppBarContainerViewController {
+        appBarContainer.appBarViewController.headerView.trackingScrollView = tableView
+      }
+      tableView.delegate = self
+      tableView.dataSource = self
+      tableView.frame = view.bounds
+      tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      tableView.rowHeight = UITableView.automaticDimension
+      tableView.estimatedRowHeight = 56
+      tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+      view.addSubview(tableView)
     }
-    return actionSheet
+
+    func showActionSheet(_ type: ActionSheetExampleType) {
+      let actionSheet: MDCActionSheetController
+      switch type {
+      case .typical:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.typical()
+      case .title:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.title()
+      case .message:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.message()
+      case .noIcons:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.noIcons()
+      case .titleAndMessage:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.titleAndMessage()
+      case .dynamicType:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.dynamic()
+      case .delayed:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.titleAndMessage()
+        let action = MDCActionSheetAction(title: "Home", image: UIImage(named: "ic_home")) { _ in
+          print("Second home action")
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+          actionSheet.title = "New title"
+          actionSheet.message = "New Message"
+          actionSheet.addAction(action)
+          actionSheet.addAction(action)
+          actionSheet.addAction(action)
+          actionSheet.backgroundColor = .green
+          actionSheet.contentEdgeInsets = UIEdgeInsets(top: -10, left: 0, bottom: -10, right: 0)
+        }
+      case .thirtyOptions:
+        actionSheet = ActionSheetTypicalUseSwiftExampleViewController.thirtyOptions()
+      }
+      actionSheet.applyTheme(withScheme: containerScheme)
+      present(actionSheet, animated: true, completion: nil)
+    }
   }
-}
+
+  // MARK: Catalog by Convensions
+  extension ActionSheetTypicalUseSwiftExampleViewController {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Action Sheet", "Action Sheet (Swift)"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
+  }
+
+  extension ActionSheetTypicalUseSwiftExampleViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      showActionSheet(data[indexPath.row].type)
+    }
+  }
+
+  extension ActionSheetTypicalUseSwiftExampleViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+      let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+      cell.textLabel?.text = data[indexPath.row].label
+      return cell
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      return data.count
+    }
+  }
+
+  extension ActionSheetTypicalUseSwiftExampleViewController {
+    static var actionOne: MDCActionSheetAction {
+      let image = UIImage(named: "ic_home") ?? UIImage()
+      return MDCActionSheetAction(
+        title: "Home",
+        image: image
+      ) { (_) in
+        print("Home action")
+      }
+    }
+
+    static var actionTwo: MDCActionSheetAction {
+      let image = UIImage(named: "ic_favorite") ?? UIImage()
+      return MDCActionSheetAction(
+        title: "Favorite",
+        image: image
+      ) { (_) in
+        print("Favorite action")
+      }
+    }
+
+    static var actionThree: MDCActionSheetAction {
+      let image = UIImage(named: "ic_email") ?? UIImage()
+      return MDCActionSheetAction(
+        title: "Email",
+        image: image
+      ) { (_) in
+        print("Email action")
+      }
+    }
+
+    static var messageString: String {
+      return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ultricies diam "
+        + "libero, eget porta arcu feugiat sit amet. Maecenas placerat felis sed risusnmaximus tempus. "
+        + "Integer feugiat, augue in pellentesque dictum, justo erat ultricies leo, quis eleifend nisi "
+        + "eros dictum mi. In finibus vulputate eros, in luctus diam auctor in."
+    }
+
+    static func typical() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController()
+      actionSheet.addAction(actionOne)
+      actionSheet.addAction(actionTwo)
+      actionSheet.addAction(actionThree)
+      return actionSheet
+    }
+
+    static func title() -> MDCActionSheetController {
+      let actionSheet: MDCActionSheetController = MDCActionSheetController(title: "Action Sheet")
+      actionSheet.addAction(actionOne)
+      actionSheet.addAction(actionTwo)
+      actionSheet.addAction(actionThree)
+      return actionSheet
+    }
+
+    static func message() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController(
+        title: nil,
+        message: messageString)
+      actionSheet.addAction(actionOne)
+      actionSheet.addAction(actionTwo)
+      actionSheet.addAction(actionThree)
+      return actionSheet
+    }
+
+    static func titleAndMessage() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController(
+        title: "Action Sheet",
+        message: messageString)
+      actionSheet.addAction(actionOne)
+      actionSheet.addAction(actionTwo)
+      actionSheet.addAction(actionThree)
+      return actionSheet
+    }
+
+    static func noIcons() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController(title: "Action Sheet", message: messageString)
+      let action1 = MDCActionSheetAction(
+        title: "Home", image: nil,
+        handler: { _ in
+          print("Home action")
+        })
+      let action2 = MDCActionSheetAction(
+        title: "Favorite", image: nil,
+        handler: { _ in
+          print("Favorite action")
+        })
+      let action3 = MDCActionSheetAction(
+        title: "Email", image: nil,
+        handler: { _ in
+          print("Email action")
+        })
+      actionSheet.addAction(action1)
+      actionSheet.addAction(action2)
+      actionSheet.addAction(action3)
+      return actionSheet
+    }
+
+    static func dynamic() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController(title: "Action sheet", message: messageString)
+      actionSheet.mdc_adjustsFontForContentSizeCategory = true
+      let image = UIImage(named: "ic_email") ?? UIImage()
+      let actionThree = MDCActionSheetAction(
+        title: "Email",
+        image: image,
+        handler: nil)
+      actionSheet.addAction(actionOne)
+      actionSheet.addAction(actionTwo)
+      actionSheet.addAction(actionThree)
+      return actionSheet
+    }
+
+    static func thirtyOptions() -> MDCActionSheetController {
+      let actionSheet = MDCActionSheetController(title: "Action sheet", message: messageString)
+
+      for i in 1...30 {
+        let action = MDCActionSheetAction(
+          title: "Action \(i)",
+          image: UIImage(named: "ic_home"),
+          handler: nil)
+        actionSheet.addAction(action)
+      }
+      return actionSheet
+    }
+  }
 
 #endif

--- a/components/ActionSheet/examples/ActionSheetTypicalUseExample.m
+++ b/components/ActionSheet/examples/ActionSheetTypicalUseExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "MaterialActionSheet+Theming.h"
 #import "MaterialActionSheet.h"
 #import "MaterialButtons+Theming.h"
@@ -151,3 +153,5 @@
 }
 
 @end
+
+#endif

--- a/components/ActionSheet/src/MDCActionSheetAction.h
+++ b/components/ActionSheet/src/MDCActionSheetAction.h
@@ -26,6 +26,7 @@ typedef void (^MDCActionSheetHandler)(MDCActionSheetAction *_Nonnull action);
  An instance of MDCActionSheetAction is passed to MDCActionSheetController to
  add an action to the action sheet.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCActionSheetAction : NSObject <NSCopying, UIAccessibilityIdentification>
 
 /**

--- a/components/ActionSheet/src/MDCActionSheetController.h
+++ b/components/ActionSheet/src/MDCActionSheetController.h
@@ -42,6 +42,7 @@
  in a sheet from the bottom.
 
  */
+API_UNAVAILABLE(macCatalyst)
 __attribute__((objc_subclassing_restricted)) @interface MDCActionSheetController
     : UIViewController<MDCElevatable, MDCElevationOverriding>
 

--- a/components/ActionSheet/src/MDCActionSheetControllerDelegate.h
+++ b/components/ActionSheet/src/MDCActionSheetControllerDelegate.h
@@ -20,6 +20,7 @@
  Defines methods that allows the adopting delegate to respond to messages from an
  @c MDCActionSheetController.
  */
+API_UNAVAILABLE(macCatalyst)
 @protocol MDCActionSheetControllerDelegate <NSObject>
 @optional
 

--- a/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
+++ b/components/ActionSheet/src/private/MDCActionSheetItemTableViewCell.h
@@ -17,6 +17,7 @@
 #import "MDCActionSheetController.h"
 #import "MaterialInk.h"
 
+API_UNAVAILABLE(macCatalyst)
 @interface MDCActionSheetItemTableViewCell : UITableViewCell
 /**
   The action contains the title, image, and handler

--- a/components/BottomSheet/examples/BottomSheetAutolayoutExample.m
+++ b/components/BottomSheet/examples/BottomSheetAutolayoutExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyStaticViewController.h"
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
@@ -49,3 +51,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetAutolayoutSafeAreaExample.m
+++ b/components/BottomSheet/examples/BottomSheetAutolayoutSafeAreaExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
 #import "MaterialApplication.h"
@@ -166,3 +168,5 @@ static const CGFloat kSafeContentWidth = 300;
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
+++ b/components/BottomSheet/examples/BottomSheetDismissOnDraggingDownExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyCollectionViewController.h"
 #import "MaterialAppBar+ColorThemer.h"
 #import "MaterialAppBar.h"
@@ -111,3 +113,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_Theming
@@ -96,3 +99,5 @@ extension BottomSheetFirstResponderExample {
     ]
   }
 }
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
+++ b/components/BottomSheet/examples/BottomSheetFirstResponderExample.swift
@@ -16,88 +16,89 @@ import Foundation
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomSheet
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_Theming
-import MaterialComponents.MaterialContainerScheme
-import MaterialComponents.MaterialTextFields
+  import MaterialComponents.MaterialBottomSheet
+  import MaterialComponents.MaterialButtons
+  import MaterialComponents.MaterialButtons_Theming
+  import MaterialComponents.MaterialContainerScheme
+  import MaterialComponents.MaterialTextFields
 
-class BottomSheetFirstResponderExample: UIViewController {
-  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+  class BottomSheetFirstResponderExample: UIViewController {
+    @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
 
-  let contentStackView: UIStackView = {
-    let stackView = UIStackView()
-    stackView.axis = .vertical
-    stackView.spacing = 8
-    return stackView
-  }()
+    let contentStackView: UIStackView = {
+      let stackView = UIStackView()
+      stackView.axis = .vertical
+      stackView.spacing = 8
+      return stackView
+    }()
 
-  let issueDescriptionLabel: UILabel = {
-    let label = UILabel()
-    label.numberOfLines = 0
-    label.text = """
-    With VoiceOver on, the focused text field steals focus back from the bottom sheet
-    if resignFirstResponder is not called.
-    """
-    label.textColor = .black
-    return label
-  }()
+    let issueDescriptionLabel: UILabel = {
+      let label = UILabel()
+      label.numberOfLines = 0
+      label.text = """
+        With VoiceOver on, the focused text field steals focus back from the bottom sheet
+        if resignFirstResponder is not called.
+        """
+      label.textColor = .black
+      return label
+    }()
 
-  let textField: MDCMultilineTextField = {
-    let textField = MDCMultilineTextField()
-    textField.backgroundColor = UIColor.blue.withAlphaComponent(0.3)
-    return textField
-  }()
+    let textField: MDCMultilineTextField = {
+      let textField = MDCMultilineTextField()
+      textField.backgroundColor = UIColor.blue.withAlphaComponent(0.3)
+      return textField
+    }()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    override func viewDidLoad() {
+      super.viewDidLoad()
 
-    view.backgroundColor = containerScheme.colorScheme.backgroundColor
+      view.backgroundColor = containerScheme.colorScheme.backgroundColor
 
-    let button = MDCButton()
-    button.setTitle("Show bottom sheet", for: .normal)
-    button.addTarget(self,
-                     action: #selector(BottomSheetFirstResponderExample.didTapButton),
-                     for: .touchUpInside)
+      let button = MDCButton()
+      button.setTitle("Show bottom sheet", for: .normal)
+      button.addTarget(
+        self,
+        action: #selector(BottomSheetFirstResponderExample.didTapButton),
+        for: .touchUpInside)
 
-    button.applyContainedTheme(withScheme: containerScheme)
-    button.sizeToFit()
+      button.applyContainedTheme(withScheme: containerScheme)
+      button.sizeToFit()
 
-    contentStackView.addArrangedSubview(issueDescriptionLabel)
-    contentStackView.addArrangedSubview(textField)
-    contentStackView.addArrangedSubview(button)
+      contentStackView.addArrangedSubview(issueDescriptionLabel)
+      contentStackView.addArrangedSubview(textField)
+      contentStackView.addArrangedSubview(button)
 
-    contentStackView.translatesAutoresizingMaskIntoConstraints = false
-    view.addSubview(contentStackView)
-    contentStackView.leadingAnchor
+      contentStackView.translatesAutoresizingMaskIntoConstraints = false
+      view.addSubview(contentStackView)
+      contentStackView.leadingAnchor
         .constraint(equalTo: view.leadingAnchor, constant: 10).isActive = true
-    contentStackView.trailingAnchor
+      contentStackView.trailingAnchor
         .constraint(equalTo: view.trailingAnchor, constant: -10).isActive = true
-    contentStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+      contentStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+      super.viewDidAppear(animated)
+      textField.becomeFirstResponder()
+    }
+
+    @objc func didTapButton() {
+      let menu = BottomSheetUIControl()
+      let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+      textField.resignFirstResponder()
+      present(bottomSheet, animated: true)
+    }
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    textField.becomeFirstResponder()
+  // MARK: Catalog by Convention
+  extension BottomSheetFirstResponderExample {
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Bottom Sheet", "Over Focused Text Field (Swift)"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-
-  @objc func didTapButton() {
-    let menu = BottomSheetUIControl()
-    let bottomSheet = MDCBottomSheetController(contentViewController: menu)
-    textField.resignFirstResponder()
-    present(bottomSheet, animated: true)
-  }
-}
-
-// MARK: Catalog by Convention
-extension BottomSheetFirstResponderExample {
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Bottom Sheet", "Over Focused Text Field (Swift)"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-}
 
 #endif

--- a/components/BottomSheet/examples/BottomSheetLongTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetLongTableViewExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons_ButtonThemer 
 import MaterialComponents.MaterialButtons
@@ -132,3 +135,5 @@ extension BottomSheetLongTableViewExample {
     ]
   }
 }
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetLongTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetLongTableViewExample.swift
@@ -16,124 +16,124 @@ import Foundation
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomSheet
-import MaterialComponents.MaterialButtons_ButtonThemer 
-import MaterialComponents.MaterialButtons
+  import MaterialComponents.MaterialBottomSheet
+  import MaterialComponents.MaterialButtons_ButtonThemer
+  import MaterialComponents.MaterialButtons
 
-/// In this example we present a tableview with a height that is longer than the
-/// BottomSheetTableViewExample. For a more comprehensive example see BottomSheetTypicalUseExample.m.
-class BottomSheetLongTableViewExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  @objc var typographyScheme = MDCTypographyScheme()
+  /// In this example we present a tableview with a height that is longer than the
+  /// BottomSheetTableViewExample. For a more comprehensive example see BottomSheetTypicalUseExample.m.
+  class BottomSheetLongTableViewExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    @objc var typographyScheme = MDCTypographyScheme()
 
-  init() {
-    super.init(nibName: nil, bundle: nil)
+    init() {
+      super.init(nibName: nil, bundle: nil)
 
-    self.title = "Table View Menu"
+      self.title = "Table View Menu"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+
+      view.backgroundColor = colorScheme.backgroundColor
+
+      let button = MDCButton()
+      button.setTitle("Show bottom sheet", for: .normal)
+      button.addTarget(
+        self,
+        action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
+        for: .touchUpInside)
+
+      let buttonScheme = MDCButtonScheme()
+      buttonScheme.colorScheme = colorScheme
+      buttonScheme.typographyScheme = typographyScheme
+      MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+
+      button.sizeToFit()
+      button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
+      button.autoresizingMask = [
+        .flexibleLeftMargin,
+        .flexibleTopMargin,
+        .flexibleRightMargin,
+        .flexibleBottomMargin,
+      ]
+
+      view.addSubview(button)
+    }
+
+    @objc func didTapFloatingButton(_ sender: MDCFloatingButton) {
+      let menu = BottomSheetTableViewMenu(style: .plain)
+      let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+      bottomSheet.isScrimAccessibilityElement = true
+      bottomSheet.scrimAccessibilityLabel = "Close"
+      bottomSheet.trackingScrollView = menu.tableView
+      present(bottomSheet, animated: true)
+    }
   }
 
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+  private class BottomSheetTableViewMenu: UITableViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    view.backgroundColor = colorScheme.backgroundColor
-
-    let button = MDCButton()
-    button.setTitle("Show bottom sheet", for: .normal)
-    button.addTarget(
-      self,
-      action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
-      for: .touchUpInside)
-
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-
-    button.sizeToFit()
-    button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
-    button.autoresizingMask = [
-      .flexibleLeftMargin,
-      .flexibleTopMargin,
-      .flexibleRightMargin,
-      .flexibleBottomMargin,
+    let tableData = [
+      "Action 1",
+      "Action 2",
+      "Action 3",
+      "Action 4",
+      "Action 5",
+      "Action 6",
+      "Action 7",
+      "Action 8",
+      "Action 9",
+      "Action 10",
+      "Action 11",
+      "Action 12",
+      "Action 13",
     ]
+    let cellIdentifier = "MenuCell"
 
-    view.addSubview(button)
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+      self.tableView.separatorStyle = .none
+    }
+
+    override func tableView(
+      _ tableView: UITableView,
+      cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+      let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+      let cellData = tableData[indexPath.item]
+      cell.textLabel?.text = cellData
+      return cell
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      return tableData.count
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+      return 1
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      tableView.deselectRow(at: indexPath, animated: true)
+      self.dismiss(animated: true, completion: nil)
+    }
   }
 
-  @objc func didTapFloatingButton(_ sender: MDCFloatingButton) {
-    let menu = BottomSheetTableViewMenu(style: .plain)
-    let bottomSheet = MDCBottomSheetController(contentViewController: menu)
-    bottomSheet.isScrimAccessibilityElement = true
-    bottomSheet.scrimAccessibilityLabel = "Close"
-    bottomSheet.trackingScrollView = menu.tableView
-    present(bottomSheet, animated: true)
+  // MARK: Catalog by convention
+  extension BottomSheetLongTableViewExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Bottom Sheet", "Long Table View Menu"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-}
-
-private class BottomSheetTableViewMenu: UITableViewController {
-
-  let tableData = [
-    "Action 1",
-    "Action 2",
-    "Action 3",
-    "Action 4",
-    "Action 5",
-    "Action 6",
-    "Action 7",
-    "Action 8",
-    "Action 9",
-    "Action 10",
-    "Action 11",
-    "Action 12",
-    "Action 13",
-  ]
-  let cellIdentifier = "MenuCell"
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
-    self.tableView.separatorStyle = .none
-  }
-
-  override func tableView(
-    _ tableView: UITableView,
-    cellForRowAt indexPath: IndexPath
-  ) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-    let cellData = tableData[indexPath.item]
-    cell.textLabel?.text = cellData
-    return cell
-  }
-
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableData.count
-  }
-
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    self.dismiss(animated: true, completion: nil)
-  }
-}
-
-// MARK: Catalog by convention
-extension BottomSheetLongTableViewExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Bottom Sheet", "Long Table View Menu"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-}
 
 #endif

--- a/components/BottomSheet/examples/BottomSheetModalPresentationExample.m
+++ b/components/BottomSheet/examples/BottomSheetModalPresentationExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyStaticViewController.h"
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
@@ -107,3 +109,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetPresentationControllerDelegateExample.m
+++ b/components/BottomSheet/examples/BottomSheetPresentationControllerDelegateExample.m
@@ -1,3 +1,19 @@
+// Copyright 2020-present the Material Components for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if !TARGET_OS_MACCATALYST
+
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
 
@@ -161,3 +177,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetShapedExample.m
+++ b/components/BottomSheet/examples/BottomSheetShapedExample.m
@@ -24,6 +24,8 @@
 #import "MaterialShapeLibrary.h"
 #import "MaterialShapes.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @interface BottomSheetShapedExample : BottomSheetPresenterViewController
 @end
 
@@ -69,3 +71,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetShortCollectionExample.m
+++ b/components/BottomSheet/examples/BottomSheetShortCollectionExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyCollectionViewController.h"
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
@@ -47,3 +49,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetSimpleExample.m
+++ b/components/BottomSheet/examples/BottomSheetSimpleExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyStaticViewController.h"
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
@@ -47,3 +49,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons_ButtonThemer 
 import MaterialComponents.MaterialButtons
@@ -122,3 +125,5 @@ extension BottomSheetTableViewExample {
     ]
   }
 }
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetTableViewExample.swift
+++ b/components/BottomSheet/examples/BottomSheetTableViewExample.swift
@@ -16,114 +16,114 @@ import Foundation
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomSheet
-import MaterialComponents.MaterialButtons_ButtonThemer 
-import MaterialComponents.MaterialButtons
+  import MaterialComponents.MaterialBottomSheet
+  import MaterialComponents.MaterialButtons_ButtonThemer
+  import MaterialComponents.MaterialButtons
 
-/// In this example we present a custom tableview. For a more comprehensive example see
-/// BottomSheetTypicalUseExample.m.
-class BottomSheetTableViewExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  @objc var typographyScheme = MDCTypographyScheme()
+  /// In this example we present a custom tableview. For a more comprehensive example see
+  /// BottomSheetTypicalUseExample.m.
+  class BottomSheetTableViewExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    @objc var typographyScheme = MDCTypographyScheme()
 
-  init() {
-    super.init(nibName: nil, bundle: nil)
+    init() {
+      super.init(nibName: nil, bundle: nil)
 
-    self.title = "Table View Menu"
+      self.title = "Table View Menu"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+
+      view.backgroundColor = colorScheme.backgroundColor
+
+      let button = MDCButton()
+      button.setTitle("Show bottom sheet", for: .normal)
+      button.addTarget(
+        self,
+        action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
+        for: .touchUpInside)
+
+      let buttonScheme = MDCButtonScheme()
+      buttonScheme.colorScheme = colorScheme
+      buttonScheme.typographyScheme = typographyScheme
+      MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
+
+      button.sizeToFit()
+      button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
+      button.autoresizingMask = [
+        .flexibleLeftMargin,
+        .flexibleTopMargin,
+        .flexibleRightMargin,
+        .flexibleBottomMargin,
+      ]
+
+      view.addSubview(button)
+    }
+
+    @objc func didTapFloatingButton(_ sender: MDCFloatingButton) {
+      let menu = BottomSheetTableViewMenu(style: .plain)
+      let bottomSheet = MDCBottomSheetController(contentViewController: menu)
+      bottomSheet.isScrimAccessibilityElement = true
+      bottomSheet.scrimAccessibilityLabel = "Close"
+      bottomSheet.trackingScrollView = menu.tableView
+      present(bottomSheet, animated: true)
+    }
   }
 
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+  private class BottomSheetTableViewMenu: UITableViewController {
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    view.backgroundColor = colorScheme.backgroundColor
-
-    let button = MDCButton()
-    button.setTitle("Show bottom sheet", for: .normal)
-    button.addTarget(
-      self,
-      action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
-      for: .touchUpInside)
-
-    let buttonScheme = MDCButtonScheme()
-    buttonScheme.colorScheme = colorScheme
-    buttonScheme.typographyScheme = typographyScheme
-    MDCContainedButtonThemer.applyScheme(buttonScheme, to: button)
-
-    button.sizeToFit()
-    button.center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
-    button.autoresizingMask = [
-      .flexibleLeftMargin,
-      .flexibleTopMargin,
-      .flexibleRightMargin,
-      .flexibleBottomMargin,
+    let tableData = [
+      "Action 1",
+      "Action 2",
+      "Action 3",
     ]
+    let cellIdentifier = "MenuCell"
 
-    view.addSubview(button)
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+      self.tableView.separatorStyle = .none
+    }
+
+    override func tableView(
+      _ tableView: UITableView,
+      cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+      let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+      let cellData = tableData[indexPath.item]
+      cell.textLabel?.text = cellData
+      return cell
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      return tableData.count
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+      return 1
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      tableView.deselectRow(at: indexPath, animated: true)
+      self.dismiss(animated: true, completion: nil)
+    }
   }
 
-  @objc func didTapFloatingButton(_ sender: MDCFloatingButton) {
-    let menu = BottomSheetTableViewMenu(style: .plain)
-    let bottomSheet = MDCBottomSheetController(contentViewController: menu)
-    bottomSheet.isScrimAccessibilityElement = true
-    bottomSheet.scrimAccessibilityLabel = "Close"
-    bottomSheet.trackingScrollView = menu.tableView
-    present(bottomSheet, animated: true)
+  // MARK: Catalog by convention
+  extension BottomSheetTableViewExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Bottom Sheet", "Table View Menu"],
+        "primaryDemo": false,
+        "presentable": true,
+      ]
+    }
   }
-}
-
-private class BottomSheetTableViewMenu: UITableViewController {
-
-  let tableData = [
-    "Action 1",
-    "Action 2",
-    "Action 3",
-  ]
-  let cellIdentifier = "MenuCell"
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
-    self.tableView.separatorStyle = .none
-  }
-
-  override func tableView(
-    _ tableView: UITableView,
-    cellForRowAt indexPath: IndexPath
-  ) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-    let cellData = tableData[indexPath.item]
-    cell.textLabel?.text = cellData
-    return cell
-  }
-
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return tableData.count
-  }
-
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    self.dismiss(animated: true, completion: nil)
-  }
-}
-
-// MARK: Catalog by convention
-extension BottomSheetTableViewExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Bottom Sheet", "Table View Menu"],
-      "primaryDemo": false,
-      "presentable": true,
-    ]
-  }
-}
 
 #endif

--- a/components/BottomSheet/examples/BottomSheetTallExample.m
+++ b/components/BottomSheet/examples/BottomSheetTallExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyStaticViewController.h"
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
@@ -48,3 +50,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
+++ b/components/BottomSheet/examples/BottomSheetTypicalUseExample.m
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "supplemental/BottomSheetDummyCollectionViewController.h"
 #import "MaterialAppBar+ColorThemer.h"
 #import "MaterialAppBar.h"
@@ -105,3 +107,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetUIControlExample.swift
+++ b/components/BottomSheet/examples/BottomSheetUIControlExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomSheet
 import MaterialComponents.MaterialButtons
 import MaterialComponents.MaterialButtons_ButtonThemer
@@ -100,3 +103,5 @@ extension BottomSheetUIControlExample {
     ]
   }
 }
+
+#endif

--- a/components/BottomSheet/examples/BottomSheetUIControlExample.swift
+++ b/components/BottomSheet/examples/BottomSheetUIControlExample.swift
@@ -16,11 +16,11 @@ import Foundation
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomSheet
-import MaterialComponents.MaterialButtons
-import MaterialComponents.MaterialButtons_ButtonThemer
+  import MaterialComponents.MaterialBottomSheet
+  import MaterialComponents.MaterialButtons
+  import MaterialComponents.MaterialButtons_ButtonThemer
 
-class BottomSheetUIControlExample: UIViewController {
+  class BottomSheetUIControlExample: UIViewController {
 
     @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
     @objc var typographyScheme = MDCTypographyScheme()
@@ -42,9 +42,10 @@ class BottomSheetUIControlExample: UIViewController {
 
       let button = MDCButton()
       button.setTitle("Show bottom sheet", for: .normal)
-      button.addTarget(self,
-                       action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
-                       for: .touchUpInside)
+      button.addTarget(
+        self,
+        action: #selector(BottomSheetTableViewExample.didTapFloatingButton),
+        for: .touchUpInside)
 
       let buttonScheme = MDCButtonScheme()
       buttonScheme.colorScheme = colorScheme
@@ -57,51 +58,49 @@ class BottomSheetUIControlExample: UIViewController {
         .flexibleLeftMargin,
         .flexibleTopMargin,
         .flexibleRightMargin,
-        .flexibleBottomMargin
+        .flexibleBottomMargin,
       ]
 
       view.addSubview(button)
     }
 
-    @objc func didTapFloatingButton(_ sender : MDCFloatingButton) {
+    @objc func didTapFloatingButton(_ sender: MDCFloatingButton) {
       let menu = BottomSheetUIControl()
       let bottomSheet = MDCBottomSheetController(contentViewController: menu)
       present(bottomSheet, animated: true)
     }
 
-}
-
-class BottomSheetUIControl: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.view.backgroundColor = .white
-
-        
-        let slideControl = UISlider()
-        slideControl.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addSubview(slideControl)
-        
-        NSLayoutConstraint.activate([
-            slideControl.widthAnchor.constraint(equalToConstant: 300),
-            slideControl.heightAnchor.constraint(equalToConstant: 20),
-            slideControl.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            slideControl.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
-        ])
-    }
-}
-
-
-// MARK: Catalog by convention
-extension BottomSheetUIControlExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Bottom Sheet", "Bottom sheet with UIControl"],
-      "primaryDemo": false,
-      "presentable": true,
-    ]
   }
-}
+
+  class BottomSheetUIControl: UIViewController {
+    override func viewDidLoad() {
+      super.viewDidLoad()
+
+      self.view.backgroundColor = .white
+
+      let slideControl = UISlider()
+      slideControl.translatesAutoresizingMaskIntoConstraints = false
+      self.view.addSubview(slideControl)
+
+      NSLayoutConstraint.activate([
+        slideControl.widthAnchor.constraint(equalToConstant: 300),
+        slideControl.heightAnchor.constraint(equalToConstant: 20),
+        slideControl.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        slideControl.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+      ])
+    }
+  }
+
+  // MARK: Catalog by convention
+  extension BottomSheetUIControlExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Bottom Sheet", "Bottom sheet with UIControl"],
+        "primaryDemo": false,
+        "presentable": true,
+      ]
+    }
+  }
 
 #endif

--- a/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
+++ b/components/BottomSheet/examples/BottomSheetWebViewPresentationExample.m
@@ -15,6 +15,8 @@
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "BottomSheetPresenterViewController.h"
 #import "MaterialBottomSheet.h"
 
@@ -75,3 +77,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetAutolayoutDummyViewController.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetAutolayoutDummyViewController.h
@@ -14,6 +14,10 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 @interface BottomSheetAutolayoutDummyViewController : UIViewController
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetAutolayoutDummyViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetAutolayoutDummyViewController.m
@@ -14,6 +14,8 @@
 
 #import "BottomSheetAutolayoutDummyViewController.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @implementation BottomSheetAutolayoutDummyViewController
 
 - (IBAction)dismissButtonPressed:(id)sender {
@@ -21,3 +23,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 @interface BottomSheetDummyCollectionViewController : UICollectionViewController
 - (instancetype)initWithNumItems:(NSInteger)numItems NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_UNAVAILABLE;
@@ -21,3 +23,5 @@
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil
                          bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyCollectionViewController.m
@@ -14,6 +14,8 @@
 
 #import "BottomSheetDummyCollectionViewController.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @interface BottomSheetDummyCollectionViewController () <UICollectionViewDataSource>
 @end
 
@@ -72,3 +74,5 @@
 
 @implementation DummyCollectionViewCell
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyStaticViewController.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyStaticViewController.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 @interface BottomSheetDummyStaticViewController : UIViewController
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
@@ -22,3 +24,5 @@
                          bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetDummyStaticViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetDummyStaticViewController.m
@@ -14,6 +14,8 @@
 
 #import "BottomSheetDummyStaticViewController.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @implementation BottomSheetDummyStaticViewController {
   // Add a view just beyond the bottom of our bounds so that bottom sheet bounce doesn't reveal the
   // background underneath.
@@ -44,3 +46,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.h
+++ b/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.h
@@ -14,6 +14,8 @@
 
 #import <UIKit/UIKit.h>
 
+#if !TARGET_OS_MACCATALYST
+
 #import "MaterialButtons.h"
 #import "MaterialColorScheme.h"
 #import "MaterialTypographyScheme.h"
@@ -27,3 +29,5 @@
 - (void)presentBottomSheet;
 
 @end
+
+#endif

--- a/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.m
+++ b/components/BottomSheet/examples/supplemental/BottomSheetPresenterViewController.m
@@ -14,6 +14,8 @@
 
 #import "BottomSheetPresenterViewController.h"
 
+#if !TARGET_OS_MACCATALYST
+
 @implementation BottomSheetPresenterViewController
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -54,3 +56,5 @@
 }
 
 @end
+
+#endif

--- a/components/BottomSheet/src/MDCBottomSheetController.h
+++ b/components/BottomSheet/src/MDCBottomSheetController.h
@@ -33,6 +33,7 @@
  MDCBottomSheetController automatically sets the appropriate presentation style and
  transitioningDelegate for the bottom sheet behavior.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomSheetController : UIViewController <MDCElevatable, MDCElevationOverriding>
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.h
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.h
@@ -25,6 +25,7 @@
 /**
  A UIPresentationController for presenting a modal view controller as a bottom sheet.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomSheetPresentationController : UIPresentationController
 
 /**

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -21,7 +21,8 @@
 #import "MDCSheetContainerViewDelegate.h"
 #import "MaterialMath.h"
 
-static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewController) API_UNAVAILABLE(macCatalyst) {
+static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewController)
+    API_UNAVAILABLE(macCatalyst) {
   UIScrollView *scrollView = nil;
 
   // Ensure the view is loaded - occasionally during non-animated transitions the view may not be

--- a/components/BottomSheet/src/MDCBottomSheetPresentationController.m
+++ b/components/BottomSheet/src/MDCBottomSheetPresentationController.m
@@ -21,7 +21,7 @@
 #import "MDCSheetContainerViewDelegate.h"
 #import "MaterialMath.h"
 
-static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewController) {
+static UIScrollView *MDCBottomSheetGetPrimaryScrollView(UIViewController *viewController) API_UNAVAILABLE(macCatalyst) {
   UIScrollView *scrollView = nil;
 
   // Ensure the view is loaded - occasionally during non-animated transitions the view may not be

--- a/components/BottomSheet/src/MDCBottomSheetTransitionController.h
+++ b/components/BottomSheet/src/MDCBottomSheetTransitionController.h
@@ -29,6 +29,7 @@
  The presenting UIViewController then calls presentViewController:animated:completion:
  [rootViewController presentViewController:myDialogViewController animated:YES completion:...];
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomSheetTransitionController
     : NSObject <UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
 

--- a/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.h
+++ b/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.h
@@ -41,7 +41,6 @@ __deprecated_msg("There is no replacement for this API yet.")
  */
 + (void)applyShapeScheme:(nonnull id<MDCShapeScheming>)shapeScheme
     toBottomSheetController:(nonnull MDCBottomSheetController *)bottomSheetController
-    API_UNAVAILABLE(macCatalyst)
-    __deprecated_msg("There is no replacement for this API yet.");
+    API_UNAVAILABLE(macCatalyst)__deprecated_msg("There is no replacement for this API yet.");
 
 @end

--- a/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.h
+++ b/components/BottomSheet/src/ShapeThemer/MDCBottomSheetControllerShapeThemer.h
@@ -41,6 +41,7 @@ __deprecated_msg("There is no replacement for this API yet.")
  */
 + (void)applyShapeScheme:(nonnull id<MDCShapeScheming>)shapeScheme
     toBottomSheetController:(nonnull MDCBottomSheetController *)bottomSheetController
+    API_UNAVAILABLE(macCatalyst)
     __deprecated_msg("There is no replacement for this API yet.");
 
 @end

--- a/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
+++ b/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
@@ -28,6 +28,7 @@
  controller.
  */
 @property(nonatomic, nullable, readonly)
-    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController;
+    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController
+    API_UNAVAILABLE(macCatalyst);
 
 @end

--- a/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
+++ b/components/BottomSheet/src/UIViewController+MaterialBottomSheet.h
@@ -28,7 +28,7 @@
  controller.
  */
 @property(nonatomic, nullable, readonly)
-    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController
-    API_UNAVAILABLE(macCatalyst);
+    MDCBottomSheetPresentationController *mdc_bottomSheetPresentationController API_UNAVAILABLE(
+        macCatalyst);
 
 @end

--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -230,11 +230,11 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 
 #if !TARGET_OS_MACCATALYST
   UIBarButtonItem *alignmentButton = [[UIBarButtonItem alloc]
-                                      initWithImage:[MDCIcons.imageFor_ic_settings
-                                                     imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
-                                      style:UIBarButtonItemStylePlain
-                                      target:self
-                                      action:@selector(didTapAlignmentButton)];
+      initWithImage:[MDCIcons.imageFor_ic_settings
+                        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+              style:UIBarButtonItemStylePlain
+             target:self
+             action:@selector(didTapAlignmentButton)];
   alignmentButton.accessibilityLabel = kPreferredLayoutMenuAccessibilityLabel;
 
   self.navigationItem.rightBarButtonItems = @[ alignmentButton, insetsButton ];

--- a/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
+++ b/components/Tabs/examples/MDCTabBarViewTypicalExampleViewController.m
@@ -221,14 +221,6 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
   [self addSegmentedControl];
   [self addButtons];
 
-  UIBarButtonItem *alignmentButton = [[UIBarButtonItem alloc]
-      initWithImage:[MDCIcons.imageFor_ic_settings
-                        imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
-              style:UIBarButtonItemStylePlain
-             target:self
-             action:@selector(didTapAlignmentButton)];
-  alignmentButton.accessibilityLabel = kPreferredLayoutMenuAccessibilityLabel;
-
   UIBarButtonItem *insetsButton =
       [[UIBarButtonItem alloc] initWithImage:self.contentInsetToggleDisabledImage
                                        style:UIBarButtonItemStylePlain
@@ -236,7 +228,19 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
                                       action:@selector(didToggleInsets:)];
   insetsButton.accessibilityLabel = kToggleContentInsetsAccessibilityLabel;
 
+#if !TARGET_OS_MACCATALYST
+  UIBarButtonItem *alignmentButton = [[UIBarButtonItem alloc]
+                                      initWithImage:[MDCIcons.imageFor_ic_settings
+                                                     imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+                                      style:UIBarButtonItemStylePlain
+                                      target:self
+                                      action:@selector(didTapAlignmentButton)];
+  alignmentButton.accessibilityLabel = kPreferredLayoutMenuAccessibilityLabel;
+
   self.navigationItem.rightBarButtonItems = @[ alignmentButton, insetsButton ];
+#else
+  self.navigationItem.rightBarButtonItems = @[ insetsButton ];
+#endif
 }
 
 - (void)applyThemingToTabBarView {
@@ -371,7 +375,7 @@ static NSString *const kPreferredLayoutMenuAccessibilityLabel = @"Change preferr
 
 #pragma mark - Item style variations
 
-- (void)didTapAlignmentButton {
+- (void)didTapAlignmentButton API_UNAVAILABLE(macCatalyst) {
   MDCTabBarViewLayoutStyle currentStyle = self.tabBar.preferredLayoutStyle;
   UIImage *checkIcon =
       [MDCIcons.imageFor_ic_check imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.h
+++ b/components/schemes/Shape/examples/MDCShapeSchemeExampleViewController.h
@@ -14,6 +14,7 @@
 
 #import <UIKit/UIKit.h>
 
+API_UNAVAILABLE(macCatalyst)
 @interface MDCShapeSchemeExampleViewController : UIViewController
 
 @end

--- a/components/schemes/Shape/examples/supplemental/MDCBottomSheetControllerShapeThemerDefaultMapping.h
+++ b/components/schemes/Shape/examples/supplemental/MDCBottomSheetControllerShapeThemerDefaultMapping.h
@@ -19,6 +19,7 @@
 /**
  The Material Design shape system's themer for instances of MDCBottomSheetController.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomSheetControllerShapeThemerDefaultMapping : MDCBottomSheetControllerShapeThemer
 
 /**


### PR DESCRIPTION
BottomSheets and ActionSheets are an iPhone-only pattern. We do not, at this time, intend to allow them to be used for Mac Catalyst apps.