### PR TITLE
[NavigationDrawer] Disable NavigationDrawer on macCatalyst builds.

### DIFF
--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -16,135 +16,143 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerExpandFullscreenExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerExpandFullscreenExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = ExpandFullscreenContentViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = ExpandFullscreenContentViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.colorScheme = colorScheme
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.colorScheme = colorScheme
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
-  }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
 
-    layoutBottomAppBar()
-  }
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
 
-  @objc private func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.contentViewController = contentViewController
-    contentViewController.drawerVC = bottomDrawerViewController
-    bottomDrawerViewController.headerViewController = headerViewController
-    bottomDrawerViewController.trackingScrollView = contentViewController.tableView
-    bottomDrawerViewController.headerViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.contentViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
-    present(bottomDrawerViewController, animated: true, completion: nil)
-  }
-}
+      layoutBottomAppBar()
+    }
 
-class ExpandFullscreenContentViewController: UITableViewController {
-  @objc var colorScheme: MDCSemanticColorScheme!
-  weak var drawerVC: MDCBottomDrawerViewController!
-
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    if self.preferredContentSize == .zero {
-      self.tableView.layoutIfNeeded()
-      self.preferredContentSize = CGSize(width: view.bounds.width,
-                                         height: tableView.contentSize.height)
+    @objc private func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.contentViewController = contentViewController
+      contentViewController.drawerVC = bottomDrawerViewController
+      bottomDrawerViewController.headerViewController = headerViewController
+      bottomDrawerViewController.trackingScrollView = contentViewController.tableView
+      bottomDrawerViewController.headerViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.contentViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+      present(bottomDrawerViewController, animated: true, completion: nil)
     }
   }
 
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    cell.textLabel?.text = "cell #\(indexPath.item)"
-    cell.backgroundColor = colorScheme.surfaceColor
-    print(cell.textLabel?.text ?? "")
-    return cell
+  class ExpandFullscreenContentViewController: UITableViewController {
+    @objc var colorScheme: MDCSemanticColorScheme!
+    weak var drawerVC: MDCBottomDrawerViewController!
+
+    init() {
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      super.init(coder: aDecoder)
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+      if self.preferredContentSize == .zero {
+        self.tableView.layoutIfNeeded()
+        self.preferredContentSize = CGSize(
+          width: view.bounds.width,
+          height: tableView.contentSize.height)
+      }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
+      -> UITableViewCell
+    {
+      let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+      cell.textLabel?.text = "cell #\(indexPath.item)"
+      cell.backgroundColor = colorScheme.surfaceColor
+      print(cell.textLabel?.text ?? "")
+      return cell
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      return 4
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+      return 1
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      tableView.deselectRow(at: indexPath, animated: true)
+      drawerVC.expandToFullscreen(
+        withDuration: 0.2,
+        completion: { _ in
+          print("finished expanding")
+        })
+    }
+
   }
 
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 4
+  extension BottomDrawerExpandFullscreenExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Expand to Fullscreen Example"],
+        "description": "Navigation Drawer",
+        "primaryDemo": true,
+        "presentable": true,
+        "skip_snapshots": true,
+      ]
+    }
   }
-
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
-
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    drawerVC.expandToFullscreen(withDuration: 0.2, completion: { _ in
-      print("finished expanding");
-    })
-  }
-
-}
-
-extension BottomDrawerExpandFullscreenExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Expand to Fullscreen Example"],
-      "description": "Navigation Drawer",
-      "primaryDemo": true,
-      "presentable": true,
-      "skip_snapshots": true,
-    ]
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerExpandFullscreenExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -143,3 +146,5 @@ extension BottomDrawerExpandFullscreenExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialNavigationDrawer
 import MaterialComponents.MaterialNavigationDrawer_Theming 
@@ -165,3 +168,5 @@ extension BottomDrawerInfiniteScrollingExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerInfiniteScrollingExample.swift
@@ -16,157 +16,157 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialNavigationDrawer
-import MaterialComponents.MaterialNavigationDrawer_Theming 
-import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialNavigationDrawer_Theming
+  import MaterialComponents.MaterialColorScheme
 
