### PR TITLE
[BottomNavigation] Use strong/weak attribute instead of assign for the property to an Objective-C object

### DIFF
--- a/components/BottomNavigation/src/MDCBottomNavigationBarController.h
+++ b/components/BottomNavigation/src/MDCBottomNavigationBarController.h
@@ -121,7 +121,7 @@ typedef NS_ENUM(NSInteger, MDCBottomNavigationBarLayoutMode) {
  The current selected view controller.  When setting this property, the view controller must be in
  @c viewControllers.
  */
-@property(nonatomic, assign, nullable) __kindof UIViewController *selectedViewController;
+@property(nonatomic, weak, nullable) __kindof UIViewController *selectedViewController;
 
 /**
  The index of the current selected tab item.  When setting this property the value must be in bounds


### PR DESCRIPTION
This change fixes the warning generated by clang when we enable `-Wobjc-property-assign-on-object-type` flag under the ARC environment.

Clang with the flag generates the warning if a property to an Objective-C object/block has an `assign` attribute because an assign property is treated as unretained property and it potentially becomes a dangling pointer.
The flag is added by https://github.com/llvm/llvm-project/commit/52a503d4f333d
So using `strong` / `weak` / `copy` would be better in general.

`selectedViewController` is the currently selected view controller and the view must be in `viewControllers` which is strongly retained.
I think it's safe to use `weak` to `selectedViewController`.