### PR TITLE
[Math] Remove use of deprecated methods.

### DIFF
--- a/components/private/Math/src/MDCMath.h
+++ b/components/private/Math/src/MDCMath.h
@@ -74,7 +74,7 @@ static inline BOOL MDCCGFloatEqual(CGFloat a, CGFloat b) {
   const CGFloat epsilon = FLT_EPSILON;
   const CGFloat min = FLT_MIN;
 #endif
-  return (MDCFabs(a - b) < constantK * epsilon * MDCFabs(a + b) || MDCFabs(a - b) < min);
+  return (fabs(a - b) < constantK * epsilon * fabs(a + b) || fabs(a - b) < min);
 }
 
 __deprecated_msg("Use floor instead.") static inline CGFloat MDCFloor(CGFloat value) {
@@ -143,7 +143,7 @@ static inline CGFloat MDCCeilScaled(CGFloat value, CGFloat scale) {
     return 0;
   }
 
-  return MDCCeil(value * scale) / scale;
+  return ceil(value * scale) / scale;
 }
 
 /**
@@ -159,7 +159,7 @@ static inline CGFloat MDCFloorScaled(CGFloat value, CGFloat scale) {
     return 0;
   }
 
-  return MDCFloor(value * scale) / scale;
+  return floor(value * scale) / scale;
 }
 
 /**
@@ -186,13 +186,13 @@ static inline CGRect MDCRectAlignToScale(CGRect rect, CGFloat scale) {
   }
 
   CGPoint originalMinimumPoint = CGPointMake(CGRectGetMinX(rect), CGRectGetMinY(rect));
-  CGPoint newOrigin = CGPointMake(MDCFloor(originalMinimumPoint.x * scale) / scale,
-                                  MDCFloor(originalMinimumPoint.y * scale) / scale);
+  CGPoint newOrigin = CGPointMake(floor(originalMinimumPoint.x * scale) / scale,
+                                  floor(originalMinimumPoint.y * scale) / scale);
   CGSize adjustWidthHeight =
       CGSizeMake(originalMinimumPoint.x - newOrigin.x, originalMinimumPoint.y - newOrigin.y);
   return CGRectMake(newOrigin.x, newOrigin.y,
-                    MDCCeil((CGRectGetWidth(rect) + adjustWidthHeight.width) * scale) / scale,
-                    MDCCeil((CGRectGetHeight(rect) + adjustWidthHeight.height) * scale) / scale);
+                    ceil((CGRectGetWidth(rect) + adjustWidthHeight.width) * scale) / scale,
+                    ceil((CGRectGetHeight(rect) + adjustWidthHeight.height) * scale) / scale);
 }
 
 static inline CGPoint MDCPointRoundWithScale(CGPoint point, CGFloat scale) {
@@ -200,7 +200,7 @@ static inline CGPoint MDCPointRoundWithScale(CGPoint point, CGFloat scale) {
     return CGPointZero;
   }
 
-  return CGPointMake(MDCRound(point.x * scale) / scale, MDCRound(point.y * scale) / scale);
+  return CGPointMake(round(point.x * scale) / scale, round(point.y * scale) / scale);
 }
 
 /**
@@ -217,7 +217,7 @@ static inline CGSize MDCSizeCeilWithScale(CGSize size, CGFloat scale) {
     return CGSizeZero;
   }
 
-  return CGSizeMake(MDCCeil(size.width * scale) / scale, MDCCeil(size.height * scale) / scale);
+  return CGSizeMake(ceil(size.width * scale) / scale, ceil(size.height * scale) / scale);
 }
 
 /**


### PR DESCRIPTION
This fixes a bug introduced by [e1afe22](https://github.com/material-components/material-components-ios/commit/e1afe22cfb01722fd7e52a3ac61503e90e3a89c9) which caused failing builds on Xcode 12 due to use of deprecated methods.

Specifically: the related commit above deprecated the custom MDCMath-specific methods, but MDCMath.h itself continues to use those same deprecated methods. This causes builds to fail (v117, Xcode 12, included as a Pod); previous version with v116 or a custom version with my commit resolves the issue.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [X] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Please add unit tests, snapshot tests, or manual testing steps depending on the change.
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-ios/tree/develop/contributing) has more information and tips for a great
pull request.