-class BottomDrawerInfiniteScrollingExample: UIViewController {
-  @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerInfiniteScrollingExample: UIViewController {
+    @objc var containerScheme: MDCContainerScheming = MDCContainerScheme()
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = DrawerContentTableViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = DrawerContentTableViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = containerScheme.colorScheme.backgroundColor
-    contentViewController.colorScheme = containerScheme.colorScheme as? MDCSemanticColorScheme
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = containerScheme.colorScheme.backgroundColor
+      contentViewController.colorScheme = containerScheme.colorScheme as? MDCSemanticColorScheme
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = containerScheme.colorScheme.surfaceColor
-    let barItemTintColor = containerScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(
-      containerScheme.colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(
-      containerScheme.colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(
-      containerScheme.colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = containerScheme.colorScheme.surfaceColor
+      let barItemTintColor = containerScheme.colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(
+        containerScheme.colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(
+        containerScheme.colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(
+        containerScheme.colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(
-      x: 0,
-      y: view.bounds.size.height - size.height,
-      width: size.width,
-      height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
-  }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    layoutBottomAppBar()
-  }
-
-  @objc private func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.maximumInitialDrawerHeight = 400
-    bottomDrawerViewController.contentViewController = contentViewController
-    contentViewController.drawerVC = bottomDrawerViewController
-    bottomDrawerViewController.setTopCornersRadius(12, for: .collapsed)
-    bottomDrawerViewController.headerViewController = headerViewController
-    bottomDrawerViewController.trackingScrollView = contentViewController.tableView
-    bottomDrawerViewController.shouldIncludeSafeAreaInContentHeight = true
-    bottomDrawerViewController.isTopHandleHidden = false
-    bottomDrawerViewController.applyTheme(withScheme: containerScheme)
-    bottomDrawerViewController.maximumDrawerHeight = 600
-    present(bottomDrawerViewController, animated: true, completion: nil)
-  }
-}
-
-class DrawerContentTableViewController: UITableViewController {
-  @objc var colorScheme: MDCSemanticColorScheme!
-  weak var drawerVC: MDCBottomDrawerViewController!
-
-  override var preferredContentSize: CGSize {
-    get {
-      return CGSize(width: view.bounds.width, height: tableView.contentSize.height)
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
     }
-    set {
-      super.preferredContentSize = newValue
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    @objc private func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.maximumInitialDrawerHeight = 400
+      bottomDrawerViewController.contentViewController = contentViewController
+      contentViewController.drawerVC = bottomDrawerViewController
+      bottomDrawerViewController.setTopCornersRadius(12, for: .collapsed)
+      bottomDrawerViewController.headerViewController = headerViewController
+      bottomDrawerViewController.trackingScrollView = contentViewController.tableView
+      bottomDrawerViewController.shouldIncludeSafeAreaInContentHeight = true
+      bottomDrawerViewController.isTopHandleHidden = false
+      bottomDrawerViewController.applyTheme(withScheme: containerScheme)
+      bottomDrawerViewController.maximumDrawerHeight = 600
+      present(bottomDrawerViewController, animated: true, completion: nil)
     }
   }
 
-  var supportScrollToTop = true
+  class DrawerContentTableViewController: UITableViewController {
+    @objc var colorScheme: MDCSemanticColorScheme!
+    weak var drawerVC: MDCBottomDrawerViewController!
 
-  var numberOfRows = 10
-
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
-  }
-
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
-    -> UITableViewCell
-  {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    cell.textLabel?.text = "cell #\(indexPath.item)"
-    cell.backgroundColor = colorScheme.surfaceColor
-    print(cell.textLabel?.text ?? "")
-    return cell
-  }
-
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    if supportScrollToTop == false {
-      return numberOfRows
+    override var preferredContentSize: CGSize {
+      get {
+        return CGSize(width: view.bounds.width, height: tableView.contentSize.height)
+      }
+      set {
+        super.preferredContentSize = newValue
+      }
     }
-    return 100
+
+    var supportScrollToTop = true
+
+    var numberOfRows = 10
+
+    init() {
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      super.init(coder: aDecoder)
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
+      -> UITableViewCell
+    {
+      let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+      cell.textLabel?.text = "cell #\(indexPath.item)"
+      cell.backgroundColor = colorScheme.surfaceColor
+      print(cell.textLabel?.text ?? "")
+      return cell
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      if supportScrollToTop == false {
+        return numberOfRows
+      }
+      return 100
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+      return 1
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      tableView.deselectRow(at: indexPath, animated: true)
+      if supportScrollToTop == false {
+        toggleNumberOfRows()
+        tableView.reloadData()
+        self.preferredContentSize = tableView.contentSize
+      } else {
+        drawerVC.setContentOffsetY(0, animated: false)
+      }
+    }
+
+    private func toggleNumberOfRows() {
+      numberOfRows = (numberOfRows == 10) ? 14 : 10
+    }
+
   }
 
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return 1
-  }
+  extension BottomDrawerInfiniteScrollingExample {
 
-  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    tableView.deselectRow(at: indexPath, animated: true)
-    if supportScrollToTop == false {
-      toggleNumberOfRows()
-      tableView.reloadData()
-      self.preferredContentSize = tableView.contentSize
-    } else {
-      drawerVC.setContentOffsetY(0, animated: false)
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Infinite Scrolling"],
+        "description": "Navigation Drawer",
+        "presentable": true,
+      ]
     }
   }
-
-  private func toggleNumberOfRows() {
-    numberOfRows = (numberOfRows == 10) ? 14 : 10
-  }
-
-}
-
-extension BottomDrawerInfiniteScrollingExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Infinite Scrolling"],
-      "description": "Navigation Drawer",
-      "presentable": true,
-    ]
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -16,81 +16,82 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerNoHeaderExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
-  
-  let contentViewController = DrawerContentViewController()
-  let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
+  class BottomDrawerNoHeaderExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.view.backgroundColor = colorScheme.primaryColor
+    let contentViewController = DrawerContentViewController()
+    let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.view.backgroundColor = colorScheme.primaryColor
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    view.addSubview(bottomAppBar)
-  }
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    layoutBottomAppBar()
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
+
+    @objc func presentNavigationDrawer() {
+      // This shows that it is possible to present the content view controller directly without
+      // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
+      // inside the drawer, both the transition controller and the custom presentation controller
+      // of the drawer need to be set.
+      contentViewController.transitioningDelegate = bottomDrawerTransitionController
+      contentViewController.modalPresentationStyle = .custom
+      present(contentViewController, animated: true, completion: nil)
+    }
   }
 
-  @objc func presentNavigationDrawer() {
-    // This shows that it is possible to present the content view controller directly without
-    // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
-    // inside the drawer, both the transition controller and the custom presentation controller
-    // of the drawer need to be set.
-    contentViewController.transitioningDelegate = bottomDrawerTransitionController
-    contentViewController.modalPresentationStyle = .custom
-    present(contentViewController, animated: true, completion: nil)
+  extension BottomDrawerNoHeaderExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
+
   }
-}
-
-extension BottomDrawerNoHeaderExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -89,3 +92,5 @@ extension BottomDrawerNoHeaderExample {
   }
 
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
@@ -16,84 +16,85 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerNoHeaderLessContentExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerNoHeaderLessContentExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let contentViewController = DrawerContentViewController()
-  let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
+    let contentViewController = DrawerContentViewController()
+    let bottomDrawerTransitionController = MDCBottomDrawerTransitionController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
+    override func viewDidLoad() {
+      super.viewDidLoad()
 
-    contentViewController.preferredHeight = UIScreen.main.bounds.size.height
+      contentViewController.preferredHeight = UIScreen.main.bounds.size.height
 
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.view.backgroundColor = colorScheme.primaryColor
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.view.backgroundColor = colorScheme.primaryColor
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    layoutBottomAppBar()
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
+
+    @objc func presentNavigationDrawer() {
+      // This shows that it is possible to present the content view controller directly without
+      // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
+      // inside the drawer, both the transition controller and the custom presentation controller
+      // of the drawer need to be set.
+      contentViewController.transitioningDelegate = bottomDrawerTransitionController
+      contentViewController.modalPresentationStyle = .custom
+      present(contentViewController, animated: true, completion: nil)
+    }
   }
 
