### PR TITLE
Add dependency MotionInterchange for ActivityIndicator 

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -104,6 +104,7 @@ Pod::Spec.new do |mdc|
     component.dependency "MaterialComponents/Palettes"
     component.dependency "MaterialComponents/private/Application"
     component.dependency "MotionAnimator", "~> 4.0"
+    component.dependency "MotionInterchange", "~> 3.0"
 
     component.test_spec 'UnitTests' do |unit_tests|
       unit_tests.source_files = [


### PR DESCRIPTION
It fixes a linking error with MaterialComponent target in case where I use only  'MaterialComponents/ActivityIndicator' and install the library only with 'pod install —repo-update' and 'use_frameworks!':

`Undefined symbol: _MDMMotionCurveMakeBezier`
 
### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [x] Please add unit tests, snapshot tests, or manual testing steps depending on the change.
- [x] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](https://github.com/material-components/material-components-ios/tree/develop/contributing) has more information and tips for a great
pull request.
