### PR TITLE
[MDCOutlinedTextField] MINOR: Allow subclassing

### DIFF
--- a/components/TextControls/src/OutlinedTextFields/MDCOutlinedTextField.h
+++ b/components/TextControls/src/OutlinedTextFields/MDCOutlinedTextField.h
@@ -19,7 +19,7 @@
 /**
  An implementation of a Material outlined text field.
  */
-__attribute__((objc_subclassing_restricted)) @interface MDCOutlinedTextField : MDCBaseTextField
+@interface MDCOutlinedTextField : MDCBaseTextField
 
 /**
  MDCOutlinedTextField does not support UITextBorderStyle borders.


### PR DESCRIPTION
Closes Issue: [#10212](https://github.com/material-components/material-components-ios/issues/10212)

Not sure why subclassing the MDCOutlinedTextField is restricted, but allowing subclasses will let users build custom functionality on top of the existing class.

No functionality changes