-  @objc func presentNavigationDrawer() {
-    // This shows that it is possible to present the content view controller directly without
-    // the need of the MDCBottomDrawerViewController wrapper. To present the view controller
-    // inside the drawer, both the transition controller and the custom presentation controller
-    // of the drawer need to be set.
-    contentViewController.transitioningDelegate = bottomDrawerTransitionController
-    contentViewController.modalPresentationStyle = .custom
-    present(contentViewController, animated: true, completion: nil)
+  extension BottomDrawerNoHeaderLessContentExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header Less Content"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
+
   }
-}
-
-extension BottomDrawerNoHeaderLessContentExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer No Header Less Content"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerNoHeaderLessContentExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -92,3 +95,5 @@ extension BottomDrawerNoHeaderLessContentExample {
   }
 
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerSwappingScrollViewsExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerSwappingScrollViewsExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -166,3 +169,5 @@ extension BottomDrawerSwappingScrollViewsExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerSwappingScrollViewsExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerSwappingScrollViewsExample.swift
@@ -16,158 +16,161 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
-import MaterialComponents.MaterialNavigationDrawer_ColorThemer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialNavigationDrawer_ColorThemer
 
-class BottomDrawerSwappingScrollViewsExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerSwappingScrollViewsExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = SwappingScrollViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = SwappingScrollViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.colorScheme = colorScheme
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.colorScheme = colorScheme
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
-    }
-    bottomAppBar.frame = bottomBarViewFrame
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    layoutBottomAppBar()
-  }
-
-  @objc private func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.contentViewController = contentViewController
-    contentViewController.setDrawer(drawer: bottomDrawerViewController)
-    bottomDrawerViewController.headerViewController = headerViewController
-    MDCBottomDrawerColorThemer.applySemanticColorScheme(colorScheme,
-                                                        toBottomDrawer: bottomDrawerViewController)
-    present(bottomDrawerViewController, animated: true, completion: nil)
-  }
-}
-
-class SwappingScrollViewController: UIViewController, UITableViewDataSource {
-  @objc var colorScheme: MDCSemanticColorScheme!
-  weak var drawerVC: MDCBottomDrawerViewController!
-  var tableView1: UITableView!
-  var tableView2: UITableView!
-
-  override func loadView() {
-    super.loadView()
-
-    self.view.backgroundColor = .white
-
-    tableView1 = UITableView()
-    tableView1.dataSource = self
-    self.view.addSubview(tableView1)
-
-    tableView2 = UITableView()
-    tableView2.dataSource = self
-
-    tableView1.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-    tableView2.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-
-    let switchButton = UIButton(type: .system)
-    switchButton.setTitle("Switch Scroll View", for: .normal)
-    switchButton.addTarget(self, action: #selector(switchScrollView(sender:)), for: .touchUpInside)
-    switchButton.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 48)
-
-    tableView1.tableHeaderView = switchButton
-  }
-
-  func setDrawer(drawer: MDCBottomDrawerViewController) {
-    drawerVC = drawer
-
-    // Default to the first scroll view for initial presentation.
-    drawer.trackingScrollView = tableView1
-  }
-
-  @objc func switchScrollView(sender: AnyObject) {
-    tableView1.removeFromSuperview()
-
-    // Switch active scroll views
-    self.view.addSubview(tableView2)
-    drawerVC.trackingScrollView = tableView2
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    tableView1.frame = self.view.bounds
-    tableView2.frame = self.view.bounds
-
-    self.preferredContentSize = CGSize(width: 0, height: tableView1.contentSize.height)
-  }
-
-  @available(iOS 11.0, *)
-  override func viewSafeAreaInsetsDidChange() {
-    super.viewSafeAreaInsetsDidChange()
-
-    self.preferredContentSize = CGSize(width: 0, height: tableView1.contentSize.height)
-  }
-
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return 100
-  }
-
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-
-    if tableView == tableView1 {
-      cell.textLabel?.text = "Scroll View 1"
-    } else {
-      cell.textLabel?.text = "Scroll View 2"
+      view.addSubview(bottomAppBar)
     }
 
-    return cell
-  }
-}
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
 
-extension BottomDrawerSwappingScrollViewsExample {
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
 
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Swapping ScrollViews"],
-      "description": "Navigation Drawer",
-      "presentable": true,
-    ]
+      layoutBottomAppBar()
+    }
+
+    @objc private func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.contentViewController = contentViewController
+      contentViewController.setDrawer(drawer: bottomDrawerViewController)
+      bottomDrawerViewController.headerViewController = headerViewController
+      MDCBottomDrawerColorThemer.applySemanticColorScheme(
+        colorScheme,
+        toBottomDrawer: bottomDrawerViewController)
+      present(bottomDrawerViewController, animated: true, completion: nil)
+    }
   }
