### PR TITLE
[MDCAlertControllerView] The alert dialog text view should avoid cutting off the top of Thai text.

### DIFF
--- a/components/Dialogs/src/private/MDCAlertControllerView+Private.m
+++ b/components/Dialogs/src/private/MDCAlertControllerView+Private.m
@@ -36,6 +36,35 @@ static const CGFloat MDCDialogActionMinTouchTarget = 48.0f;
 
 static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
+/** Calculates the minimum text height for a single line text using device metrics. */
+static CGFloat SingleLineTextViewHeight(NSString *_Nullable title, UIFont *_Nullable font) {
+  if (title.length == 0) {
+    return font.lineHeight;
+  }
+
+  NSDictionary<NSAttributedStringKey, id> *attributes =
+      font == nil ? nil : @{NSFontAttributeName : font};
+  CGRect boundingRect = [title boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
+                                            options:NSStringDrawingUsesDeviceMetrics
+                                         attributes:attributes
+                                            context:nil];
+  // Some text height may exceed the UIFont.lineHeight.
+  // https://developer.apple.com/documentation/uikit/uifont?language=objc
+  // --------------------
+  //  |               |
+  //  | <= ascender   |
+  //  |               | <= lineHeight
+  // -----------------|
+  //  | <= descender  |
+  // --------------------
+  // UIFont.lineHeight consist of UIFont.ascender and UIFont.descender. UIFont.descender is the
+  // bottom offset from the baseline. The boundingRect.origin.y is the amount of space the text will
+  // occupy in UIFont.descender. So the minimum text view line height is text height + the leftover
+  // space in the UIFont.descender not occupied by the rendered text.
+  CGFloat bottomPadding = boundingRect.origin.y - font.descender;
+  return boundingRect.size.height + bottomPadding;
+}
+
 @interface MDCNonselectableTextView : UITextView
 @end
 
@@ -1059,6 +1088,41 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
 
 @implementation MDCNonselectableTextView
 
+#pragma mark - UITextView
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+  if ([self.attributedText isEqual:attributedText]) {
+    return;
+  }
+
+  [super setAttributedText:attributedText];
+  [self updateTopInsetAndTextContainerInset:self.textContainerInset];
+}
+
+- (void)setFont:(UIFont *)font {
+  if ([self.font isEqual:font]) {
+    return;
+  }
+
+  [super setFont:font];
+  [self updateTopInsetAndTextContainerInset:self.textContainerInset];
+}
+
+- (void)setText:(NSString *)text {
+  if ([self.text isEqual:text]) {
+    return;
+  }
+
+  [super setText:text];
+  [self updateTopInsetAndTextContainerInset:self.textContainerInset];
+}
+
+- (void)setTextContainerInset:(UIEdgeInsets)textContainerInset {
+  [self updateTopInsetAndTextContainerInset:textContainerInset];
+}
+
+#pragma mark - UIView
+
 // Disabling text selection when selectable is YES, while allowing gestures for inlined links.
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
   if (UIAccessibilityIsVoiceOverRunning()) {
@@ -1084,6 +1148,30 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
   NSInteger offset = [self offsetFromPosition:self.beginningOfDocument toPosition:range.start];
   id link = [self.attributedText attribute:NSLinkAttributeName atIndex:offset effectiveRange:nil];
   return link != nil;
+}
+
+#pragma mark - Private
+
+/**
+ * Updates the top text inset of the UITextView to avoid rendering text outside the view
+ * boundary. We need to calculate the text margin when we change the text or the text font.
+ *
+ * @note Our title UILabel already has top margin, so its text won't exceed the parent view's
+ * boundary.
+ *
+ * @param textContainerInset The target text insets to display. We will override the top inset will
+ * be updated.
+ */
+- (void)updateTopInsetAndTextContainerInset:(UIEdgeInsets)textContainerInset {
+  // To avoid changing the top margin when the view width changes, we only compare the text height
+  // for a single line text.
+  UIFont *font = self.font;
+  CGFloat singleLineTextViewHeight = SingleLineTextViewHeight(self.text, font);
+  textContainerInset.top = MAX(0.0f, singleLineTextViewHeight - font.lineHeight);
+  if (!UIEdgeInsetsEqualToEdgeInsets(super.textContainerInset, textContainerInset)) {
+    // Note that |self setTextContainerInset:| will call this method.
+    super.textContainerInset = textContainerInset;
+  }
 }
 
 @end

--- a/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
+++ b/components/Dialogs/tests/snapshot/MDCAlertControllerLocalizationTests.m
@@ -21,6 +21,7 @@
 #import "MDCAlertController+Testing.h"
 #import "MaterialSnapshot.h"
 
+static NSString *const kThaiTextWithDiacritics = @"นี้ Thai text นี้";
 static NSString *const kTitleUrdu = @"عنوان";
 static NSString *const kMessageUrdu =
     @"براہ کرم اپنا نیٹ ورک کنکشن چیک کریں اور دوبارہ کوشش کریں۔براہ کرم اپنا نیٹ ورک کنکشن چیک "
@@ -85,6 +86,35 @@ static NSString *const kActionLowUrdu = @"کم";
 }
 
 #pragma mark - Tests
+
+/** Verifies the top of Thai attributed message with diacritics won't be cut off. */
+- (void)testPreferredContentSizeWithThaiAttributedMessage {
+  // When
+  self.alertController.attributedMessage =
+      [[NSAttributedString alloc] initWithString:kThaiTextWithDiacritics];
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForAlert:self.alertController];
+}
+
+/** Verifies the top of Thai message with diacritics won't be cut off. */
+- (void)testPreferredContentSizeWithThaiMessage {
+  // When
+  self.alertController.message = kThaiTextWithDiacritics;
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForAlert:self.alertController];
+}
+
+/** Verifies the top of Thai message and title with diacritics won't be cut off. */
+- (void)testPreferredContentSizeWithThaiMessageAndTitle {
+  // When
+  self.alertController.title = kThaiTextWithDiacritics;
+  self.alertController.message = kThaiTextWithDiacritics;
+
+  // Then
+  [self generateSizedSnapshotAndVerifyForAlert:self.alertController];
+}
 
 - (void)testPreferredContentSizeWithNotoNastaliqUrdu {
   // When


### PR DESCRIPTION
[MDCAlertControllerView] Avoid cutting off the top of Thai characters with diacritics.
In iOS platform, text font are not strictly required to fit within the UIFont.lineHeight. Some Thai characters with diacritics are rendered outside the UILabel/UITextView's bounds. 

One solution is to increase the top margin of the UILabel/UITextView so we leave extra padding between the parent view's top edge and the top edge of the UILabel/UITextView (Like the _titleLabel in MDCAlertControllerView).

![2021_02_15_material_dialog_thai](https://user-images.githubusercontent.com/4530782/108010072-ed401e80-6fb8-11eb-9cdd-88270f338e11.png)

closes #10161