-}
+
+  class SwappingScrollViewController: UIViewController, UITableViewDataSource {
+    @objc var colorScheme: MDCSemanticColorScheme!
+    weak var drawerVC: MDCBottomDrawerViewController!
+    var tableView1: UITableView!
+    var tableView2: UITableView!
+
+    override func loadView() {
+      super.loadView()
+
+      self.view.backgroundColor = .white
+
+      tableView1 = UITableView()
+      tableView1.dataSource = self
+      self.view.addSubview(tableView1)
+
+      tableView2 = UITableView()
+      tableView2.dataSource = self
+
+      tableView1.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+      tableView2.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+
+      let switchButton = UIButton(type: .system)
+      switchButton.setTitle("Switch Scroll View", for: .normal)
+      switchButton.addTarget(
+        self, action: #selector(switchScrollView(sender:)), for: .touchUpInside)
+      switchButton.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 48)
+
+      tableView1.tableHeaderView = switchButton
+    }
+
+    func setDrawer(drawer: MDCBottomDrawerViewController) {
+      drawerVC = drawer
+
+      // Default to the first scroll view for initial presentation.
+      drawer.trackingScrollView = tableView1
+    }
+
+    @objc func switchScrollView(sender: AnyObject) {
+      tableView1.removeFromSuperview()
+
+      // Switch active scroll views
+      self.view.addSubview(tableView2)
+      drawerVC.trackingScrollView = tableView2
+    }
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      tableView1.frame = self.view.bounds
+      tableView2.frame = self.view.bounds
+
+      self.preferredContentSize = CGSize(width: 0, height: tableView1.contentSize.height)
+    }
+
+    @available(iOS 11.0, *)
+    override func viewSafeAreaInsetsDidChange() {
+      super.viewSafeAreaInsetsDidChange()
+
+      self.preferredContentSize = CGSize(width: 0, height: tableView1.contentSize.height)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+      return 100
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+      let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+
+      if tableView == tableView1 {
+        cell.textLabel?.text = "Scroll View 1"
+      } else {
+        cell.textLabel?.text = "Scroll View 2"
+      }
+
+      return cell
+    }
+  }
+
+  extension BottomDrawerSwappingScrollViewsExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Swapping ScrollViews"],
+        "description": "Navigation Drawer",
+        "presentable": true,
+      ]
+    }
+  }
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -167,3 +170,5 @@ extension BottomDrawerWithChangingContentSizeExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithChangingContentSize.swift
@@ -16,159 +16,171 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerWithChangingContentSizeExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerWithChangingContentSizeExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = DrawerChangingContentSizeViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = DrawerChangingContentSizeViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.colorScheme = colorScheme
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.colorScheme = colorScheme
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
-  }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    layoutBottomAppBar()
-  }
-
-  @objc func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.setTopCornersRadius(8, for: .collapsed)
-    bottomDrawerViewController.setTopCornersRadius(0, for: .expanded)
-    bottomDrawerViewController.isTopHandleHidden = false
-    bottomDrawerViewController.contentViewController = contentViewController
-    bottomDrawerViewController.headerViewController = headerViewController
-    bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
-    bottomDrawerViewController.headerViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.contentViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
-    present(bottomDrawerViewController, animated: true, completion: nil)
-  }
-}
-
-class DrawerChangingContentSizeViewController: UIViewController,
-UICollectionViewDelegate, UICollectionViewDataSource {
-  @objc var colorScheme: MDCSemanticColorScheme!
-  let numberOfRowsShort : Int = 2
-  let numberOfRowsLong : Int = 12
-  var longList = false
-
-  let collectionView: UICollectionView
-  let layout = UICollectionViewFlowLayout()
-
-  init() {
-    collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-    super.init(coder: aDecoder)
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    collectionView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width,
-                                  height: self.view.bounds.height)
-    collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-    collectionView.delegate = self
-    collectionView.dataSource = self
-    collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    layout.minimumLineSpacing = 0
-    layout.minimumInteritemSpacing = 0
-    self.view.addSubview(collectionView)
-
-    let tapGestureRecognizer = UITapGestureRecognizer(target: self, action:#selector(didTap(gestureRecognizer:)))
-    collectionView.addGestureRecognizer(tapGestureRecognizer)
-  }
-
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    let s = self.view.frame.size.width / 3
-    layout.itemSize = CGSize(width: s, height: s)
-    self.preferredContentSize = CGSize(width: view.bounds.width,
-                                       height: layout.collectionViewContentSize.height)
-  }
-
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    let numberOfRows = longList ? numberOfRowsLong : numberOfRowsShort
-    return numberOfRows * 3
-  }
-
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
-    let colorPick = indexPath.row % 2 == 0
-    print(indexPath.item)
-    if longList {
-      cell.backgroundColor =
-        colorPick ? colorScheme.secondaryColor : colorScheme.errorColor
-    } else {
-      cell.backgroundColor =
-        colorPick ? colorScheme.secondaryColor : colorScheme.primaryColorVariant
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
     }
-    return cell
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    @objc func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.setTopCornersRadius(8, for: .collapsed)
+      bottomDrawerViewController.setTopCornersRadius(0, for: .expanded)
+      bottomDrawerViewController.isTopHandleHidden = false
+      bottomDrawerViewController.contentViewController = contentViewController
+      bottomDrawerViewController.headerViewController = headerViewController
+      bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
+      bottomDrawerViewController.headerViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.contentViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+      present(bottomDrawerViewController, animated: true, completion: nil)
+    }
   }
 
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return 1
+  class DrawerChangingContentSizeViewController: UIViewController,
+    UICollectionViewDelegate, UICollectionViewDataSource
+  {
+    @objc var colorScheme: MDCSemanticColorScheme!
+    let numberOfRowsShort: Int = 2
+    let numberOfRowsLong: Int = 12
+    var longList = false
+
+    let collectionView: UICollectionView
+    let layout = UICollectionViewFlowLayout()
+
+    init() {
+      collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+      super.init(coder: aDecoder)
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      collectionView.frame = CGRect(
+        x: 0, y: 0, width: self.view.bounds.width,
+        height: self.view.bounds.height)
+      collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+      collectionView.delegate = self
+      collectionView.dataSource = self
+      collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      layout.minimumLineSpacing = 0
+      layout.minimumInteritemSpacing = 0
+      self.view.addSubview(collectionView)
+
+      let tapGestureRecognizer = UITapGestureRecognizer(
+        target: self, action: #selector(didTap(gestureRecognizer:)))
+      collectionView.addGestureRecognizer(tapGestureRecognizer)
+    }
+
+    override func viewWillLayoutSubviews() {
+      super.viewWillLayoutSubviews()
+      let s = self.view.frame.size.width / 3
+      layout.itemSize = CGSize(width: s, height: s)
+      self.preferredContentSize = CGSize(
+        width: view.bounds.width,
+        height: layout.collectionViewContentSize.height)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+      -> Int
+    {
+      let numberOfRows = longList ? numberOfRowsLong : numberOfRowsShort
+      return numberOfRows * 3
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+      -> UICollectionViewCell
+    {
+      let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+      let colorPick = indexPath.row % 2 == 0
+      print(indexPath.item)
+      if longList {
+        cell.backgroundColor =
+          colorPick ? colorScheme.secondaryColor : colorScheme.errorColor
+      } else {
+        cell.backgroundColor =
+          colorPick ? colorScheme.secondaryColor : colorScheme.primaryColorVariant
+      }
+      return cell
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+      return 1
+    }
+
+    @objc func didTap(gestureRecognizer: UITapGestureRecognizer) {
+      longList = !longList
+      collectionView.reloadData()
+      self.preferredContentSize = CGSize(
+        width: self.view.bounds.width,
+        height: self.layout.collectionViewContentSize.height)
+    }
   }
 
-  @objc func didTap(gestureRecognizer : UITapGestureRecognizer) {
-    longList = !longList
-    collectionView.reloadData()
-    self.preferredContentSize = CGSize(width: self.view.bounds.width,
-                                       height: self.layout.collectionViewContentSize.height)
-  }
-}
+  extension BottomDrawerWithChangingContentSizeExample {
 
-extension BottomDrawerWithChangingContentSizeExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Changing Content Size"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Changing Content Size"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -100,3 +103,5 @@ extension BottomDrawerWithHeaderExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderExample.swift
@@ -16,92 +16,98 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {
+  class BottomDrawerWithHeaderExample: UIViewController, MDCBottomDrawerViewControllerDelegate {
 
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = DrawerContentViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = DrawerContentViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
+
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    @objc func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
+      bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)
+      bottomDrawerViewController.isTopHandleHidden = false
+      bottomDrawerViewController.topHandleColor = UIColor.lightGray
+      bottomDrawerViewController.contentViewController = contentViewController
+      bottomDrawerViewController.headerViewController = headerViewController
+      bottomDrawerViewController.delegate = self
+      bottomDrawerViewController.headerViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.contentViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+      present(bottomDrawerViewController, animated: true, completion: nil)
+    }
+
+    func bottomDrawerControllerDidChangeTopInset(
+      _ controller: MDCBottomDrawerViewController,
+      topInset: CGFloat
+    ) {
+      headerViewController.titleLabel.center =
+        CGPoint(
+          x: headerViewController.view.frame.size.width / 2,
+          y: (headerViewController.view.frame.size.height + topInset) / 2)
+    }
   }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
+  extension BottomDrawerWithHeaderExample {
 
-    layoutBottomAppBar()
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-
-  @objc func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.setTopCornersRadius(24, for: .collapsed)
-    bottomDrawerViewController.setTopCornersRadius(8, for: .expanded)
-    bottomDrawerViewController.isTopHandleHidden = false
-    bottomDrawerViewController.topHandleColor = UIColor.lightGray
-    bottomDrawerViewController.contentViewController = contentViewController
-    bottomDrawerViewController.headerViewController = headerViewController
-    bottomDrawerViewController.delegate = self
-    bottomDrawerViewController.headerViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.contentViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
-    present(bottomDrawerViewController, animated: true, completion: nil)
-  }
-
-  func bottomDrawerControllerDidChangeTopInset(_ controller: MDCBottomDrawerViewController,
-                                               topInset: CGFloat) {
-    headerViewController.titleLabel.center =
-      CGPoint(x: headerViewController.view.frame.size.width / 2,
-              y: (headerViewController.view.frame.size.height + topInset) / 2)
-  }
-}
-
-extension BottomDrawerWithHeaderExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -32,3 +35,5 @@ class BottomDrawerWithHeaderLessContentExample: BottomDrawerWithHeaderExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithHeaderLessContentExample.swift
@@ -16,24 +16,24 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerWithHeaderLessContentExample: BottomDrawerWithHeaderExample {
+  class BottomDrawerWithHeaderLessContentExample: BottomDrawerWithHeaderExample {
 
-  @objc override func presentNavigationDrawer() {
-    contentViewController.preferredHeight = 500
-    super.presentNavigationDrawer()
+    @objc override func presentNavigationDrawer() {
+      contentViewController.preferredHeight = 500
+      super.presentNavigationDrawer()
+    }
+
+    @objc override class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Less Content"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-
-  @objc override class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Less Content"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -16,136 +16,146 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialBottomAppBar
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialBottomAppBar
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class BottomDrawerWithScrollableContentExample: UIViewController {
-  @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
-  let bottomAppBar = MDCBottomAppBarView()
+  class BottomDrawerWithScrollableContentExample: UIViewController {
+    @objc var colorScheme = MDCSemanticColorScheme(defaults: .material201804)
+    let bottomAppBar = MDCBottomAppBarView()
 
-  let headerViewController = DrawerHeaderViewController()
-  let contentViewController = DrawerContentWithScrollViewController()
+    let headerViewController = DrawerHeaderViewController()
+    let contentViewController = DrawerContentWithScrollViewController()
 
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.backgroundColor = colorScheme.backgroundColor
-    contentViewController.colorScheme = colorScheme
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.backgroundColor = colorScheme.backgroundColor
+      contentViewController.colorScheme = colorScheme
 
-    bottomAppBar.isFloatingButtonHidden = true
-    let barButtonLeadingItem = UIBarButtonItem()
-    let menuImage = UIImage(named:"ic_menu")?.withRenderingMode(.alwaysTemplate)
-    barButtonLeadingItem.image = menuImage
-    barButtonLeadingItem.target = self
-    barButtonLeadingItem.action = #selector(presentNavigationDrawer)
-    bottomAppBar.leadingBarButtonItems = [ barButtonLeadingItem ]
+      bottomAppBar.isFloatingButtonHidden = true
+      let barButtonLeadingItem = UIBarButtonItem()
+      let menuImage = UIImage(named: "ic_menu")?.withRenderingMode(.alwaysTemplate)
+      barButtonLeadingItem.image = menuImage
+      barButtonLeadingItem.target = self
+      barButtonLeadingItem.action = #selector(presentNavigationDrawer)
+      bottomAppBar.leadingBarButtonItems = [barButtonLeadingItem]
 
-    bottomAppBar.barTintColor = colorScheme.surfaceColor;
-    let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
-    bottomAppBar.leadingBarItemsTintColor = barItemTintColor
-    bottomAppBar.trailingBarItemsTintColor = barItemTintColor
-    bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
-    bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
-    bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.barTintColor = colorScheme.surfaceColor
+      let barItemTintColor = colorScheme.onSurfaceColor.withAlphaComponent(0.6)
+      bottomAppBar.leadingBarItemsTintColor = barItemTintColor
+      bottomAppBar.trailingBarItemsTintColor = barItemTintColor
+      bottomAppBar.floatingButton.setBackgroundColor(colorScheme.primaryColor, for: .normal)
+      bottomAppBar.floatingButton.setTitleColor(colorScheme.onPrimaryColor, for: .normal)
+      bottomAppBar.floatingButton.setImageTintColor(colorScheme.onPrimaryColor, for: .normal)
 
-    view.addSubview(bottomAppBar)
-  }
-
-  private func layoutBottomAppBar() {
-    let size = bottomAppBar.sizeThatFits(view.bounds.size)
-    var bottomBarViewFrame = CGRect(x: 0,
-                                    y: view.bounds.size.height - size.height,
-                                    width: size.width,
-                                    height: size.height)
-    if #available(iOS 11.0, *) {
-      bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
-      bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      view.addSubview(bottomAppBar)
     }
-    bottomAppBar.frame = bottomBarViewFrame
+
+    private func layoutBottomAppBar() {
+      let size = bottomAppBar.sizeThatFits(view.bounds.size)
+      var bottomBarViewFrame = CGRect(
+        x: 0,
+        y: view.bounds.size.height - size.height,
+        width: size.width,
+        height: size.height)
+      if #available(iOS 11.0, *) {
+        bottomBarViewFrame.size.height += view.safeAreaInsets.bottom
+        bottomBarViewFrame.origin.y -= view.safeAreaInsets.bottom
+      }
+      bottomAppBar.frame = bottomBarViewFrame
+    }
+
+    override func viewDidLayoutSubviews() {
+      super.viewDidLayoutSubviews()
+
+      layoutBottomAppBar()
+    }
+
+    @objc func presentNavigationDrawer() {
+      let bottomDrawerViewController = MDCBottomDrawerViewController()
+      bottomDrawerViewController.maximumInitialDrawerHeight = 400
+      bottomDrawerViewController.contentViewController = contentViewController
+      bottomDrawerViewController.headerViewController = headerViewController
+      bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
+      bottomDrawerViewController.headerViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.contentViewController?.view.backgroundColor =
+        colorScheme.surfaceColor
+      bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
+      present(bottomDrawerViewController, animated: true, completion: nil)
+    }
   }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
+  class DrawerContentWithScrollViewController: UIViewController,
+    UICollectionViewDelegate, UICollectionViewDataSource
+  {
+    @objc var colorScheme: MDCSemanticColorScheme!
 
-    layoutBottomAppBar()
+    let collectionView: UICollectionView
+    let layout = UICollectionViewFlowLayout()
+
+    init() {
+      collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+      super.init(coder: aDecoder)
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      collectionView.frame = CGRect(
+        x: 0, y: 0, width: self.view.bounds.width,
+        height: self.view.bounds.height)
+      collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+      collectionView.delegate = self
+      collectionView.dataSource = self
+      collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      layout.minimumLineSpacing = 0
+      layout.minimumInteritemSpacing = 0
+      self.view.addSubview(collectionView)
+    }
+
+    override func viewWillLayoutSubviews() {
+      super.viewWillLayoutSubviews()
+      let s = self.view.frame.size.width / 3
+      layout.itemSize = CGSize(width: s, height: s)
+      self.preferredContentSize = CGSize(
+        width: view.bounds.width,
+        height: layout.collectionViewContentSize.height)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+      -> Int
+    {
+      return 102
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+      -> UICollectionViewCell
+    {
+      let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+      let colorPick = indexPath.row % 2 == 0
+      cell.backgroundColor = colorPick ? colorScheme.surfaceColor : colorScheme.primaryColorVariant
+      return cell
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+      return 1
+    }
   }
 
-  @objc func presentNavigationDrawer() {
-    let bottomDrawerViewController = MDCBottomDrawerViewController()
-    bottomDrawerViewController.maximumInitialDrawerHeight = 400;
-    bottomDrawerViewController.contentViewController = contentViewController
-    bottomDrawerViewController.headerViewController = headerViewController
-    bottomDrawerViewController.trackingScrollView = contentViewController.collectionView
-    bottomDrawerViewController.headerViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.contentViewController?.view.backgroundColor = colorScheme.surfaceColor;
-    bottomDrawerViewController.scrimColor = colorScheme.onSurfaceColor.withAlphaComponent(0.32)
-    present(bottomDrawerViewController, animated: true, completion: nil)
+  extension BottomDrawerWithScrollableContentExample {
+
+    @objc class func catalogMetadata() -> [String: Any] {
+      return [
+        "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Scrollable Content"],
+        "primaryDemo": false,
+        "presentable": false,
+      ]
+    }
   }
-}
-
-class DrawerContentWithScrollViewController: UIViewController,
-    UICollectionViewDelegate, UICollectionViewDataSource {
-  @objc var colorScheme: MDCSemanticColorScheme!
-
-  let collectionView: UICollectionView
-  let layout = UICollectionViewFlowLayout()
-
-  init() {
-    collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-    super.init(coder: aDecoder)
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    collectionView.frame = CGRect(x: 0, y: 0, width: self.view.bounds.width,
-                             height: self.view.bounds.height)
-    collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-    collectionView.delegate = self
-    collectionView.dataSource = self
-    collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    layout.minimumLineSpacing = 0
-    layout.minimumInteritemSpacing = 0
-    self.view.addSubview(collectionView)
-  }
-
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    let s = self.view.frame.size.width / 3
-    layout.itemSize = CGSize(width: s, height: s)
-    self.preferredContentSize = CGSize(width: view.bounds.width,
-                                       height: layout.collectionViewContentSize.height)
-  }
-
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 102
-  }
-
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
-    let colorPick = indexPath.row % 2 == 0
-    cell.backgroundColor = colorPick ? colorScheme.surfaceColor : colorScheme.primaryColorVariant
-    return cell
-  }
-
-  func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return 1
-  }
-}
-
-extension BottomDrawerWithScrollableContentExample {
-
-  @objc class func catalogMetadata() -> [String: Any] {
-    return [
-      "breadcrumbs": ["Navigation Drawer", "Bottom Drawer Scrollable Content"],
-      "primaryDemo": false,
-      "presentable": false,
-    ]
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
+++ b/components/NavigationDrawer/examples/BottomDrawerWithScrollableContentExample.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialBottomAppBar
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
@@ -144,3 +147,5 @@ extension BottomDrawerWithScrollableContentExample {
     ]
   }
 }
+
+#endif

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -16,92 +16,92 @@ import UIKit
 
 #if !targetEnvironment(macCatalyst)
 
-import MaterialComponents.MaterialColorScheme
-import MaterialComponents.MaterialNavigationDrawer
+  import MaterialComponents.MaterialColorScheme
+  import MaterialComponents.MaterialNavigationDrawer
 
-class DrawerContentViewController: UIViewController {
-  var preferredHeight: CGFloat = 2000
-  let bodyLabel : UILabel = {
-    let label = UILabel(frame: .zero)
-    label.text = "Example body"
-    label.sizeToFit()
-    return label
-  }()
+  class DrawerContentViewController: UIViewController {
+    var preferredHeight: CGFloat = 2000
+    let bodyLabel: UILabel = {
+      let label = UILabel(frame: .zero)
+      label.text = "Example body"
+      label.sizeToFit()
+      return label
+    }()
 
-  override var preferredContentSize: CGSize {
-    get {
-      return CGSize(width: view.bounds.width, height: preferredHeight)
+    override var preferredContentSize: CGSize {
+      get {
+        return CGSize(width: view.bounds.width, height: preferredHeight)
+      }
+      set {
+        super.preferredContentSize = newValue
+      }
     }
-    set {
-      super.preferredContentSize = newValue
+
+    init() {
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      super.init(coder: aDecoder)
+    }
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.addSubview(bodyLabel)
+    }
+
+    override func viewWillLayoutSubviews() {
+      super.viewWillLayoutSubviews()
+      bodyLabel.center =
+        CGPoint(x: self.view.frame.size.width / 2, y: 20)
+    }
+
+  }
+
+  class DrawerHeaderViewController: UIViewController, MDCBottomDrawerHeader {
+    let preferredHeight: CGFloat = 80
+
+    lazy var closeButton: UIButton = {
+      let button = UIButton()
+      button.setTitle("Close", for: .normal)
+      button.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+      button.setTitleColor(.black, for: .normal)
+      return button
+    }()
+
+    let titleLabel: UILabel = {
+      let label = UILabel(frame: .zero)
+      label.text = "Example Header"
+      label.accessibilityTraits = .header
+      label.sizeToFit()
+      return label
+    }()
+
+    override var preferredContentSize: CGSize {
+      get {
+        return CGSize(width: view.bounds.width, height: preferredHeight)
+      }
+      set {
+        super.preferredContentSize = newValue
+      }
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      view.addSubview(closeButton)
+      view.addSubview(titleLabel)
+    }
+
+    override func viewWillLayoutSubviews() {
+      super.viewWillLayoutSubviews()
+      closeButton.sizeToFit()
+      closeButton.center = CGPoint(x: 30, y: self.preferredHeight - 20)
+      titleLabel.center = CGPoint(x: self.view.frame.size.width / 2, y: self.preferredHeight - 20)
+    }
+
+    @objc
+    func closeButtonTapped() {
+      dismiss(animated: true)
     }
   }
-
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-  }
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.addSubview(bodyLabel)
-  }
-
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    bodyLabel.center =
-      CGPoint(x: self.view.frame.size.width / 2, y: 20)
-  }
-
-}
-
-class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
-  let preferredHeight: CGFloat = 80
-
-  lazy var closeButton: UIButton = {
-    let button = UIButton()
-    button.setTitle("Close", for: .normal)
-    button.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
-    button.setTitleColor(.black, for: .normal)
-    return button
-  }()
-
-  let titleLabel : UILabel = {
-    let label = UILabel(frame: .zero)
-    label.text = "Example Header"
-    label.accessibilityTraits = .header
-    label.sizeToFit()
-    return label
-  }()
-
-  override var preferredContentSize: CGSize {
-    get {
-      return CGSize(width: view.bounds.width, height: preferredHeight)
-    }
-    set {
-      super.preferredContentSize = newValue
-    }
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    view.addSubview(closeButton)
-    view.addSubview(titleLabel)
-  }
-
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    closeButton.sizeToFit()
-    closeButton.center = CGPoint(x: 30, y: self.preferredHeight - 20)
-    titleLabel.center = CGPoint(x: self.view.frame.size.width / 2, y: self.preferredHeight - 20)
-  }
-
-  @objc
-  func closeButtonTapped() {
-    dismiss(animated: true)
-  }
-}
 
 #endif

--- a/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
+++ b/components/NavigationDrawer/examples/supplemental/BottomDrawerSupplemental.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import UIKit
+
+#if !targetEnvironment(macCatalyst)
+
 import MaterialComponents.MaterialColorScheme
 import MaterialComponents.MaterialNavigationDrawer
 
@@ -100,3 +103,5 @@ class DrawerHeaderViewController: UIViewController,MDCBottomDrawerHeader {
     dismiss(animated: true)
   }
 }
+
+#endif

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
@@ -27,8 +27,7 @@
 __deprecated_msg("No replacement exists. Please comment on"
                  " https://github.com/material-components/material-components-ios/issues/7172"
                  " in order to indicate interest in a replacement API.")
-API_UNAVAILABLE(macCatalyst)
-@interface MDCBottomDrawerColorThemer : NSObject
+    API_UNAVAILABLE(macCatalyst) @interface MDCBottomDrawerColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCBottomDrawerViewController

--- a/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
+++ b/components/NavigationDrawer/src/ColorThemer/MDCBottomDrawerColorThemer.h
@@ -27,7 +27,8 @@
 __deprecated_msg("No replacement exists. Please comment on"
                  " https://github.com/material-components/material-components-ios/issues/7172"
                  " in order to indicate interest in a replacement API.")
-    @interface MDCBottomDrawerColorThemer : NSObject
+API_UNAVAILABLE(macCatalyst)
+@interface MDCBottomDrawerColorThemer : NSObject
 
 /**
  Applies a color scheme's properties to an MDCBottomDrawerViewController

--- a/components/NavigationDrawer/src/MDCBottomDrawerHeader.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerHeader.h
@@ -18,6 +18,7 @@
  A protocol view controllers should conform to for enabling the view controller to be
  used as a drawer header view controller.
  */
+API_UNAVAILABLE(macCatalyst)
 @protocol MDCBottomDrawerHeader
 
 @optional

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationController.h
@@ -26,6 +26,7 @@
 /**
  The presentation controller to use for presenting an MDC bottom drawer.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerPresentationController : UIPresentationController
 
 /**

--- a/components/NavigationDrawer/src/MDCBottomDrawerPresentationControllerDelegate.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerPresentationControllerDelegate.h
@@ -21,6 +21,7 @@
 /**
  Delegate for MDCBottomSheetPresentationController.
  */
+API_UNAVAILABLE(macCatalyst)
 @protocol MDCBottomDrawerPresentationControllerDelegate <UIAdaptivePresentationControllerDelegate>
 /**
  This method is called when the bottom drawer will change its presented state to one of the

--- a/components/NavigationDrawer/src/MDCBottomDrawerState.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerState.h
@@ -29,4 +29,4 @@ typedef NS_ENUM(NSUInteger, MDCBottomDrawerState) {
   MDCBottomDrawerStateCollapsed = 0,
   MDCBottomDrawerStateExpanded = 1,
   MDCBottomDrawerStateFullScreen = 2,
-};
+} API_UNAVAILABLE(macCatalyst);

--- a/components/NavigationDrawer/src/MDCBottomDrawerTransitionController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerTransitionController.h
@@ -17,6 +17,7 @@
 /**
  The transitioning delegate to use for presenting a view controller as a MDC bottom drawer.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerTransitionController
     : NSObject <UIViewControllerAnimatedTransitioning, UIViewControllerTransitioningDelegate>
 

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewController.h
@@ -27,6 +27,7 @@
 /**
  View controller for containing a Material bottom drawer.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerViewController
     : UIViewController <MDCBottomDrawerPresentationControllerDelegate,
                         MDCElevatable,

--- a/components/NavigationDrawer/src/MDCBottomDrawerViewControllerDelegate.h
+++ b/components/NavigationDrawer/src/MDCBottomDrawerViewControllerDelegate.h
@@ -19,6 +19,7 @@
 /**
  Delegate for MDCBottomDrawerViewController.
  */
+API_UNAVAILABLE(macCatalyst)
 @protocol MDCBottomDrawerViewControllerDelegate <NSObject>
 
 @optional

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewController.h
@@ -26,6 +26,7 @@
 /**
  View controller for containing a Material bottom drawer. Used internally only.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerContainerViewController : UIViewController <UIGestureRecognizerDelegate>
 
 /**

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewControllerDelegate.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerContainerViewControllerDelegate.h
@@ -19,6 +19,7 @@
 /**
  Delegate for MDCBottomDrawerContainerViewController.
  */
+API_UNAVAILABLE(macCatalyst)
 @protocol MDCBottomDrawerContainerViewControllerDelegate <NSObject>
 
 /**

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerHeaderMask.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerHeaderMask.h
@@ -19,6 +19,7 @@
  MDCBottomDrawerHeaderLayer handles the shape calculations for
  MDCBottomDrawerContainerViewController.
  */
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerHeaderMask : NSObject
 
 /**

--- a/components/NavigationDrawer/src/private/MDCBottomDrawerShadowedView.h
+++ b/components/NavigationDrawer/src/private/MDCBottomDrawerShadowedView.h
@@ -14,6 +14,7 @@
 
 #import "MaterialShadowLayer.h"
 
+API_UNAVAILABLE(macCatalyst)
 @interface MDCBottomDrawerShadowedView : UIView
 - (MDCShadowLayer *)shadowLayer;
 @end


### PR DESCRIPTION
NavigationDrawer is an iPhone-only pattern. We do not, at this time, intend to allow it to be used for Mac Catalyst apps.
